### PR TITLE
feat: add upskill remove command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,14 @@ enum Commands {
     },
     /// List installed skills
     List,
+    /// Remove an installed skill
+    Remove {
+        /// Skill name to remove
+        skill: String,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 fn main() {
@@ -56,6 +64,7 @@ fn main() {
             all,
         } => run_add(&source, &skills, claude, copilot, all),
         Commands::List => run_list(),
+        Commands::Remove { skill, yes } => run_remove(&skill, yes),
     };
 
     std::process::exit(exit_code);
@@ -182,6 +191,93 @@ fn run_list() -> i32 {
     }
 
     0
+}
+
+fn run_remove(skill: &str, yes: bool) -> i32 {
+    let skill_path = std::path::Path::new(CANONICAL_TARGET).join(skill);
+    if !skill_path.is_dir() {
+        eprintln!("error: skill not installed: {}", skill);
+        return 2;
+    }
+
+    if !yes && !confirm_removal(skill) {
+        eprintln!("error: removal cancelled");
+        return 1;
+    }
+
+    if let Err(err) = std::fs::remove_dir_all(&skill_path) {
+        eprintln!("error: failed to remove {}: {}", skill_path.display(), err);
+        return 1;
+    }
+
+    if let Err(err) = cleanup_agent_symlinks_if_empty() {
+        eprintln!("error: {}", err);
+        return 1;
+    }
+
+    println!("removed skill: {}", skill);
+    0
+}
+
+fn confirm_removal(skill: &str) -> bool {
+    use std::io::{self, Write};
+
+    print!("remove skill '{}' ? [y/N]: ", skill);
+    if io::stdout().flush().is_err() {
+        return false;
+    }
+
+    let mut answer = String::new();
+    if io::stdin().read_line(&mut answer).is_err() {
+        return false;
+    }
+
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+fn cleanup_agent_symlinks_if_empty() -> Result<(), String> {
+    if !canonical_has_skills()? {
+        for link in AGENT_SKILL_LINKS {
+            remove_symlink_if_exists(link)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn canonical_has_skills() -> Result<bool, String> {
+    let canonical = std::path::Path::new(CANONICAL_TARGET);
+    if !canonical.exists() {
+        return Ok(false);
+    }
+
+    let entries = std::fs::read_dir(canonical)
+        .map_err(|err| format!("failed to inspect installed skills: {}", err))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|err| format!("failed to inspect installed skills: {}", err))?;
+        if entry.path().is_dir() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn remove_symlink_if_exists(link_path: &str) -> Result<(), String> {
+    let link = std::path::Path::new(link_path);
+    match std::fs::symlink_metadata(link) {
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                std::fs::remove_file(link).map_err(|err| {
+                    format!("failed to remove symlink {}: {}", link.display(), err)
+                })?;
+            }
+            Ok(())
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!("failed to inspect {}: {}", link.display(), err)),
+    }
 }
 
 fn resolve_requested_skills(skills: &[String], default_skill: &str) -> Vec<String> {

--- a/tests/cli_remove.rs
+++ b/tests/cli_remove.rs
@@ -1,0 +1,119 @@
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+#[test]
+fn remove_deletes_installed_skill_with_yes() {
+    let cwd = tempdir().expect("must create temp dir");
+
+    let mut add = Command::cargo_bin("upskill").expect("binary exists");
+    add.current_dir(cwd.path())
+        .args(["add", "microsoft/skills", "--skill", "rust-lint"])
+        .assert()
+        .success();
+
+    let mut remove = Command::cargo_bin("upskill").expect("binary exists");
+    remove
+        .current_dir(cwd.path())
+        .args(["remove", "rust-lint", "--yes"])
+        .assert()
+        .success()
+        .stdout("removed skill: rust-lint\n");
+
+    assert!(!cwd.path().join(".agents/skills/rust-lint").exists());
+}
+
+#[test]
+fn remove_requires_confirmation_without_yes() {
+    let cwd = tempdir().expect("must create temp dir");
+
+    let mut add = Command::cargo_bin("upskill").expect("binary exists");
+    add.current_dir(cwd.path())
+        .args(["add", "microsoft/skills", "--skill", "rust-lint"])
+        .assert()
+        .success();
+
+    let mut remove = Command::cargo_bin("upskill").expect("binary exists");
+    remove
+        .current_dir(cwd.path())
+        .args(["remove", "rust-lint"])
+        .write_stdin("n\n")
+        .assert()
+        .code(1)
+        .stderr("error: removal cancelled\n");
+
+    assert!(cwd.path().join(".agents/skills/rust-lint").is_dir());
+}
+
+#[test]
+fn remove_deletes_agent_symlinks_when_no_skills_remain() {
+    let cwd = tempdir().expect("must create temp dir");
+    std::fs::create_dir_all(cwd.path().join(".claude")).expect("must create .claude");
+    std::fs::create_dir_all(cwd.path().join(".github")).expect("must create .github");
+
+    let mut add = Command::cargo_bin("upskill").expect("binary exists");
+    add.current_dir(cwd.path())
+        .args([
+            "add",
+            "microsoft/skills",
+            "--skill",
+            "rust-lint",
+            "--claude",
+            "--copilot",
+        ])
+        .assert()
+        .success();
+
+    let mut remove = Command::cargo_bin("upskill").expect("binary exists");
+    remove
+        .current_dir(cwd.path())
+        .args(["remove", "rust-lint", "--yes"])
+        .assert()
+        .success();
+
+    assert!(std::fs::symlink_metadata(cwd.path().join(".claude/skills")).is_err());
+    assert!(std::fs::symlink_metadata(cwd.path().join(".github/skills")).is_err());
+}
+
+#[test]
+fn remove_keeps_symlinks_when_other_skills_exist() {
+    let cwd = tempdir().expect("must create temp dir");
+    std::fs::create_dir_all(cwd.path().join(".claude")).expect("must create .claude");
+
+    let mut add = Command::cargo_bin("upskill").expect("binary exists");
+    add.current_dir(cwd.path())
+        .args([
+            "add",
+            "microsoft/skills",
+            "--skill",
+            "rust-lint",
+            "--skill",
+            "release-check",
+            "--claude",
+        ])
+        .assert()
+        .success();
+
+    let mut remove = Command::cargo_bin("upskill").expect("binary exists");
+    remove
+        .current_dir(cwd.path())
+        .args(["remove", "rust-lint", "--yes"])
+        .assert()
+        .success();
+
+    let link_meta = std::fs::symlink_metadata(cwd.path().join(".claude/skills")).expect("metadata");
+    assert!(link_meta.file_type().is_symlink());
+    assert!(cwd.path().join(".agents/skills/release-check").is_dir());
+}
+
+#[test]
+fn remove_fails_for_missing_skill() {
+    let cwd = tempdir().expect("must create temp dir");
+
+    let mut remove = Command::cargo_bin("upskill").expect("binary exists");
+    remove
+        .current_dir(cwd.path())
+        .args(["remove", "missing", "--yes"])
+        .assert()
+        .code(2)
+        .stderr("error: skill not installed: missing\n");
+}


### PR DESCRIPTION
Epic: #1

Implements Story #12 by adding `upskill remove` to uninstall skills and clean up symlinks.

## What changed
- add `upskill remove <skill>` subcommand
- add confirmation prompt before removal
- add `--yes` to bypass confirmation
- remove installed skill directory under `.agents/skills/<skill>`
- remove agent symlinks when no skills remain
- keep symlinks when other installed skills still exist

## Tests
- `just fmt`
- `just check`
- new integration tests in `tests/cli_remove.rs`

Part of #1