### PR TITLE
feat: add ci-friendly mode behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,7 @@ fn run_remove(skill: &str, yes: bool) -> i32 {
         return 2;
     }
 
-    if !yes && !confirm_removal(skill) {
+    if should_prompt_for_confirmation(yes) && !confirm_removal(skill) {
         eprintln!("error: removal cancelled");
         return 1;
     }
@@ -219,10 +219,20 @@ fn run_remove(skill: &str, yes: bool) -> i32 {
     0
 }
 
-fn confirm_removal(skill: &str) -> bool {
-    use std::io::{self, Write};
+fn should_prompt_for_confirmation(yes: bool) -> bool {
+    use std::io::IsTerminal;
 
-    print!("remove skill '{}' ? [y/N]: ", skill);
+    !yes && std::io::stdin().is_terminal()
+}
+
+fn confirm_removal(skill: &str) -> bool {
+    use std::io::{self, IsTerminal, Write};
+
+    if io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+        print!("\u{1b}[33mremove skill '{}' ? [y/N]:\u{1b}[0m ", skill);
+    } else {
+        print!("remove skill '{}' ? [y/N]: ", skill);
+    }
     if io::stdout().flush().is_err() {
         return false;
     }

--- a/tests/cli_ci_mode.rs
+++ b/tests/cli_ci_mode.rs
@@ -1,0 +1,15 @@
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+#[test]
+fn no_color_produces_plain_error_output() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .env("NO_COLOR", "1")
+        .args(["add", "not-a-valid-source"])
+        .assert()
+        .code(2)
+        .stderr("error: source must be in owner/repo format\n");
+}

--- a/tests/cli_remove.rs
+++ b/tests/cli_remove.rs
@@ -23,7 +23,7 @@ fn remove_deletes_installed_skill_with_yes() {
 }
 
 #[test]
-fn remove_requires_confirmation_without_yes() {
+fn remove_without_yes_skips_prompt_in_non_tty() {
     let cwd = tempdir().expect("must create temp dir");
 
     let mut add = Command::cargo_bin("upskill").expect("binary exists");
@@ -36,12 +36,11 @@ fn remove_requires_confirmation_without_yes() {
     remove
         .current_dir(cwd.path())
         .args(["remove", "rust-lint"])
-        .write_stdin("n\n")
         .assert()
-        .code(1)
-        .stderr("error: removal cancelled\n");
+        .success()
+        .stdout("removed skill: rust-lint\n");
 
-    assert!(cwd.path().join(".agents/skills/rust-lint").is_dir());
+    assert!(!cwd.path().join(".agents/skills/rust-lint").exists());
 }
 
 #[test]


### PR DESCRIPTION
Epic: #1

Implements Story #14 with CI-friendly prompt behavior.

## What changed
- remove flow now checks TTY before prompting
- non-TTY stdin skips interactive confirmation automatically
- `--yes` continues to bypass confirmation
- confirmation prompt respects `NO_COLOR` (no ANSI style when set)
- add CI-mode integration test for `NO_COLOR` plain error output
- update remove integration test for non-TTY skip behavior

## Tests
- `just fmt`
- `just check`

Part of #1