### PR TITLE
feat: support --all for agent symlink creation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,15 @@ use clap::{Parser, Subcommand};
 use upskill::{InstallSource, parse_install_source};
 
 const CANONICAL_TARGET: &str = ".agents/skills";
+const AGENT_SKILL_LINKS: [&str; 7] = [
+    ".claude/skills",
+    ".github/skills",
+    ".codex/skills",
+    ".cursor/skills",
+    ".kiro/skills",
+    ".windsurf/skills",
+    ".opencode/skills",
+];
 
 #[derive(Parser, Debug)]
 #[command(name = "upskill")]
@@ -24,6 +33,9 @@ enum Commands {
         /// Symlink to Copilot skills directory
         #[arg(long)]
         copilot: bool,
+        /// Symlink to every supported agent skills directory
+        #[arg(long)]
+        all: bool,
     },
 }
 
@@ -35,13 +47,14 @@ fn main() {
             source,
             claude,
             copilot,
-        } => run_add(&source, claude, copilot),
+            all,
+        } => run_add(&source, claude, copilot, all),
     };
 
     std::process::exit(exit_code);
 }
 
-fn run_add(source: &str, claude: bool, copilot: bool) -> i32 {
+fn run_add(source: &str, claude: bool, copilot: bool, all: bool) -> i32 {
     if let Err(err) = ensure_canonical_target() {
         eprintln!("error: {}", err);
         return 1;
@@ -49,7 +62,7 @@ fn run_add(source: &str, claude: bool, copilot: bool) -> i32 {
 
     match parse_install_source(source) {
         Ok(InstallSource::Github(repo)) => {
-            if let Err(err) = ensure_agent_symlinks(claude, copilot) {
+            if let Err(err) = ensure_agent_symlinks(claude, copilot, all) {
                 eprintln!("error: {}", err);
                 return 1;
             }
@@ -65,7 +78,7 @@ fn run_add(source: &str, claude: bool, copilot: bool) -> i32 {
                 return 2;
             }
 
-            if let Err(err) = ensure_agent_symlinks(claude, copilot) {
+            if let Err(err) = ensure_agent_symlinks(claude, copilot, all) {
                 eprintln!("error: {}", err);
                 return 1;
             }
@@ -90,7 +103,14 @@ fn ensure_canonical_target() -> Result<(), String> {
     })
 }
 
-fn ensure_agent_symlinks(claude: bool, copilot: bool) -> Result<(), String> {
+fn ensure_agent_symlinks(claude: bool, copilot: bool, all: bool) -> Result<(), String> {
+    if all {
+        for link in AGENT_SKILL_LINKS {
+            create_symlink(link)?;
+        }
+        return Ok(());
+    }
+
     let auto_detect = !claude && !copilot;
 
     let link_claude = claude || (auto_detect && std::path::Path::new(".claude").exists());

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -161,3 +161,31 @@ fn add_auto_detects_agent_directories_when_no_flags() {
     assert!(std::fs::symlink_metadata(cwd.path().join(".claude/skills")).is_ok());
     assert!(std::fs::symlink_metadata(cwd.path().join(".github/skills")).is_ok());
 }
+
+#[test]
+fn add_all_creates_symlinks_for_all_supported_agents() {
+    let cwd = tempdir().expect("must create temp dir");
+
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .args(["add", "microsoft/skills", "--all"])
+        .assert()
+        .success();
+
+    let expected_links = [
+        ".claude/skills",
+        ".github/skills",
+        ".codex/skills",
+        ".cursor/skills",
+        ".kiro/skills",
+        ".windsurf/skills",
+        ".opencode/skills",
+    ];
+
+    for link in expected_links {
+        let path = cwd.path().join(link);
+        let meta = std::fs::symlink_metadata(&path).expect("symlink metadata");
+        assert!(meta.file_type().is_symlink(), "{link} must be a symlink");
+    }
+}


### PR DESCRIPTION
Epic: #1

Implements Story #8 by adding `--all` support to create symlinks for all supported agents in one command.

## What changed
- add `--all` flag to `upskill add`
- when `--all` is provided, create symlinks for all known agents:
  - `.claude/skills`
  - `.github/skills`
  - `.codex/skills`
  - `.cursor/skills`
  - `.kiro/skills`
  - `.windsurf/skills`
  - `.opencode/skills`
- preserve existing explicit flag and auto-detect behavior
- add integration test verifying all symlinks are created with `--all`

## Tests
- `just fmt`
- `just check`

Part of #1