### PR TITLE
feat: enforce POSIX exit code mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +104,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -143,10 +158,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "equivalent"
@@ -269,6 +307,33 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -484,6 +549,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "ctrlc",
  "tempfile",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+ctrlc = "3.4"
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,17 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, error::ErrorKind};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use upskill::{InstallSource, parse_install_source};
 
 const PROJECT_CANONICAL_TARGET: &str = ".agents/skills";
 const GLOBAL_CANONICAL_TARGET: &str = ".agents/skills";
+const EXIT_SUCCESS: i32 = 0;
+const EXIT_ERROR: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+const EXIT_INTERRUPTED: i32 = 130;
+
+static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
 const AGENT_SKILL_LINKS: [&str; 7] = [
     ".claude/skills",
     ".github/skills",
@@ -64,9 +72,21 @@ enum Commands {
 }
 
 fn main() {
-    let cli = Cli::parse();
+    if let Err(err) = install_signal_handlers() {
+        eprintln!("error: {}", err);
+        std::process::exit(EXIT_ERROR);
+    }
 
-    let exit_code = match cli.command {
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(err) => {
+            let code = map_clap_error(&err);
+            let _ = err.print();
+            std::process::exit(code);
+        }
+    };
+
+    let mut exit_code = match cli.command {
         Commands::Add {
             source,
             skills,
@@ -79,7 +99,29 @@ fn main() {
         Commands::Remove { skill, yes, global } => run_remove(&skill, yes, global),
     };
 
+    if was_interrupted() {
+        exit_code = EXIT_INTERRUPTED;
+    }
+
     std::process::exit(exit_code);
+}
+
+fn install_signal_handlers() -> Result<(), String> {
+    ctrlc::set_handler(|| {
+        INTERRUPTED.store(true, Ordering::SeqCst);
+    })
+    .map_err(|err| format!("failed to install signal handler: {}", err))
+}
+
+fn was_interrupted() -> bool {
+    INTERRUPTED.load(Ordering::SeqCst)
+}
+
+fn map_clap_error(err: &clap::Error) -> i32 {
+    match err.kind() {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => EXIT_SUCCESS,
+        _ => EXIT_USAGE,
+    }
 }
 
 fn run_add(

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -1,0 +1,37 @@
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+#[test]
+fn help_exits_zero() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .args(["--help"])
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn usage_errors_exit_two() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .args(["add", "invalid-source"])
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn general_errors_exit_one() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    cmd.current_dir(cwd.path())
+        .env_remove("HOME")
+        .args(["list", "-g"])
+        .assert()
+        .code(1)
+        .stderr("error: HOME is not set\n");
+}


### PR DESCRIPTION
Epic: #1

Implements Story #16 with explicit POSIX exit code behavior.

## What changed
- define explicit exit code constants:
  - `0` success
  - `1` general error
  - `2` usage errors
  - `130` interrupted
- switch CLI parse flow to `Cli::try_parse()` and map clap errors to POSIX usage/success semantics
- install SIGINT handler and map interrupted runs to exit `130`
- add integration tests for exit code expectations

## Tests
- `just fmt`
- `just check`
- new integration tests in `tests/cli_exit_codes.rs`

Part of #1