### PR TITLE
feat: add upskill list command with source and symlink reporting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,8 @@ enum Commands {
         #[arg(long)]
         all: bool,
     },
+    /// List installed skills
+    List,
 }
 
 fn main() {
@@ -53,6 +55,7 @@ fn main() {
             copilot,
             all,
         } => run_add(&source, &skills, claude, copilot, all),
+        Commands::List => run_list(),
     };
 
     std::process::exit(exit_code);
@@ -66,7 +69,19 @@ fn run_add(source: &str, skills: &[String], claude: bool, copilot: bool, all: bo
 
     match parse_install_source(source) {
         Ok(InstallSource::Github(repo)) => {
+            let source_label = if let Some(subfolder) = &repo.subfolder {
+                format!("github:{}/{}:{}", repo.owner, repo.name, subfolder)
+            } else {
+                format!("github:{}/{}", repo.owner, repo.name)
+            };
+            let resolved_skills = resolve_requested_skills(skills, &repo.name);
+
             if let Err(err) = ensure_agent_symlinks(claude, copilot, all) {
+                eprintln!("error: {}", err);
+                return 1;
+            }
+
+            if let Err(err) = persist_installed_skills(&resolved_skills, &source_label) {
                 eprintln!("error: {}", err);
                 return 1;
             }
@@ -86,7 +101,20 @@ fn run_add(source: &str, skills: &[String], claude: bool, copilot: bool, all: bo
                 return 2;
             }
 
+            let default_skill = std::path::Path::new(&path)
+                .file_name()
+                .and_then(|v| v.to_str())
+                .filter(|v| !v.is_empty())
+                .unwrap_or("local-skill");
+            let resolved_skills = resolve_requested_skills(skills, default_skill);
+
             if let Err(err) = ensure_agent_symlinks(claude, copilot, all) {
+                eprintln!("error: {}", err);
+                return 1;
+            }
+
+            let source_label = format!("local:{}", path);
+            if let Err(err) = persist_installed_skills(&resolved_skills, &source_label) {
                 eprintln!("error: {}", err);
                 return 1;
             }
@@ -101,6 +129,107 @@ fn run_add(source: &str, skills: &[String], claude: bool, copilot: bool, all: bo
             2
         }
     }
+}
+
+fn run_list() -> i32 {
+    let canonical = std::path::Path::new(CANONICAL_TARGET);
+    if !canonical.exists() {
+        println!("no skills installed");
+        return 0;
+    }
+
+    let mut skills = Vec::new();
+    let entries = match std::fs::read_dir(canonical) {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!("error: failed to read {}: {}", CANONICAL_TARGET, err);
+            return 1;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let Some(name) = path.file_name().and_then(|v| v.to_str()) else {
+            continue;
+        };
+
+        let source = std::fs::read_to_string(path.join(".upskill-source"))
+            .unwrap_or_else(|_| "unknown".to_string())
+            .trim()
+            .to_string();
+        skills.push((name.to_string(), source));
+    }
+
+    skills.sort_by(|a, b| a.0.cmp(&b.0));
+    if skills.is_empty() {
+        println!("no skills installed");
+        return 0;
+    }
+
+    let active_agents = detect_active_agents();
+    let symlink_text = if active_agents.is_empty() {
+        "none".to_string()
+    } else {
+        active_agents.join(",")
+    };
+
+    for (name, source) in skills {
+        println!("{}\tsource={}\tsymlinks={}", name, source, symlink_text);
+    }
+
+    0
+}
+
+fn resolve_requested_skills(skills: &[String], default_skill: &str) -> Vec<String> {
+    if skills.is_empty() {
+        return vec![default_skill.to_string()];
+    }
+
+    skills.to_vec()
+}
+
+fn persist_installed_skills(skills: &[String], source: &str) -> Result<(), String> {
+    for skill in skills {
+        let skill_dir = std::path::Path::new(CANONICAL_TARGET).join(skill);
+        std::fs::create_dir_all(&skill_dir)
+            .map_err(|err| format!("failed to create {}: {}", skill_dir.display(), err))?;
+        std::fs::write(skill_dir.join(".upskill-source"), source)
+            .map_err(|err| format!("failed to write source metadata for {}: {}", skill, err))?;
+    }
+
+    Ok(())
+}
+
+fn detect_active_agents() -> Vec<String> {
+    let mut agents = Vec::new();
+
+    if std::fs::symlink_metadata(".claude/skills").is_ok() {
+        agents.push("claude".to_string());
+    }
+    if std::fs::symlink_metadata(".github/skills").is_ok() {
+        agents.push("copilot".to_string());
+    }
+    if std::fs::symlink_metadata(".codex/skills").is_ok() {
+        agents.push("codex".to_string());
+    }
+    if std::fs::symlink_metadata(".cursor/skills").is_ok() {
+        agents.push("cursor".to_string());
+    }
+    if std::fs::symlink_metadata(".kiro/skills").is_ok() {
+        agents.push("kiro".to_string());
+    }
+    if std::fs::symlink_metadata(".windsurf/skills").is_ok() {
+        agents.push("windsurf".to_string());
+    }
+    if std::fs::symlink_metadata(".opencode/skills").is_ok() {
+        agents.push("opencode".to_string());
+    }
+
+    agents
 }
 
 fn print_selected_skills(skills: &[String]) {

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -1,0 +1,66 @@
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+#[test]
+fn list_shows_no_skills_when_empty() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout("no skills installed\n");
+}
+
+#[test]
+fn list_shows_installed_skill_with_source_and_symlinks() {
+    let cwd = tempdir().expect("must create temp dir");
+    std::fs::create_dir_all(cwd.path().join(".claude")).expect("must create .claude");
+
+    let mut add = Command::cargo_bin("upskill").expect("binary exists");
+    add.current_dir(cwd.path())
+        .args([
+            "add",
+            "microsoft/skills",
+            "--skill",
+            "rust-lint",
+            "--claude",
+        ])
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("upskill").expect("binary exists");
+    list.current_dir(cwd.path())
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout("rust-lint\tsource=github:microsoft/skills\tsymlinks=claude\n");
+}
+
+#[test]
+fn list_shows_multiple_skills_sorted() {
+    let cwd = tempdir().expect("must create temp dir");
+
+    let mut add = Command::cargo_bin("upskill").expect("binary exists");
+    add.current_dir(cwd.path())
+        .args([
+            "add",
+            "microsoft/skills",
+            "--skill",
+            "zeta",
+            "--skill",
+            "alpha",
+        ])
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("upskill").expect("binary exists");
+    list.current_dir(cwd.path())
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(
+            "alpha\tsource=github:microsoft/skills\tsymlinks=none\nzeta\tsource=github:microsoft/skills\tsymlinks=none\n",
+        );
+}


### PR DESCRIPTION
Epic: #1

Implements Story #11 by adding `upskill list` to show installed skills.

## What changed
- add `upskill list` subcommand
- persist lightweight install metadata during `add`:
  - create `.agents/skills/<skill>/`
  - write source marker `.upskill-source`
- list output now includes for each installed skill:
  - skill name
  - source (`github:owner/repo` or `local:path`)
  - active agent symlink set (`symlinks=...`)
- add integration tests for:
  - empty list (`no skills installed`)
  - single installed skill with source/symlinks
  - multiple skills sorted output

## Tests
- `just fmt`
- `just check`

Part of #1