### PR TITLE
refactor: code quality debt — anyhow, auto-detect agents, release hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 name = "upskill"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["agent", "skills", "cli", "ai", "package-manager"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }
 ctrlc = "3.4"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -28,3 +29,5 @@ tempfile = "3.14"
 lto = true
 strip = true
 codegen-units = 1
+opt-level = "z"
+panic = "abort"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use std::path::Path;
 
 struct AgentDef {
@@ -54,7 +55,7 @@ pub fn ensure_agent_targets(
     all: bool,
     copy: bool,
     canonical_target: &Path,
-) -> Result<(), String> {
+) -> Result<()> {
     if all {
         for link in all_skill_links() {
             create_agent_target(link, copy, canonical_target)?;
@@ -64,21 +65,28 @@ pub fn ensure_agent_targets(
 
     let auto_detect = !claude && !copilot;
 
-    let link_claude = claude || (auto_detect && Path::new(".claude").exists());
-    let link_copilot = copilot || (auto_detect && Path::new(".github").exists());
-
-    if link_claude {
-        create_agent_target(".claude/skills", copy, canonical_target)?;
-    }
-
-    if link_copilot {
-        create_agent_target(".github/skills", copy, canonical_target)?;
+    if auto_detect {
+        for agent in &AGENT_DEFS {
+            let parent = Path::new(agent.skill_link)
+                .parent()
+                .unwrap_or(Path::new("."));
+            if parent.exists() {
+                create_agent_target(agent.skill_link, copy, canonical_target)?;
+            }
+        }
+    } else {
+        if claude {
+            create_agent_target(".claude/skills", copy, canonical_target)?;
+        }
+        if copilot {
+            create_agent_target(".github/skills", copy, canonical_target)?;
+        }
     }
 
     Ok(())
 }
 
-pub fn cleanup_agent_symlinks_if_empty(canonical: &Path) -> Result<(), String> {
+pub fn cleanup_agent_symlinks_if_empty(canonical: &Path) -> Result<()> {
     if !canonical_has_skills(canonical)? {
         for link in all_skill_links() {
             remove_symlink_if_exists(link)?;
@@ -88,16 +96,20 @@ pub fn cleanup_agent_symlinks_if_empty(canonical: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn canonical_has_skills(canonical: &Path) -> Result<bool, String> {
+fn canonical_has_skills(canonical: &Path) -> Result<bool> {
     if !canonical.exists() {
         return Ok(false);
     }
 
-    let entries = std::fs::read_dir(canonical)
-        .map_err(|err| format!("failed to inspect installed skills: {}", err))?;
+    let entries = std::fs::read_dir(canonical).with_context(|| {
+        format!(
+            "failed to inspect installed skills in {}",
+            canonical.display()
+        )
+    })?;
 
     for entry in entries {
-        let entry = entry.map_err(|err| format!("failed to inspect installed skills: {}", err))?;
+        let entry = entry.context("failed to inspect installed skills")?;
         if entry.path().is_dir() {
             return Ok(true);
         }
@@ -106,37 +118,36 @@ fn canonical_has_skills(canonical: &Path) -> Result<bool, String> {
     Ok(false)
 }
 
-fn remove_symlink_if_exists(link_path: &str) -> Result<(), String> {
+fn remove_symlink_if_exists(link_path: &str) -> Result<()> {
     let link = Path::new(link_path);
     match std::fs::symlink_metadata(link) {
         Ok(meta) => {
             if meta.file_type().is_symlink() {
-                std::fs::remove_file(link).map_err(|err| {
-                    format!("failed to remove symlink {}: {}", link.display(), err)
-                })?;
+                std::fs::remove_file(link)
+                    .with_context(|| format!("failed to remove symlink {}", link.display()))?;
             }
             Ok(())
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(format!("failed to inspect {}: {}", link.display(), err)),
+        Err(err) => Err(err).with_context(|| format!("failed to inspect {}", link.display())),
     }
 }
 
-fn create_agent_target(link_path: &str, copy: bool, canonical_target: &Path) -> Result<(), String> {
+fn create_agent_target(link_path: &str, copy: bool, canonical_target: &Path) -> Result<()> {
     let link = Path::new(link_path);
 
     if let Some(parent) = link.parent() {
         std::fs::create_dir_all(parent)
-            .map_err(|err| format!("failed to create {}: {}", parent.display(), err))?;
+            .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
     if link.exists() || std::fs::symlink_metadata(link).is_ok() {
         if link.is_dir() && !link.is_symlink() {
             std::fs::remove_dir_all(link)
-                .map_err(|err| format!("failed to reset {}: {}", link.display(), err))?;
+                .with_context(|| format!("failed to reset {}", link.display()))?;
         } else {
             std::fs::remove_file(link)
-                .map_err(|err| format!("failed to reset {}: {}", link.display(), err))?;
+                .with_context(|| format!("failed to reset {}", link.display()))?;
         }
     }
 
@@ -147,12 +158,11 @@ fn create_agent_target(link_path: &str, copy: bool, canonical_target: &Path) -> 
 
     #[cfg(unix)]
     {
-        std::os::unix::fs::symlink(canonical_target, link).map_err(|err| {
+        std::os::unix::fs::symlink(canonical_target, link).with_context(|| {
             format!(
-                "failed to create symlink {} -> {}: {}",
+                "failed to create symlink {} -> {}",
                 link.display(),
                 canonical_target.display(),
-                err
             )
         })?;
     }
@@ -160,33 +170,31 @@ fn create_agent_target(link_path: &str, copy: bool, canonical_target: &Path) -> 
     #[cfg(not(unix))]
     {
         let _ = link;
-        return Err("symlink creation is currently supported on unix platforms".to_string());
+        anyhow::bail!("symlink creation is currently supported on unix platforms");
     }
 
     Ok(())
 }
 
-fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), String> {
-    std::fs::create_dir_all(dst)
-        .map_err(|err| format!("failed to create {}: {}", dst.display(), err))?;
+fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst).with_context(|| format!("failed to create {}", dst.display()))?;
 
-    let entries = std::fs::read_dir(src)
-        .map_err(|err| format!("failed to read {}: {}", src.display(), err))?;
+    let entries =
+        std::fs::read_dir(src).with_context(|| format!("failed to read {}", src.display()))?;
 
     for entry in entries {
-        let entry = entry.map_err(|err| format!("failed to read {}: {}", src.display(), err))?;
+        let entry = entry.with_context(|| format!("failed to read {}", src.display()))?;
         let entry_path = entry.path();
         let target_path = dst.join(entry.file_name());
 
         if entry_path.is_dir() {
             copy_dir_all(&entry_path, &target_path)?;
         } else {
-            std::fs::copy(&entry_path, &target_path).map_err(|err| {
+            std::fs::copy(&entry_path, &target_path).with_context(|| {
                 format!(
-                    "failed to copy {} to {}: {}",
+                    "failed to copy {} to {}",
                     entry_path.display(),
                     target_path.display(),
-                    err
                 )
             })?;
         }

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
 use crate::ui;
@@ -5,23 +6,22 @@ use crate::ui;
 const PROJECT_CANONICAL_TARGET: &str = ".agents/skills";
 const GLOBAL_CANONICAL_TARGET: &str = ".agents/skills";
 
-pub fn canonical_target(global: bool) -> Result<PathBuf, String> {
+pub fn canonical_target(global: bool) -> Result<PathBuf> {
     if global {
         let home = std::env::var_os("HOME")
             .map(PathBuf::from)
-            .ok_or_else(|| "HOME is not set".to_string())?;
+            .ok_or_else(|| anyhow::anyhow!("HOME is not set"))?;
         return Ok(home.join(GLOBAL_CANONICAL_TARGET));
     }
 
     Ok(PathBuf::from(PROJECT_CANONICAL_TARGET))
 }
 
-pub fn ensure_canonical_target(canonical_target: &Path) -> Result<(), String> {
-    std::fs::create_dir_all(canonical_target).map_err(|err| {
+pub fn ensure_canonical_target(canonical_target: &Path) -> Result<()> {
+    std::fs::create_dir_all(canonical_target).with_context(|| {
         format!(
-            "failed to create canonical target {}: {}",
+            "failed to create canonical target {}",
             canonical_target.display(),
-            err
         )
     })
 }
@@ -30,22 +30,19 @@ pub fn persist_installed_skills(
     canonical_target: &Path,
     skills: &[String],
     source: &str,
-) -> Result<(), String> {
+) -> Result<()> {
     for skill in skills {
         let skill_dir = canonical_target.join(skill);
         std::fs::create_dir_all(&skill_dir)
-            .map_err(|err| format!("failed to create {}: {}", skill_dir.display(), err))?;
+            .with_context(|| format!("failed to create {}", skill_dir.display()))?;
         std::fs::write(skill_dir.join(".upskill-source"), source)
-            .map_err(|err| format!("failed to write source metadata for {}: {}", skill, err))?;
+            .with_context(|| format!("failed to write source metadata for {}", skill))?;
     }
 
     Ok(())
 }
 
-pub fn resolve_requested_skills(
-    skills: &[String],
-    default_skill: &str,
-) -> Result<Vec<String>, String> {
+pub fn resolve_requested_skills(skills: &[String], default_skill: &str) -> Result<Vec<String>> {
     if !skills.is_empty() {
         return Ok(skills.to_vec());
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -54,12 +55,11 @@ impl Lockfile {
     }
 
     /// Write the lockfile to disk.
-    pub fn save(&self, project_root: &Path) -> Result<(), String> {
+    pub fn save(&self, project_root: &Path) -> Result<()> {
         let path = lockfile_path(project_root);
-        let json = serde_json::to_string_pretty(self)
-            .map_err(|e| format!("failed to serialize lockfile: {}", e))?;
+        let json = serde_json::to_string_pretty(self).context("failed to serialize lockfile")?;
         std::fs::write(&path, format!("{}\n", json))
-            .map_err(|e| format!("failed to write {}: {}", path.display(), e))
+            .with_context(|| format!("failed to write {}", path.display()))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use clap::{Parser, Subcommand, error::ErrorKind};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -130,11 +131,11 @@ fn main() {
     std::process::exit(exit_code);
 }
 
-fn install_signal_handlers() -> Result<(), String> {
+fn install_signal_handlers() -> anyhow::Result<()> {
     ctrlc::set_handler(|| {
         INTERRUPTED.store(true, Ordering::SeqCst);
     })
-    .map_err(|err| format!("failed to install signal handler: {}", err))
+    .context("failed to install signal handler")
 }
 
 fn was_interrupted() -> bool {
@@ -148,14 +149,49 @@ fn map_clap_error(err: &clap::Error) -> i32 {
     }
 }
 
-fn lockfile_root(global: bool) -> Result<std::path::PathBuf, String> {
+fn lockfile_root(global: bool) -> anyhow::Result<std::path::PathBuf> {
     if global {
         std::env::var_os("HOME")
             .map(std::path::PathBuf::from)
-            .ok_or_else(|| "HOME is not set".to_string())
+            .ok_or_else(|| anyhow::anyhow!("HOME is not set"))
     } else {
-        std::env::current_dir().map_err(|e| format!("failed to get current directory: {}", e))
+        std::env::current_dir().context("failed to get current directory")
     }
+}
+
+fn finish_install(
+    canonical_target: &std::path::Path,
+    lockfile_root: &std::path::Path,
+    resolved_skills: &[String],
+    source_label: &str,
+    git_ref: Option<&str>,
+    claude: bool,
+    copilot: bool,
+    all: bool,
+    copy: bool,
+    global: bool,
+    explicit_skills: bool,
+) -> anyhow::Result<()> {
+    install::persist_installed_skills(canonical_target, resolved_skills, source_label)?;
+
+    if !global {
+        agent::ensure_agent_targets(claude, copilot, all, copy, canonical_target)?;
+    }
+
+    let mut lf = Lockfile::load(lockfile_root);
+    for skill in resolved_skills {
+        let skill_dir = canonical_target.join(skill);
+        lf.upsert(LockedSkill {
+            name: skill.clone(),
+            source: source_label.to_string(),
+            git_ref: git_ref.map(str::to_string),
+            hash: lockfile::hash_skill_dir(&skill_dir),
+        });
+    }
+    lf.save(lockfile_root)?;
+
+    ui::print_selected_skills(resolved_skills, explicit_skills);
+    Ok(())
 }
 
 fn run_add(
@@ -191,98 +227,66 @@ fn run_add(
     match parse_install_source(source) {
         Ok(InstallSource::Github(repo)) => {
             let mut source_label = format!("github:{}/{}", repo.owner, repo.name);
-            if let Some(git_ref) = &repo.git_ref {
-                source_label.push_str(&format!("@{}", git_ref));
+            if let Some(r) = &repo.git_ref {
+                source_label.push_str(&format!("@{}", r));
             }
-            if let Some(subfolder) = &repo.subfolder {
-                source_label.push_str(&format!(":{}", subfolder));
+            if let Some(s) = &repo.subfolder {
+                source_label.push_str(&format!(":{}", s));
             }
+
             let resolved_skills = match install::resolve_requested_skills(skills, &repo.name) {
-                Ok(skills) => skills,
+                Ok(s) => s,
                 Err(err) => {
                     eprintln!("error: {}", err);
                     return EXIT_ERROR;
                 }
             };
-
-            if let Err(err) = install::persist_installed_skills(
-                &canonical_target,
-                &resolved_skills,
-                &source_label,
-            ) {
-                eprintln!("error: {}", err);
-                return EXIT_ERROR;
-            }
-
-            if !global
-                && let Err(err) =
-                    agent::ensure_agent_targets(claude, copilot, all, copy, &canonical_target)
-            {
-                eprintln!("error: {}", err);
-                return EXIT_ERROR;
-            }
 
             println!("install source: github");
             println!("owner: {}", repo.owner);
             println!("repo: {}", repo.name);
-            if let Some(git_ref) = &repo.git_ref {
-                println!("ref: {}", git_ref);
+            if let Some(r) = &repo.git_ref {
+                println!("ref: {}", r);
             }
-            if let Some(subfolder) = repo.subfolder {
-                println!("subfolder: {}", subfolder);
-            }
-
-            // Update lockfile
-            let mut lockfile = Lockfile::load(&lockfile_root);
-            for skill in &resolved_skills {
-                let skill_dir = canonical_target.join(skill);
-                lockfile.upsert(LockedSkill {
-                    name: skill.clone(),
-                    source: source_label.clone(),
-                    git_ref: repo.git_ref.clone(),
-                    hash: lockfile::hash_skill_dir(&skill_dir),
-                });
-            }
-            if let Err(err) = lockfile.save(&lockfile_root) {
-                eprintln!("error: {}", err);
-                return EXIT_ERROR;
+            if let Some(s) = &repo.subfolder {
+                println!("subfolder: {}", s);
             }
 
-            ui::print_selected_skills(&resolved_skills, skills.is_empty());
-            EXIT_SUCCESS
-        }
-        Ok(InstallSource::Gitlab(repo)) => {
-            let mut source_label = format!("gitlab:{}/{}", repo.owner, repo.name);
-            if let Some(git_ref) = &repo.git_ref {
-                source_label.push_str(&format!("@{}", git_ref));
-            }
-            if let Some(subfolder) = &repo.subfolder {
-                source_label.push_str(&format!(":{}", subfolder));
-            }
-            let resolved_skills = match install::resolve_requested_skills(skills, &repo.name) {
-                Ok(skills) => skills,
-                Err(err) => {
-                    eprintln!("error: {}", err);
-                    return EXIT_ERROR;
-                }
-            };
-
-            if let Err(err) = install::persist_installed_skills(
+            if let Err(err) = finish_install(
                 &canonical_target,
+                &lockfile_root,
                 &resolved_skills,
                 &source_label,
+                repo.git_ref.as_deref(),
+                claude,
+                copilot,
+                all,
+                copy,
+                global,
+                skills.is_empty(),
             ) {
                 eprintln!("error: {}", err);
                 return EXIT_ERROR;
             }
 
-            if !global
-                && let Err(err) =
-                    agent::ensure_agent_targets(claude, copilot, all, copy, &canonical_target)
-            {
-                eprintln!("error: {}", err);
-                return EXIT_ERROR;
+            EXIT_SUCCESS
+        }
+        Ok(InstallSource::Gitlab(repo)) => {
+            let mut source_label = format!("gitlab:{}/{}", repo.owner, repo.name);
+            if let Some(r) = &repo.git_ref {
+                source_label.push_str(&format!("@{}", r));
             }
+            if let Some(s) = &repo.subfolder {
+                source_label.push_str(&format!(":{}", s));
+            }
+
+            let resolved_skills = match install::resolve_requested_skills(skills, &repo.name) {
+                Ok(s) => s,
+                Err(err) => {
+                    eprintln!("error: {}", err);
+                    return EXIT_ERROR;
+                }
+            };
 
             println!("install source: gitlab");
             println!("owner: {}", repo.owner);
@@ -290,30 +294,30 @@ fn run_add(
             if repo.host != "gitlab.com" {
                 println!("host: {}", repo.host);
             }
-            if let Some(git_ref) = &repo.git_ref {
-                println!("ref: {}", git_ref);
+            if let Some(r) = &repo.git_ref {
+                println!("ref: {}", r);
             }
-            if let Some(subfolder) = repo.subfolder {
-                println!("subfolder: {}", subfolder);
+            if let Some(s) = &repo.subfolder {
+                println!("subfolder: {}", s);
             }
 
-            // Update lockfile
-            let mut lockfile = Lockfile::load(&lockfile_root);
-            for skill in &resolved_skills {
-                let skill_dir = canonical_target.join(skill);
-                lockfile.upsert(LockedSkill {
-                    name: skill.clone(),
-                    source: source_label.clone(),
-                    git_ref: repo.git_ref.clone(),
-                    hash: lockfile::hash_skill_dir(&skill_dir),
-                });
-            }
-            if let Err(err) = lockfile.save(&lockfile_root) {
+            if let Err(err) = finish_install(
+                &canonical_target,
+                &lockfile_root,
+                &resolved_skills,
+                &source_label,
+                repo.git_ref.as_deref(),
+                claude,
+                copilot,
+                all,
+                copy,
+                global,
+                skills.is_empty(),
+            ) {
                 eprintln!("error: {}", err);
                 return EXIT_ERROR;
             }
 
-            ui::print_selected_skills(&resolved_skills, skills.is_empty());
             EXIT_SUCCESS
         }
         Ok(InstallSource::LocalPath(path)) => {
@@ -327,8 +331,9 @@ fn run_add(
                 .and_then(|v| v.to_str())
                 .filter(|v| !v.is_empty())
                 .unwrap_or("local-skill");
+
             let resolved_skills = match install::resolve_requested_skills(skills, default_skill) {
-                Ok(skills) => skills,
+                Ok(s) => s,
                 Err(err) => {
                     eprintln!("error: {}", err);
                     return EXIT_ERROR;
@@ -336,43 +341,27 @@ fn run_add(
             };
 
             let source_label = format!("local:{}", path.display());
-            if let Err(err) = install::persist_installed_skills(
+
+            println!("install source: local");
+            println!("path: {}", path.display());
+
+            if let Err(err) = finish_install(
                 &canonical_target,
+                &lockfile_root,
                 &resolved_skills,
                 &source_label,
+                None,
+                claude,
+                copilot,
+                all,
+                copy,
+                global,
+                skills.is_empty(),
             ) {
                 eprintln!("error: {}", err);
                 return EXIT_ERROR;
             }
 
-            if !global
-                && let Err(err) =
-                    agent::ensure_agent_targets(claude, copilot, all, copy, &canonical_target)
-            {
-                eprintln!("error: {}", err);
-                return EXIT_ERROR;
-            }
-
-            println!("install source: local");
-            println!("path: {}", path.display());
-
-            // Update lockfile
-            let mut lockfile = Lockfile::load(&lockfile_root);
-            for skill in &resolved_skills {
-                let skill_dir = canonical_target.join(skill);
-                lockfile.upsert(LockedSkill {
-                    name: skill.clone(),
-                    source: source_label.clone(),
-                    git_ref: None,
-                    hash: lockfile::hash_skill_dir(&skill_dir),
-                });
-            }
-            if let Err(err) = lockfile.save(&lockfile_root) {
-                eprintln!("error: {}", err);
-                return EXIT_ERROR;
-            }
-
-            ui::print_selected_skills(&resolved_skills, skills.is_empty());
             EXIT_SUCCESS
         }
         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,23 +159,28 @@ fn lockfile_root(global: bool) -> anyhow::Result<std::path::PathBuf> {
     }
 }
 
+struct AddContext {
+    claude: bool,
+    copilot: bool,
+    all: bool,
+    copy: bool,
+    global: bool,
+    /// true when --skill was not specified (implicit default)
+    implicit_skill: bool,
+}
+
 fn finish_install(
     canonical_target: &std::path::Path,
     lockfile_root: &std::path::Path,
     resolved_skills: &[String],
     source_label: &str,
     git_ref: Option<&str>,
-    claude: bool,
-    copilot: bool,
-    all: bool,
-    copy: bool,
-    global: bool,
-    explicit_skills: bool,
+    ctx: &AddContext,
 ) -> anyhow::Result<()> {
     install::persist_installed_skills(canonical_target, resolved_skills, source_label)?;
 
-    if !global {
-        agent::ensure_agent_targets(claude, copilot, all, copy, canonical_target)?;
+    if !ctx.global {
+        agent::ensure_agent_targets(ctx.claude, ctx.copilot, ctx.all, ctx.copy, canonical_target)?;
     }
 
     let mut lf = Lockfile::load(lockfile_root);
@@ -190,7 +195,7 @@ fn finish_install(
     }
     lf.save(lockfile_root)?;
 
-    ui::print_selected_skills(resolved_skills, explicit_skills);
+    ui::print_selected_skills(resolved_skills, ctx.implicit_skill);
     Ok(())
 }
 
@@ -258,12 +263,14 @@ fn run_add(
                 &resolved_skills,
                 &source_label,
                 repo.git_ref.as_deref(),
-                claude,
-                copilot,
-                all,
-                copy,
-                global,
-                skills.is_empty(),
+                &AddContext {
+                    claude,
+                    copilot,
+                    all,
+                    copy,
+                    global,
+                    implicit_skill: skills.is_empty(),
+                },
             ) {
                 eprintln!("error: {}", err);
                 return EXIT_ERROR;
@@ -307,12 +314,14 @@ fn run_add(
                 &resolved_skills,
                 &source_label,
                 repo.git_ref.as_deref(),
-                claude,
-                copilot,
-                all,
-                copy,
-                global,
-                skills.is_empty(),
+                &AddContext {
+                    claude,
+                    copilot,
+                    all,
+                    copy,
+                    global,
+                    implicit_skill: skills.is_empty(),
+                },
             ) {
                 eprintln!("error: {}", err);
                 return EXIT_ERROR;
@@ -351,12 +360,14 @@ fn run_add(
                 &resolved_skills,
                 &source_label,
                 None,
-                claude,
-                copilot,
-                all,
-                copy,
-                global,
-                skills.is_empty(),
+                &AddContext {
+                    claude,
+                    copilot,
+                    all,
+                    copy,
+                    global,
+                    implicit_skill: skills.is_empty(),
+                },
             ) {
                 eprintln!("error: {}", err);
                 return EXIT_ERROR;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,22 +1,21 @@
+use anyhow::{Context, Result};
 use std::io::{self, IsTerminal, Write};
 
 pub fn interactive_skill_selection_enabled() -> bool {
     std::env::var_os("UPSKILL_FORCE_INTERACTIVE").is_some() || io::stdin().is_terminal()
 }
 
-pub fn prompt_for_skill_selection(default_skill: &str) -> Result<Vec<String>, String> {
+pub fn prompt_for_skill_selection(default_skill: &str) -> Result<Vec<String>> {
     print!(
         "select skills (comma-separated, empty for '{}'): ",
         default_skill
     );
-    io::stdout()
-        .flush()
-        .map_err(|err| format!("failed to flush prompt: {}", err))?;
+    io::stdout().flush().context("failed to flush prompt")?;
 
     let mut answer = String::new();
     io::stdin()
         .read_line(&mut answer)
-        .map_err(|err| format!("failed to read selected skills: {}", err))?;
+        .context("failed to read selected skills")?;
 
     let parsed: Vec<String> = answer
         .split(',')


### PR DESCRIPTION
Epic: #48

## Summary

- **Adopt `anyhow`** — replace `Result<T, String>` with `anyhow::Result` + `.with_context()` in `agent.rs`, `install.rs`, `lockfile.rs`, `ui.rs`, `main.rs`; `source.rs` keeps `thiserror` for typed parse errors
- **Auto-detect all agents** — `ensure_agent_targets` now iterates all 7 `AGENT_DEFS` on auto-detect instead of only checking `.claude/` and `.github/`
- **Reduce `run_add` duplication** — extracted `finish_install()` to deduplicate the persist → agent targets → lockfile → print flow shared across GitHub/GitLab/LocalPath arms
- **Release profile hardening** — added `opt-level = "z"` and `panic = "abort"` to `[profile.release]`

## Test plan

- [x] All 105 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `just verify` passes (pre-push hook)