### PR TITLE
fix: address code review findings

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,41 +1,51 @@
 use std::path::Path;
 
-pub const AGENT_SKILL_LINKS: [&str; 7] = [
-    ".claude/skills",
-    ".github/skills",
-    ".codex/skills",
-    ".cursor/skills",
-    ".kiro/skills",
-    ".windsurf/skills",
-    ".opencode/skills",
+struct AgentDef {
+    name: &'static str,
+    skill_link: &'static str,
+}
+
+const AGENT_DEFS: [AgentDef; 7] = [
+    AgentDef {
+        name: "claude",
+        skill_link: ".claude/skills",
+    },
+    AgentDef {
+        name: "copilot",
+        skill_link: ".github/skills",
+    },
+    AgentDef {
+        name: "codex",
+        skill_link: ".codex/skills",
+    },
+    AgentDef {
+        name: "cursor",
+        skill_link: ".cursor/skills",
+    },
+    AgentDef {
+        name: "kiro",
+        skill_link: ".kiro/skills",
+    },
+    AgentDef {
+        name: "windsurf",
+        skill_link: ".windsurf/skills",
+    },
+    AgentDef {
+        name: "opencode",
+        skill_link: ".opencode/skills",
+    },
 ];
 
+pub fn all_skill_links() -> impl Iterator<Item = &'static str> {
+    AGENT_DEFS.iter().map(|a| a.skill_link)
+}
+
 pub fn detect_active_agents() -> Vec<String> {
-    let mut agents = Vec::new();
-
-    if std::fs::symlink_metadata(".claude/skills").is_ok() {
-        agents.push("claude".to_string());
-    }
-    if std::fs::symlink_metadata(".github/skills").is_ok() {
-        agents.push("copilot".to_string());
-    }
-    if std::fs::symlink_metadata(".codex/skills").is_ok() {
-        agents.push("codex".to_string());
-    }
-    if std::fs::symlink_metadata(".cursor/skills").is_ok() {
-        agents.push("cursor".to_string());
-    }
-    if std::fs::symlink_metadata(".kiro/skills").is_ok() {
-        agents.push("kiro".to_string());
-    }
-    if std::fs::symlink_metadata(".windsurf/skills").is_ok() {
-        agents.push("windsurf".to_string());
-    }
-    if std::fs::symlink_metadata(".opencode/skills").is_ok() {
-        agents.push("opencode".to_string());
-    }
-
-    agents
+    AGENT_DEFS
+        .iter()
+        .filter(|a| std::fs::symlink_metadata(a.skill_link).is_ok())
+        .map(|a| a.name.to_string())
+        .collect()
 }
 
 pub fn ensure_agent_targets(
@@ -46,7 +56,7 @@ pub fn ensure_agent_targets(
     canonical_target: &Path,
 ) -> Result<(), String> {
     if all {
-        for link in AGENT_SKILL_LINKS {
+        for link in all_skill_links() {
             create_agent_target(link, copy, canonical_target)?;
         }
         return Ok(());
@@ -70,7 +80,7 @@ pub fn ensure_agent_targets(
 
 pub fn cleanup_agent_symlinks_if_empty(canonical: &Path) -> Result<(), String> {
     if !canonical_has_skills(canonical)? {
-        for link in AGENT_SKILL_LINKS {
+        for link in all_skill_links() {
             remove_symlink_if_exists(link)?;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,13 +132,13 @@ fn run_add(
         Ok(path) => path,
         Err(err) => {
             eprintln!("error: {}", err);
-            return 1;
+            return EXIT_ERROR;
         }
     };
 
     if let Err(err) = install::ensure_canonical_target(&canonical_target) {
         eprintln!("error: {}", err);
-        return 1;
+        return EXIT_ERROR;
     }
 
     match parse_install_source(source) {
@@ -152,7 +152,7 @@ fn run_add(
                 Ok(skills) => skills,
                 Err(err) => {
                     eprintln!("error: {}", err);
-                    return 1;
+                    return EXIT_ERROR;
                 }
             };
 
@@ -162,7 +162,7 @@ fn run_add(
                 &source_label,
             ) {
                 eprintln!("error: {}", err);
-                return 1;
+                return EXIT_ERROR;
             }
 
             if !global
@@ -170,7 +170,7 @@ fn run_add(
                     agent::ensure_agent_targets(claude, copilot, all, copy, &canonical_target)
             {
                 eprintln!("error: {}", err);
-                return 1;
+                return EXIT_ERROR;
             }
 
             println!("install source: github");
@@ -180,15 +180,15 @@ fn run_add(
                 println!("subfolder: {}", subfolder);
             }
             ui::print_selected_skills(&resolved_skills, skills.is_empty());
-            0
+            EXIT_SUCCESS
         }
         Ok(InstallSource::LocalPath(path)) => {
-            if !std::path::Path::new(&path).exists() {
-                eprintln!("error: local path does not exist: {}", path);
-                return 2;
+            if !path.exists() {
+                eprintln!("error: local path does not exist: {}", path.display());
+                return EXIT_USAGE;
             }
 
-            let default_skill = std::path::Path::new(&path)
+            let default_skill = path
                 .file_name()
                 .and_then(|v| v.to_str())
                 .filter(|v| !v.is_empty())
@@ -197,18 +197,18 @@ fn run_add(
                 Ok(skills) => skills,
                 Err(err) => {
                     eprintln!("error: {}", err);
-                    return 1;
+                    return EXIT_ERROR;
                 }
             };
 
-            let source_label = format!("local:{}", path);
+            let source_label = format!("local:{}", path.display());
             if let Err(err) = install::persist_installed_skills(
                 &canonical_target,
                 &resolved_skills,
                 &source_label,
             ) {
                 eprintln!("error: {}", err);
-                return 1;
+                return EXIT_ERROR;
             }
 
             if !global
@@ -216,17 +216,17 @@ fn run_add(
                     agent::ensure_agent_targets(claude, copilot, all, copy, &canonical_target)
             {
                 eprintln!("error: {}", err);
-                return 1;
+                return EXIT_ERROR;
             }
 
             println!("install source: local");
-            println!("path: {}", path);
+            println!("path: {}", path.display());
             ui::print_selected_skills(&resolved_skills, skills.is_empty());
-            0
+            EXIT_SUCCESS
         }
         Err(err) => {
             eprintln!("error: {}", err);
-            2
+            EXIT_USAGE
         }
     }
 }
@@ -236,13 +236,13 @@ fn run_list(global: bool) -> i32 {
         Ok(path) => path,
         Err(err) => {
             eprintln!("error: {}", err);
-            return 1;
+            return EXIT_ERROR;
         }
     };
 
     if !canonical.exists() {
         println!("no skills installed");
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     let mut skills = Vec::new();
@@ -250,7 +250,7 @@ fn run_list(global: bool) -> i32 {
         Ok(entries) => entries,
         Err(err) => {
             eprintln!("error: failed to read {}: {}", canonical.display(), err);
-            return 1;
+            return EXIT_ERROR;
         }
     };
 
@@ -274,7 +274,7 @@ fn run_list(global: bool) -> i32 {
     skills.sort_by(|a, b| a.0.cmp(&b.0));
     if skills.is_empty() {
         println!("no skills installed");
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     let active_agents = agent::detect_active_agents();
@@ -288,7 +288,7 @@ fn run_list(global: bool) -> i32 {
         println!("{}\tsource={}\tsymlinks={}", name, source, symlink_text);
     }
 
-    0
+    EXIT_SUCCESS
 }
 
 fn run_remove(skill: &str, yes: bool, global: bool) -> i32 {
@@ -296,31 +296,31 @@ fn run_remove(skill: &str, yes: bool, global: bool) -> i32 {
         Ok(path) => path,
         Err(err) => {
             eprintln!("error: {}", err);
-            return 1;
+            return EXIT_ERROR;
         }
     };
 
     let skill_path = canonical.join(skill);
     if !skill_path.is_dir() {
         eprintln!("error: skill not installed: {}", skill);
-        return 2;
+        return EXIT_USAGE;
     }
 
     if ui::should_prompt_for_confirmation(yes) && !ui::confirm_removal(skill) {
         eprintln!("error: removal cancelled");
-        return 1;
+        return EXIT_ERROR;
     }
 
     if let Err(err) = std::fs::remove_dir_all(&skill_path) {
         eprintln!("error: failed to remove {}: {}", skill_path.display(), err);
-        return 1;
+        return EXIT_ERROR;
     }
 
     if !global && let Err(err) = agent::cleanup_agent_symlinks_if_empty(&canonical) {
         eprintln!("error: {}", err);
-        return 1;
+        return EXIT_ERROR;
     }
 
     println!("removed skill: {}", skill);
-    0
+    EXIT_SUCCESS
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,7 +12,7 @@ pub struct GithubRepo {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstallSource {
     Github(GithubRepo),
-    LocalPath(String),
+    LocalPath(PathBuf),
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -25,7 +27,7 @@ pub enum SourceParseError {
 
 pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseError> {
     if source.starts_with("./") || source.starts_with("../") || source.starts_with('/') {
-        return Ok(InstallSource::LocalPath(source.to_string()));
+        return Ok(InstallSource::LocalPath(PathBuf::from(source)));
     }
 
     parse_github_source(source).map(InstallSource::Github)
@@ -46,7 +48,7 @@ pub fn parse_github_source(source: &str) -> Result<GithubRepo, SourceParseError>
     Ok(repo)
 }
 
-pub fn parse_github_repo(source: &str) -> Result<GithubRepo, SourceParseError> {
+pub(crate) fn parse_github_repo(source: &str) -> Result<GithubRepo, SourceParseError> {
     let Some((owner, name)) = source.split_once('/') else {
         return Err(SourceParseError::InvalidFormat);
     };
@@ -105,7 +107,10 @@ mod tests {
     #[test]
     fn parse_local_path_dot_slash() {
         let source = parse_install_source("./my-skills").expect("must parse");
-        assert_eq!(source, InstallSource::LocalPath("./my-skills".to_string()));
+        assert_eq!(
+            source,
+            InstallSource::LocalPath(PathBuf::from("./my-skills"))
+        );
     }
 
     #[test]
@@ -113,14 +118,17 @@ mod tests {
         let source = parse_install_source("../shared/skills").expect("must parse");
         assert_eq!(
             source,
-            InstallSource::LocalPath("../shared/skills".to_string())
+            InstallSource::LocalPath(PathBuf::from("../shared/skills"))
         );
     }
 
     #[test]
     fn parse_local_path_absolute() {
         let source = parse_install_source("/tmp/skills").expect("must parse");
-        assert_eq!(source, InstallSource::LocalPath("/tmp/skills".to_string()));
+        assert_eq!(
+            source,
+            InstallSource::LocalPath(PathBuf::from("/tmp/skills"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes critical and important findings from code review of the modularized source.

## Changes

| Finding | Severity | Fix |
|---|---|---|
| `detect_active_agents` hardcoded 7 branches duplicating `AGENT_SKILL_LINKS` | K0 | Data-driven `AGENT_DEFS` table — single source of truth for agent name + skill link |
| `LocalPath(String)` instead of `PathBuf` | K1 | Changed to `LocalPath(PathBuf)` — proper type for filesystem paths |
| Hardcoded exit code literals (`0`, `1`, `2`) scattered through `main.rs` | K1 | Replaced with `EXIT_SUCCESS` / `EXIT_ERROR` / `EXIT_USAGE` constants |
| `parse_github_repo` unnecessarily `pub` | K2/XS | Restricted to `pub(crate)` |

## Verification

- All 46 tests pass
- `just verify` green