### PR TITLE
feat: add repeatable --skill selection for add command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,9 @@ enum Commands {
     Add {
         /// GitHub source in owner/repo format
         source: String,
+        /// Install only a specific skill (repeatable)
+        #[arg(long = "skill", short = 's')]
+        skills: Vec<String>,
         /// Symlink to Claude Code skills directory
         #[arg(long)]
         claude: bool,
@@ -45,16 +48,17 @@ fn main() {
     let exit_code = match cli.command {
         Commands::Add {
             source,
+            skills,
             claude,
             copilot,
             all,
-        } => run_add(&source, claude, copilot, all),
+        } => run_add(&source, &skills, claude, copilot, all),
     };
 
     std::process::exit(exit_code);
 }
 
-fn run_add(source: &str, claude: bool, copilot: bool, all: bool) -> i32 {
+fn run_add(source: &str, skills: &[String], claude: bool, copilot: bool, all: bool) -> i32 {
     if let Err(err) = ensure_canonical_target() {
         eprintln!("error: {}", err);
         return 1;
@@ -70,6 +74,7 @@ fn run_add(source: &str, claude: bool, copilot: bool, all: bool) -> i32 {
             println!("install source: github");
             println!("owner: {}", repo.owner);
             println!("repo: {}", repo.name);
+            print_selected_skills(skills);
             0
         }
         Ok(InstallSource::LocalPath(path)) => {
@@ -85,6 +90,7 @@ fn run_add(source: &str, claude: bool, copilot: bool, all: bool) -> i32 {
 
             println!("install source: local");
             println!("path: {}", path);
+            print_selected_skills(skills);
             0
         }
         Err(err) => {
@@ -92,6 +98,14 @@ fn run_add(source: &str, claude: bool, copilot: bool, all: bool) -> i32 {
             2
         }
     }
+}
+
+fn print_selected_skills(skills: &[String]) {
+    if skills.is_empty() {
+        return;
+    }
+
+    println!("skills: {}", skills.join(","));
 }
 
 fn ensure_canonical_target() -> Result<(), String> {

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -189,3 +189,36 @@ fn add_all_creates_symlinks_for_all_supported_agents() {
         assert!(meta.file_type().is_symlink(), "{link} must be a symlink");
     }
 }
+
+#[test]
+fn add_accepts_single_skill_flag() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .args(["add", "microsoft/skills", "--skill", "rust-lint"])
+        .assert()
+        .success()
+        .stdout("install source: github\nowner: microsoft\nrepo: skills\nskills: rust-lint\n");
+}
+
+#[test]
+fn add_accepts_multiple_skill_flags() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .args([
+            "add",
+            "microsoft/skills",
+            "--skill",
+            "rust-lint",
+            "--skill",
+            "release-check",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            "install source: github\nowner: microsoft\nrepo: skills\nskills: rust-lint,release-check\n",
+        );
+}


### PR DESCRIPTION
Epic: #1

Implements Story #9 selective install support for explicit skill selection.

## What changed
- add repeatable `--skill` / `-s` flag to `upskill add`
- support multiple `--skill` flags in one command
- print selected skills in command output for selected installs
- add integration tests for:
  - single `--skill`
  - multiple `--skill` flags

## Tests
- `just fmt`
- `just check`

## Note
- This PR implements explicit `--skill` selection first.
- Interactive multi-select mode will follow as a subsequent increment for Story #9.

Part of #1