### PR TITLE
feat: create canonical `.agents/skills/` target on add

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use clap::{Parser, Subcommand};
 
 use upskill::{InstallSource, parse_install_source};
 
+const CANONICAL_TARGET: &str = ".agents/skills";
+
 #[derive(Parser, Debug)]
 #[command(name = "upskill")]
 #[command(about = "Upskill your coding agents")]
@@ -30,6 +32,11 @@ fn main() {
 }
 
 fn run_add(source: &str) -> i32 {
+    if let Err(err) = ensure_canonical_target() {
+        eprintln!("error: {}", err);
+        return 1;
+    }
+
     match parse_install_source(source) {
         Ok(InstallSource::Github(repo)) => {
             println!("install source: github");
@@ -52,4 +59,13 @@ fn run_add(source: &str) -> i32 {
             2
         }
     }
+}
+
+fn ensure_canonical_target() -> Result<(), String> {
+    std::fs::create_dir_all(CANONICAL_TARGET).map_err(|err| {
+        format!(
+            "failed to create canonical target {}: {}",
+            CANONICAL_TARGET, err
+        )
+    })
 }

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -43,3 +43,35 @@ fn add_rejects_missing_local_path() {
         .code(2)
         .stderr("error: local path does not exist: ./definitely-not-present-upskill-skill-path\n");
 }
+
+#[test]
+fn add_creates_canonical_target_for_github_source() {
+    let cwd = tempdir().expect("must create temp dir");
+    let canonical = cwd.path().join(".agents/skills");
+
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .args(["add", "microsoft/skills"])
+        .assert()
+        .success();
+
+    assert!(canonical.is_dir(), "canonical target must be created");
+}
+
+#[test]
+fn add_creates_canonical_target_for_local_source() {
+    let cwd = tempdir().expect("must create temp dir");
+    let local_source = cwd.path().join("source");
+    std::fs::create_dir_all(&local_source).expect("must create local source");
+    let canonical = cwd.path().join(".agents/skills");
+
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .args(["add", local_source.to_str().expect("utf8 path")])
+        .assert()
+        .success();
+
+    assert!(canonical.is_dir(), "canonical target must be created");
+}


### PR DESCRIPTION
Epic: #1

Implements Story #6: always create the canonical `.agents/skills/` directory during `upskill add`.

## What changed
- add canonical target creation on every `add` operation (`.agents/skills`)
- return non-zero error if canonical target cannot be created
- add ATDD integration tests verifying canonical target creation for:
  - GitHub source (`owner/repo`)
  - local path source (`./path` / absolute path)

## Tests
- `just fmt`
- `just check`
  - `cargo test`
  - `cargo clippy -- -D warnings`
  - `cargo fmt -- --check`
  - `dprint check`
  - `markdownlint`

Part of #1