### PR TITLE
docs: v0.2 redesign documentation (format spec, ADR, agent conventions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,28 @@ upskill is a Rust CLI project for managing Agent Skills packages across coding
 agents. It focuses on a lightweight binary workflow and shared repository
 conventions used across driftsys projects.
 
+**Design priority**: ultra-light single binary. No Node.js, no npm, no async
+runtime. Targets ~2–3 MB stripped release binary.
+
+> The README still says "name reservation — real implementation coming soon."
+> That line is stale. The CLI is fully implemented (`add`, `list`, `remove`,
+> `check`, `search`, `update`) with 13 integration test files.
+
+## Stack
+
+- **Language**: Rust, edition 2024. **MSRV: 1.85** (first stable to support
+  edition 2024).
+- **Crate**: `upskill` is both library (`lib.rs`) and binary (`main.rs`).
+- **Dependencies** (kept deliberately small):
+  - `clap` 4 (derive), `anyhow` 1, `thiserror` 2, `serde` 1, `serde_json` 1,
+    `sha2` 0.11, `ureq` 2, `ctrlc` 3.
+- **Deliberately NOT used**: `tokio`, `reqwest`, `git2`, `walkdir`,
+  `dialoguer`, `serde_yaml`, `toml`. Reasons in `docs/architecture.md`. Don't
+  reach for these without a strong reason — shell out to `git`, use
+  `std::fs::read_dir`, etc.
+- **Release profile**: `opt-level = "z"`, `lto`, `codegen-units = 1`, `strip`,
+  `panic = "abort"`.
+
 ## Build commands
 
 ```bash
@@ -20,6 +42,10 @@ just build              # Assemble + check
 just verify             # Commit check + build — run before PR
 just fmt                # Format Rust + Markdown
 ```
+
+After `git clone` or `git worktree add`, run `./bootstrap` once. It installs
+`git-std` (from `driftsys/git-std`) into `~/.local/bin` and runs
+`git std bootstrap`. Release tagging (`just release`) uses `git std bump`.
 
 ## Architecture
 
@@ -42,11 +68,11 @@ src/
 └── auth.rs       Token resolution (env vars, gh/glab CLI fallback)
 ```
 
-Core docs:
+Core docs (published as mdBook at <https://driftsys.github.io/upskill/>):
 
-- `docs/specification.md`
-- `docs/architecture.md`
-- `docs/usage.md`
+- `docs/specification.md` — behavioral spec
+- `docs/architecture.md` — implementation guide (data structures, algorithms)
+- `docs/usage.md` — user-facing guide
 
 ### Key conventions
 
@@ -54,10 +80,75 @@ Core docs:
   `source.rs`, which uses `thiserror` for typed `SourceParseError`.
 - **`main.rs` only does I/O orchestration** — call modules, handle errors, print
   results. Business logic lives in the library modules.
+- **Only `main.rs` and `ui.rs` write to stdout/stderr.** Every other module
+  returns data structures or `Result<T>`; presentation belongs in `main.rs`.
 - **Zero warnings policy** — compiler, clippy, and docs tooling. `-D warnings`
   is enforced in CI.
 - **Clippy `too_many_arguments`** — group related flags into structs
   (e.g. `AddContext`) when a function would exceed 7 params.
+
+### Install layout
+
+| Scope   | Canonical skills target | Lockfile                   |
+| ------- | ----------------------- | -------------------------- |
+| Project | `.agents/skills`        | `{cwd}/.upskill-lock.json` |
+| Global  | `$HOME/.agents/skills`  | `~/.upskill-lock.json`     |
+
+Per-agent skill directories (symlinks or copies of the canonical target):
+`.claude/skills`, `.github/skills`, `.codex/skills`, `.cursor/skills`,
+`.kiro/skills`, `.windsurf/skills`, `.opencode/skills`. Source of truth:
+`AGENT_DEFS` in `src/agent.rs`.
+
+### Source format
+
+`upskill add` accepts:
+
+- `owner/repo` — GitHub shorthand
+- `owner/repo@ref` — pinned ref/tag/branch
+- `owner/repo:path/to/skill` — subfolder
+- `owner/repo@ref:path` — combined
+- `https://github.com/owner/repo[...]` — full URL
+- `gitlab:owner/repo[...]` or `https://gitlab.com/...` — GitLab
+- `./path`, `../path`, `/abs/path`, `~/path` — local paths
+
+### Authentication
+
+Token resolution order:
+
+- GitHub: `GITHUB_TOKEN` → `GH_TOKEN` → `gh auth token` → none.
+- GitLab: `GITLAB_TOKEN` → `GL_TOKEN` → `glab auth token` → none.
+
+### Exit codes
+
+| Outcome       | Code |
+| ------------- | ---- |
+| Success       | 0    |
+| General error | 1    |
+| Usage error   | 2    |
+| SIGINT        | 130  |
+
+### Testing
+
+- **Unit tests** live alongside modules. `source.rs` is pure — test parsing
+  exhaustively. Other unit tests cover flag resolution, lockfile read/write,
+  hash computation, env-var precedence, fetch with subfolder, etc.
+- **Integration tests** live in `tests/` as `cli_*.rs` files and use
+  `assert_cmd` + `tempfile`. Pattern:
+
+  ```rust
+  Command::cargo_bin("upskill")
+      .unwrap()
+      .current_dir(&tmp)
+      .args(["add", "owner/repo", "--claude"])
+      .assert()
+      .success();
+  ```
+
+- Existing test files (one per concern): `cli_add`, `cli_check`, `cli_ci_mode`,
+  `cli_dryrun`, `cli_exit_codes`, `cli_gitlab`, `cli_global`, `cli_list`,
+  `cli_lockfile`, `cli_moddetect`, `cli_remove`, `cli_search`, `cli_update`.
+  When adding behavior, prefer extending the matching file or creating a new
+  `cli_<area>.rs`.
 
 ## Workflow
 
@@ -86,7 +177,8 @@ Agent-specific rules:
 - Start from acceptance criteria first.
 - Work by example: start with ATDD integration tests using CLI/snapshot testing,
   then move to TDD with focused unit tests.
-- Every branch must be sandboxed in its own git worktree.
+- Every branch must be sandboxed in its own git worktree, in
+  `.claude/worktrees/<branch>` (already gitignored).
 - Keep code, tests, and docs in the same PR.
 - Use Conventional Commits (`feat`, `fix`, `refactor`, `docs`, `test`, `chore`).
 - Before opening a PR, run `just fmt` then `just verify`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,3 +1,4 @@
 # upskill
 
 [upskill](usage.md)
+[Portable format spec](format-spec.md)

--- a/docs/adr/0001-v0.2-architectural-reset.md
+++ b/docs/adr/0001-v0.2-architectural-reset.md
@@ -1,0 +1,157 @@
+# v0.2 architectural reset — from skills installer to multi-kind portable-format compiler
+
+**Status**: Proposed (2026-05-01)
+
+## Context
+
+upskill v0.1 is a Rust CLI that installs Agent Skills (`SKILL.md` packages)
+from git source repos for use across multiple AI coding clients. Its surface
+is `add`, `list`, `remove`, `check`, `search`, `update`. Its fetch model is
+`owner/repo[@ref][:subfolder]`. Its state is a per-project lockfile.
+
+The new requirement is broader. Rather than installing skills only, the tool
+should help authors **create, manage, and prolong** AI-assistance content of
+three kinds — rules, skills, agents — across three clients (Claude Code,
+Copilot, opencode). The companion [`docs/format-spec.md`](../format-spec.md)
+(also uncommitted) defines the portable on-disk format that drives this.
+
+The expansion is not additive. The new central abstraction is **generation**:
+SSOT → per-client output, via frontmatter mapping, directive processing
+(`<!-- @client:X -->`), override files, and a dprint-formatted body. v0.1's
+`install.rs` (fetch-and-copy) does not have a place in that pipeline.
+
+## Decision
+
+1. **Tag and branch.** Tag current `main` as v0.1.0 and rebuild for v0.2 on a
+   `v0.2-redesign` branch. v0.1 stays supported via patch releases for the
+   skills-installer use case.
+
+2. **MVP scope.** Three kinds (rules, skills, agents), three clients (Claude
+   Code, Copilot, opencode), generation pipeline as the central abstraction,
+   plus install / update / remove / sync, lint / fmt, and `new` for
+   scaffolding. **Bundles deferred** to a later release.
+
+3. **Vocabulary.** Spec terms — rules, skills, agents — stay throughout
+   schema, CLI, and docs. Client-specific words (Copilot's "instructions",
+   Claude's "subagent") appear only in generated output and per-client
+   documentation, never in upskill's own surface.
+
+4. **"Prolong" defined.**
+   - **Absorb client drift.** When Copilot or Claude Code change a path or
+     frontmatter field, `upskill sync` regenerates outputs from the same
+     SSOT; authors don't have to react.
+   - **Track upstream evolution.** `upskill update` git-pulls source repos
+     and regenerates items whose source hash changed.
+
+5. **Dependency philosophy relaxed.** [AGENTS.md](../../AGENTS.md) currently
+   lists `tokio`, `reqwest`, `git2`, `walkdir`, `dialoguer`, `serde_yaml`,
+   `toml` as deliberately not used. v0.2 admits `serde_yaml`, `walkdir`,
+   `pulldown-cmark`, `dprint-plugin-markdown`, and similar. `reqwest` may
+   replace `ureq` if multi-host fetching demands it. `git2` stays out (shell
+   out to `git`). The "no runtime deps, size-optimized" framing in AGENTS.md
+   is revised to "minimal but reasonable — prefer one focused dep over
+   hand-rolled equivalents."
+
+6. **State migration.** v0.1's per-project lockfile maps to v0.2's
+   `~/.upskill/installed.json` via a one-time translator. Existing users are
+   not silently broken.
+
+7. **CLI surface.** `add` aliased to `install`; `remove` aliased to
+   `uninstall`. Both aliases held for one minor version, then removed.
+   `search` and `update` keep their names. `check` either rolls into
+   `doctor` or stays as a lint subset (decided in Phase 5). New verbs:
+   `new`, `sync`, `lint`, `fmt`, `info`, `doctor`.
+
+## Consequences
+
+**Positive.** Single tool covers the full lifecycle of rules/skills/agents
+across all three clients. SSOT insulates authors from client conventions.
+Lint/fmt provide hygiene. Sync delivers prolong cheaply.
+
+**Negative.** ~7 engineer-weeks. Binary size grows. Small migration for v0.1
+users. README and architecture docs need rewrite. The generation pipeline
+introduces edge cases (override × directive interaction) that need careful
+test coverage.
+
+**Risk.** `dprint-plugin-markdown` crate API stability is unverified. The
+Phase 0 spike will determine whether to embed the crate or shell out to
+`dprint` at runtime.
+
+## Alternatives considered
+
+**(a) Layer rules and agents onto v0.1's existing model without a redesign.**
+Rejected: the generation pipeline is fundamentally different from
+fetch-and-copy; grafting onto `install.rs` produces churn without clarity.
+
+**(b) Keep size-optimized minimalism strict, hand-roll YAML / markdown
+traversal.** Rejected: high cost, low benefit. The deps in question are
+well-maintained and individually small.
+
+**(c) Include bundles in MVP.** Rejected: manifest format, transitive
+resolution, ref-counted uninstall, registry index — significant complexity
+orthogonal to create/manage/prolong. Better as a v0.3 increment.
+
+## Build order
+
+- **Phase 0** (1w) — tag, branch, deps, this ADR, dprint spike, model
+  skeleton.
+- **Phase 1** (1.5w) — SSOT parser + generation pipeline for skills × all
+  three clients.
+- **Phase 2** (1w) — extend pipeline to rules and agents.
+- **Phase 3** (1.5w) — install / update / remove on top of pipeline, with
+  v0.1 lockfile migration.
+- **Phase 4** (0.5w) — sync.
+- **Phase 5** (1w) — lint + fmt.
+- **Phase 6** (0.5w) — scaffold / `new`.
+- **Phase 7** (~1w) — polish + release of v0.2.0.
+
+## Phase 0 spike: dprint formatting strategy
+
+**Decision.** Embed `dprint-plugin-markdown` as a direct Rust crate
+dependency, pinned exactly (`=0.21.1`, not caret). Bump deliberately on
+each minor release after re-running golden-file fixtures. Align
+`dprint.json`'s WASM plugin pin to match the embedded crate version so
+contributors running `just lint` see the same output as CI.
+
+**Rationale.**
+
+- Output is byte-identical to the `dprint` CLI on the 36 KB
+  `docs/format-spec.md` test.
+- Byte-identity holds across 4 minor versions (`0.17.8` → `0.21.1`,
+  ~18 months apart), so the formatter is effectively output-stable
+  even though its API isn't.
+- Marginal binary cost is ~+1 MB after dep overlap — stays inside the
+  architecture target (~2-3 MB).
+- Removes the `dprint` CLI as a runtime dependency for upskill users.
+
+**Rejected alternatives.**
+
+- **Shell-out to `dprint`.** Forces a 6-9 MB Homebrew dependency on
+  users, turns formatting into a subprocess dance with stdin/stdout
+  error handling, and leaves the plugin-version-vs-test-target gap
+  unmanaged.
+- **Wasmtime-host the `.wasm` plugin.** Pulls a 5-10 MB wasmtime
+  runtime and a second runtime to debug, and reimplements what
+  `dprint` already does.
+
+**Phase 1 implementation notes.**
+
+- Real signature:
+  `format_text(text: &str, config: &Configuration, callback: impl FnMut(...) -> Result<Option<String>>) -> Result<Option<String>>`.
+  No `file_path` argument (the prompt's assumed signature was wrong).
+- `Ok(None)` means "input was already canonical, hand it back as-is" —
+  must not be misread as "no output." A naive `unwrap()` will panic on
+  already-formatted files.
+- Default `text_wrap` is `Maintain`. `line_width` alone does not
+  trigger re-wrapping; set `TextWrap::Always` to wrap.
+- Pass `|_, _, _| Ok(None)` for the code-block callback to leave
+  fenced blocks untouched.
+
+## Open questions
+
+- Does `check` survive as a separate command or merge into `doctor`/`lint`?
+  — Phase 5.
+- Multi-host auth growth (GitLab + GitHub). — Phase 3.
+- ~~`dprint` embedding vs shell-out.~~ **Resolved** — see [Phase 0 spike:
+  dprint formatting strategy](#phase-0-spike-dprint-formatting-strategy).
+- Whether v0.1 tests carry forward or are rewritten. — Start of Phase 1.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,3 @@
+# Architecture Decision Records
+
+Numbered sequentially. Status one of: Proposed | Accepted | Superseded.

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -1,0 +1,879 @@
+# Portable Format for AI-Assistance Content
+
+**Version**: 0.1.0-draft
+**Status**: Draft
+**Date**: 2026-05-01
+
+---
+
+## Abstract
+
+This specification defines a portable, tool-agnostic format for authoring rules, skills, and agents
+targeting AI coding assistants. It also defines a bundle manifest format for distributing curated sets
+of these items. The format is inspired by and compatible with the Agent Skills open standard
+(agentskills.io) and extends it to cover always-on rules and agent definitions, which the open standard
+does not address.
+
+The specification intentionally leaves implementation details (installation mechanics, caching, registry
+protocols, CLI surface) to the implementing tool. The scope is the on-disk content contract: file layout,
+frontmatter schemas, body conventions, conditional directives, and per-client override mechanics.
+
+## Audience
+
+Authors of AI-assistance content (rules, skills, agents) targeting multiple AI coding clients from a
+single source. Implementers of tools that consume this format to generate client-specific outputs.
+Maintainers of CI pipelines that validate content against this specification.
+
+---
+
+## 1. Terminology
+
+**Item**: a rule, skill, or agent. The three kinds share a base schema and differ in semantic role and
+a small number of kind-specific fields.
+
+**Rule**: always-on behavioral guidance, loaded into every session of compatible clients. Rules constrain
+behavior ("never do X", "always check Y").
+
+**Skill**: on-demand procedural content, activated by name or by a client's automatic discovery mechanism.
+Skills teach a procedure ("to accomplish X, follow these steps").
+
+**Agent**: a persona definition with its own system prompt and tool scope, invocable as a subagent or
+primary agent depending on the target client. Agents establish identity and role ("you are a security
+reviewer; when invoked, do X").
+
+**Bundle**: a manifest file grouping items (and optionally other bundles) by reference for distribution.
+Bundles contain no content themselves.
+
+**Client**: a target AI coding assistant. This specification recognizes three initial clients: Claude Code,
+GitHub Copilot (VS Code + CLI + cloud agent), and opencode. Implementations MAY extend this list.
+
+**SSOT**: single source of truth. The canonical form of an item, authored per this specification, from
+which client-specific outputs are derived.
+
+**Client-specific output**: a file or configuration entry written for a particular client's expected
+location, layout, and frontmatter conventions. Generated from the SSOT by an implementing tool.
+
+---
+
+## 2. File layout
+
+### 2.1 Item directory structure
+
+Each item is a directory containing at minimum an entrypoint file. Kind is determined by directory
+location and entrypoint filename:
+
+```text
+<item-root>/
+├── rules/
+│   └── <name>/
+│       └── RULE.md
+├── skills/
+│   └── <name>/
+│       └── SKILL.md
+└── agents/
+    └── <name>/
+        └── AGENT.md
+```
+
+Constraints:
+
+- `<name>` MUST match the `name` field in the entrypoint's YAML frontmatter.
+- `<name>` MUST consist of lowercase letters (`a-z`), digits (`0-9`), and hyphens (`-`).
+- `<name>` MUST NOT start or end with a hyphen.
+- `<name>` MUST be at most 64 characters.
+- `<item-root>` MAY be any path. Implementations SHOULD accept `.agents/` as the default convention
+  but MUST NOT require it.
+
+### 2.2 Bundle files
+
+Bundles are flat manifest files, not directories:
+
+```text
+<bundle-root>/
+├── platform-baseline.bundle.md
+├── android.bundle.md
+└── rust-embedded.bundle.md
+```
+
+- The filename stem (before `.bundle.md`) MUST match the `name` field in the bundle's frontmatter.
+
+### 2.3 Per-client override files
+
+Any item MAY have optional per-client body overrides alongside the canonical entrypoint:
+
+```text
+rules/<name>/
+├── RULE.md                    # canonical, always required
+├── RULE.claude.md             # optional — Claude Code body override
+├── RULE.copilot.md            # optional — Copilot body override
+└── RULE.opencode.md           # optional — opencode body override
+```
+
+The same pattern applies to skills (`SKILL.claude.md`, etc.) and agents (`AGENT.claude.md`, etc.).
+
+Override file rules:
+
+- Override files contain body content only; they MUST NOT include YAML frontmatter.
+- Frontmatter is always taken from the canonical entrypoint.
+- If both a per-client override file and inline `<!-- @client: -->` directives exist for the same
+  client, the override file takes precedence; directives in the canonical body are not processed
+  for that client.
+- The `<client>` suffix MUST be one of the known client identifiers (see §6.1).
+
+### 2.4 Supporting resources
+
+Items MAY contain supporting files in their directory:
+
+```text
+skills/<name>/
+├── SKILL.md
+├── templates/
+│   └── handler.ts.tmpl
+├── scripts/
+│   └── validate.sh
+└── references/
+    └── patterns.md
+```
+
+- Supporting files are referenced from the entrypoint body using standard markdown relative links.
+- Implementations MUST preserve supporting files and their directory structure during generation
+  (copy them alongside the generated entrypoint into the client-expected location).
+- SKILL.md bodies SHOULD stay under 500 lines; detailed reference material belongs in separate files.
+
+---
+
+## 3. Frontmatter schema
+
+All entrypoint files (RULE.md, SKILL.md, AGENT.md, *.bundle.md) begin with YAML frontmatter delimited
+by `---` markers. Frontmatter is followed by a blank line and then markdown body content.
+
+### 3.1 Common fields (all kinds and bundles)
+
+| Field         | Type    | Required | Description                                                  |
+| ------------- | ------- | -------- | ------------------------------------------------------------ |
+| `schema`      | integer | YES      | Protocol version of this specification. Current: `1`.        |
+| `name`        | string  | YES      | Stable identifier. See §2.1 for format constraints.          |
+| `description` | string  | YES      | What this item does and when to use it. Max 1024 characters. |
+| `license`     | string  | no       | SPDX identifier or custom (`proprietary`, `LicenseRef-*`).   |
+| `metadata`    | map     | no       | Free-form governance block. See §3.6.                        |
+
+Example:
+
+```yaml
+---
+schema: 1
+name: license-awareness
+description: Use when reviewing third-party code, AI suggestions, or external snippets to check licensing compatibility and avoid incorporating incompatible licensed code
+license: proprietary
+metadata:
+  version: "1.0.0"
+  author: platform-security
+---
+```
+
+Field semantics:
+
+- `schema`: implementations MUST reject files with `schema` greater than the highest version they
+  support and SHOULD report a clear upgrade message. See §8 for evolution rules.
+- `name`: used as the `/slash-command` name in clients that support it, as the directory name, and
+  as the identifier in bundle manifests.
+- `description`: for skills, this is the activation hint — the model reads it during discovery and
+  decides whether to load the full body. For rules and agents, it serves as documentation. Front-load
+  the key use case. Convention: start with "Use when…" for skills and agents.
+- `license`: if the item might be shared outside the authoring organization, SHOULD be populated.
+- `metadata`: see §3.6. Implementations MUST preserve unknown keys within `metadata`.
+
+### 3.2 Rule-specific fields
+
+Rules MAY include path-scoping:
+
+```yaml
+scope:
+  paths:
+    - "src/api/**/*.ts"
+    - "src/handlers/**/*.ts"
+```
+
+| Field         | Type     | Required | Description                                           |
+| ------------- | -------- | -------- | ----------------------------------------------------- |
+| `scope`       | map      | no       | Scoping constraints.                                  |
+| `scope.paths` | string[] | no       | Glob patterns. If absent or empty, rule is always-on. |
+
+When `scope.paths` is present, implementations:
+
+- SHOULD emit the rule with path-scoping for clients that support it (Claude Code's `paths:` array,
+  Copilot's `applyTo:` comma-joined string).
+- SHOULD emit the rule unconditionally for clients that lack path-scoping (opencode), accepting the
+  token-cost trade-off.
+
+### 3.3 Skill-specific fields
+
+No additional required fields beyond §3.1.
+
+The Agent Skills open standard defines optional fields (`allowed-tools`, `when_to_use`,
+`disable-model-invocation`, `context`, `agent`, `argument-hint`, `paths`, etc.) which implementations
+MAY pass through to client outputs when generating for clients that support them. This specification
+does not redefine those fields; see agentskills.io/specification for their semantics.
+
+Implementations SHOULD allow unknown top-level fields in skill frontmatter to enable pass-through of
+client-specific or standard-defined fields.
+
+### 3.4 Agent-specific fields
+
+```yaml
+mode: subagent
+model: sonnet
+tools:
+  - read
+  - grep
+  - glob
+  - bash
+preload-skills:
+  - security-baseline
+```
+
+| Field            | Type     | Required | Default    | Description                                                             |
+| ---------------- | -------- | -------- | ---------- | ----------------------------------------------------------------------- |
+| `mode`           | string   | no       | `subagent` | `primary`, `subagent`, or `all`. Mapped to client equivalents.          |
+| `model`          | string   | no       | `sonnet`   | Short alias. Implementations maintain alias → client model ID mappings. |
+| `tools`          | string[] | no       | (all)      | Capability-level tool names. See §4.                                    |
+| `preload-skills` | string[] | no       | (none)     | Skill names to load at agent startup.                                   |
+
+Implementations map these fields to each client's agent definition format:
+
+- Claude Code: `.claude/agents/<name>.md` with `tools:` as capitalized names, `model:` as literal.
+- Copilot: `.github/agents/<name>.agent.md` or similar.
+- opencode: `.opencode/agents/<name>.md` with `mode:`, `permission:`, `temperature:`, etc.
+
+### 3.5 Client-specific passthrough blocks
+
+Items MAY include top-level blocks named after specific clients for fields that have no neutral
+equivalent:
+
+```yaml
+copilot:
+  excludeAgent: code-review
+opencode:
+  temperature: 0.2
+  color: "#8b5cf6"
+```
+
+Rules:
+
+- Implementations MUST merge these blocks into the client-specific output only for the matching client.
+- Implementations MUST NOT emit passthrough blocks for non-matching clients.
+- Implementations MUST NOT validate the contents of passthrough blocks (they are opaque to the spec).
+- Known passthrough block names: `claude`, `copilot`, `opencode`. Additional names follow the same
+  pattern for new clients.
+
+### 3.6 Metadata block
+
+The `metadata` field is a free-form map for governance, versioning, and implementation-specific
+extensions.
+
+Recommended conventions (not required by this specification):
+
+| Key        | Type     | Convention                                                                                                                 |
+| ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `version`  | string   | Semver, quoted (e.g., `"1.0.0"`). MUST be quoted to avoid YAML float coercion.                                             |
+| `author`   | string   | Team or individual identifier.                                                                                             |
+| `audience` | string[] | Target clients (`claude`, `copilot`, `opencode`). When present, generate only for listed clients. When absent, target all. |
+| `updated`  | string   | ISO 8601 date of last content change.                                                                                      |
+
+Implementations:
+
+- MUST preserve all keys within `metadata` during processing.
+- MUST NOT require any specific key within `metadata` beyond what the implementation itself needs.
+- SHOULD validate `version` as semver when present.
+- SHOULD respect `audience` when present to limit generation targets.
+
+### 3.7 Bundle schema
+
+```yaml
+---
+schema: 1
+name: platform-baseline
+description: Baseline rules, skills, and agents for all repositories
+license: proprietary
+
+items:
+  rules:
+    - license-awareness
+    - security-baseline
+    - commit-style
+  skills:
+    - pr-summary
+  agents:
+    - security-reviewer
+
+requires: []
+
+metadata:
+  version: "1.2.0"
+  author: platform-dx
+---
+
+# Platform baseline
+
+What this bundle provides, who it targets, changelog...
+```
+
+| Field          | Type     | Required | Description                          |
+| -------------- | -------- | -------- | ------------------------------------ |
+| `schema`       | integer  | YES      | Same as §3.1.                        |
+| `name`         | string   | YES      | Same as §3.1. Matches filename stem. |
+| `description`  | string   | YES      | Same as §3.1.                        |
+| `license`      | string   | no       | Same as §3.1.                        |
+| `items`        | map      | YES      | What this bundle provides.           |
+| `items.rules`  | string[] | no       | Rule names.                          |
+| `items.skills` | string[] | no       | Skill names.                         |
+| `items.agents` | string[] | no       | Agent names.                         |
+| `requires`     | array    | no       | Bundle dependencies. See below.      |
+| `metadata`     | map      | no       | Same as §3.6.                        |
+
+`requires` entries:
+
+- String form: `"platform-baseline"` — any version.
+- Map form: `{ name: "platform-baseline", version: "^1.0.0" }` — with semver constraint.
+
+Implementations:
+
+- MUST resolve `items.*` entries against configured item sources by matching the `name` field.
+- MUST report unresolved item names as errors.
+- SHOULD resolve `requires` transitively.
+- SHOULD reject circular dependencies.
+
+---
+
+## 4. Capability-level tool vocabulary
+
+Agent frontmatter and item bodies reference tools by neutral capability names rather than
+client-specific identifiers. This decouples content from any single client's naming conventions.
+
+| Capability   | Meaning                   | Claude Code | Copilot      | opencode |
+| ------------ | ------------------------- | ----------- | ------------ | -------- |
+| `read`       | Read file contents        | `Read`      | —            | `read`   |
+| `write`      | Create or overwrite files | `Write`     | —            | `write`  |
+| `edit`       | Modify existing files     | `Edit`      | —            | `edit`   |
+| `bash`       | Execute shell commands    | `Bash`      | `shell`      | `bash`   |
+| `grep`       | Search file contents      | `Grep`      | —            | `grep`   |
+| `glob`       | Match file paths          | `Glob`      | —            | `glob`   |
+| `web-fetch`  | Retrieve URL content      | `WebFetch`  | `fetch`      | —        |
+| `web-search` | Search the web            | `WebSearch` | `web_search` | —        |
+
+Implementations maintain the mapping from capability names to client-specific identifiers. The mapping
+table above is informational; clients may change their tool names independently of this specification.
+
+For MCP tools, which are server-specific and not covered by this vocabulary, body content SHOULD use
+the `ServerName:tool_name` form (colon-separated, preserving case). This form is readable across
+clients; client-specific internal forms (e.g., `mcp__server__tool`) SHOULD NOT appear in SSOT content.
+
+This vocabulary is intentionally small. It covers the tools common to all three initial clients.
+Future specification versions may extend it. For tools not covered, item bodies SHOULD describe the
+desired capability in natural language rather than naming a client-specific tool.
+
+---
+
+## 5. Body content conventions
+
+Item bodies are markdown content following the frontmatter. These conventions ensure generated output
+is portable and passes standard markdown linting (markdownlint default ruleset).
+
+### 5.1 Heading structure
+
+- Body content MUST NOT contain an H1 (`#`) heading. Implementations generate H1 from the item's
+  `name` or `description` during rendering for clients that require it.
+- Body headings MUST start at H2 (`##`) and MUST NOT skip levels (no H2 → H4 without an intervening H3).
+
+Rationale: generated output prepends an H1 derived from the item metadata. An H1 in the body would
+produce duplicate H1s, violating MD025 (single-title/single-h1).
+
+### 5.2 Fenced code blocks
+
+All fenced code blocks MUST specify a language hint. Use `text` when no specific language applies.
+
+Rationale: MD040 (fenced-code-language) requires language hints. Generating output that violates
+this rule forces downstream consumers to either suppress the lint rule or fix the output.
+
+### 5.3 Tool references in prose
+
+Body content SHOULD describe tools by capability rather than by client-specific name:
+
+- YES: "Search the codebase for occurrences of the deprecated function"
+- YES: "Use `GitHub:create_issue` to file a tracking issue" (MCP tool in portable form)
+- NO: "Use the `Read` tool to open the file" (Claude-specific)
+- NO: "Use `#tool:read`" (Copilot-specific)
+
+### 5.4 File references
+
+Body content SHOULD reference supporting files using standard markdown links with relative paths
+from the item directory:
+
+```markdown
+See [approved licenses](./allowed-licenses.txt) for the canonical list.
+```
+
+Client-specific import syntax (`@path` for Claude Code, `#file:path` for Copilot) MUST NOT appear
+in canonical bodies.
+
+### 5.5 Prohibited constructs in canonical bodies
+
+The following MUST NOT appear in canonical entrypoint bodies. Use per-client override files (§2.3)
+or conditional directives (§6) instead:
+
+| Construct                       | Why prohibited            | Client      |
+| ------------------------------- | ------------------------- | ----------- |
+| `$ARGUMENTS`, `$0`, `$1`        | Substitution variable     | Claude Code |
+| `${workspaceFolder}`, `${file}` | Substitution variable     | Copilot     |
+| `` !`command` ``                | Shell pre-execution       | Claude Code |
+| `@path/to/file`                 | File import               | Claude Code |
+| `#tool:name`                    | Tool reference            | Copilot     |
+| `#file:path`                    | File reference            | Copilot     |
+| `ultrathink`                    | Extended thinking trigger | Claude Code |
+
+If an item genuinely requires any of these constructs, it SHOULD either be marked as single-client
+via `metadata.audience` or use a per-client override file.
+
+---
+
+## 6. Conditional content directives
+
+Canonical bodies MAY include client-conditional content via HTML comment directives. These allow
+minor per-client variations without requiring separate override files.
+
+### 6.1 Syntax
+
+```markdown
+<!-- @client:claude -->
+
+Content rendered only for Claude Code output.
+
+<!-- @endclient -->
+```
+
+- Opening delimiter: `<!-- @client:<client-list> -->` on its own line.
+- Closing delimiter: `<!-- @endclient -->` on its own line.
+- `<client-list>` is a comma-separated list of client identifiers, optionally prefixed with `!`
+  for negation.
+
+Known client identifiers: `claude`, `copilot`, `opencode`.
+
+### 6.2 Forms
+
+Positive (include for listed clients):
+
+```markdown
+<!-- @client:claude,copilot -->
+
+This content appears in Claude and Copilot output, not in opencode.
+
+<!-- @endclient -->
+```
+
+Negative (include for everyone except listed clients):
+
+```markdown
+<!-- @client:!opencode -->
+
+This content appears everywhere except opencode output.
+
+<!-- @endclient -->
+```
+
+### 6.3 Processing rules
+
+Implementations:
+
+- MUST strip non-matching blocks entirely, including the delimiter lines and any surrounding
+  blank lines that would otherwise produce consecutive blank lines (violating MD012).
+- MUST preserve the content of matching blocks, removing only the delimiter lines.
+- MUST validate that all opened directives are closed (balanced blocks).
+- MUST validate that client identifiers in directives are from the known set.
+- MUST reject nested directives. If nesting is detected, report an error.
+- SHOULD process directives before any other body transformation (formatting, rendering).
+
+### 6.4 Interaction with override files
+
+If a per-client override file exists for a given client (§2.3), directives in the canonical body
+are NOT processed for that client. The override file's body is used as-is.
+
+Resolution order for a given client:
+
+1. If `<KIND>.<client>.md` exists → use its body.
+2. Else → use canonical body with directives processed for this client.
+
+---
+
+## 7. Generation: client-specific output
+
+This section describes the expected output per client. It is informational; client conventions may
+change independently of this specification. Implementations SHOULD verify output against actual
+client behavior.
+
+### 7.1 Claude Code
+
+| Item kind | Output path                      | Frontmatter mapping                                                              |
+| --------- | -------------------------------- | -------------------------------------------------------------------------------- |
+| Rule      | `.claude/rules/<name>.md`        | `paths:` array from `scope.paths` (if non-empty).                                |
+| Skill     | `.claude/skills/<name>/SKILL.md` | `name:`, `description:` pass through. Agent Skills extended fields pass through. |
+| Agent     | `.claude/agents/<name>.md`       | `name:`, `description:`, `model:`, `tools:` (capitalized).                       |
+
+Additionally, implementations SHOULD generate a `CLAUDE.md` at repo root containing `@AGENTS.md`
+to bridge Claude Code to the project's `AGENTS.md` (which Claude Code does not read natively).
+
+### 7.2 GitHub Copilot
+
+| Item kind | Output path                                   | Frontmatter mapping                                                                                                       |
+| --------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Rule      | `.github/instructions/<name>.instructions.md` | `applyTo:` (comma-joined from `scope.paths`, default `"**"`), `name:`, `description:`. `copilot.excludeAgent` if present. |
+| Skill     | `.github/skills/<name>/SKILL.md`              | `name:`, `description:` pass through. Follows Agent Skills open standard.                                                 |
+| Agent     | `.github/agents/<name>.agent.md`              | `name:`, `description:`, `model:`, `tools:`. Copilot-specific fields from passthrough block.                              |
+
+Additionally, implementations SHOULD generate or update `.vscode/settings.json` with
+`chat.instructionsFilesLocations` pointing to the item source directory, enabling VS Code Copilot
+to discover rules without file duplication.
+
+### 7.3 opencode
+
+| Item kind | Output path                      | Frontmatter mapping                                                                                               |
+| --------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Rule      | (no file generation)             | Path added to `opencode.json` `instructions[]` array. File stays at SSOT location.                                |
+| Skill     | `.agents/skills/<name>/SKILL.md` | No generation needed if SSOT is already at this path (opencode walks `.agents/skills/` natively). Otherwise copy. |
+| Agent     | `.opencode/agents/<name>.md`     | `description:`, `mode:`, `model:`. opencode-specific fields from passthrough block.                               |
+
+### 7.4 Shared outputs
+
+Implementations SHOULD also generate or maintain:
+
+- `AGENTS.md` at repo root: project-specific content, hand-maintained by teams. Implementations
+  MUST NOT overwrite this file after initial creation.
+- `opencode.json`: updated `instructions[]` array for rules targeting opencode.
+
+### 7.5 Formatting guarantee
+
+Generated output MUST be formatted such that:
+
+- It is idempotent under the implementation's chosen markdown formatter (e.g., dprint).
+- It passes `markdownlint-cli2` with the default ruleset (or a documented subset pinned by the
+  implementation).
+
+Implementations SHOULD format generated markdown as the final step before writing, using an embedded
+or invoked formatter, so that developers running the same formatter locally see no diffs on generated
+files.
+
+---
+
+## 8. Schema versioning
+
+The top-level `schema` field declares the specification version the file was authored against.
+
+Current version: **1**.
+
+### 8.1 Rules for implementations
+
+- MUST reject files with `schema` greater than the highest version the implementation supports.
+- MUST produce a clear error message identifying the required specification version and suggesting
+  an upgrade of the implementing tool.
+- MUST accept files with `schema` equal to or less than the highest supported version.
+- When processing older schema versions, MUST NOT silently apply newer defaults that would change
+  the file's meaning.
+
+### 8.2 Rules for specification evolution
+
+- MINOR additions (new optional fields, new optional top-level blocks) MAY occur within the same
+  schema version. Implementations MUST ignore unknown fields they don't support.
+- BREAKING changes (removed fields, renamed fields, changed semantics of existing fields, new
+  required fields) MUST increment the schema version.
+- Each published schema version MUST have a stable reference document with a permanent URL.
+
+---
+
+## 9. MVP scope
+
+For a first implementation, the following MAY be deferred:
+
+- Per-client override files (§2.3): support only canonical entrypoint + directives.
+- `requires` in bundles (§3.7): support only flat item lists without bundle dependencies.
+- Negation in directives (`!opencode`): support only positive client lists.
+- `preload-skills` in agents (§3.4): treat as informational only.
+- Glob patterns in `scope.paths`: accept only literal path prefixes or simple `**/*.ext` patterns.
+- Custom metadata keys beyond `version`, `author`, `audience`: ignore silently.
+
+The following MUST be supported in any conforming MVP:
+
+- Common frontmatter schema (§3.1) including `schema` version field.
+- Kind-specific required fields (§3.2, §3.3, §3.4 — at minimum `scope.paths` for rules, `mode`
+  and `tools` for agents).
+- `schema` version rejection behavior (§8).
+- Body conventions: no-H1 rule (§5.1), fence language hints (§5.2).
+- At least positive-form `@client:<list>` directives (§6).
+- Bundle item resolution by name (§3.7).
+- Generation for at least one client (§7).
+- Formatting guarantee (§7.5).
+
+---
+
+## 10. Conformance
+
+An implementation is conformant with this specification if:
+
+1. It correctly parses all frontmatter fields defined in §3, accepting unknown fields within
+   `metadata` and client passthrough blocks without error.
+2. It validates `name` against §2.1 constraints and rejects non-conforming names with a clear error.
+3. It rejects files with unsupported `schema` versions per §8.
+4. It correctly processes `@client:` directives per §6.3, including balanced-block validation.
+5. It resolves bundle `items` references against available item sources and reports unresolved
+   names as errors.
+6. It preserves supporting files from item directories in generated output per §2.4.
+7. Generated output satisfies the formatting guarantee per §7.5.
+
+A reference test corpus SHOULD accompany mature versions of this specification. For v0.1-draft,
+conformance is assessed against authored examples in the implementation's own test suite.
+
+---
+
+## 11. Non-goals
+
+This specification does not define:
+
+- Client file layouts or frontmatter conventions beyond what §7 documents as informational
+  context. These are owned by each client's maintainer and may change independently.
+- Installation, caching, synchronization, or registry protocols. These are implementation concerns.
+- CLI command surfaces, configuration files, or user-facing workflows.
+- Validation of semantic content quality. This is reserved for AI-review or other semantic
+  analysis mechanisms outside the scope of format validation.
+- Formatting conventions beyond what §5 requires for portability and §7.5 requires for
+  generated output.
+- Signing, provenance, supply-chain verification, or trust models. These are important but
+  separate concerns for a future specification.
+- Access control, classification enforcement, or governance workflows. Implementations MAY
+  use `metadata` fields to integrate with external governance systems, but the mechanisms
+  are not specified here.
+
+---
+
+## 12. Open questions for future versions
+
+The following topics are explicitly deferred and tracked for future specification work:
+
+1. **Scope patterns**: whether `scope.paths` should support negation (`!test/**`), boolean
+   combinations, or named scopes.
+2. **Tool vocabulary**: whether the §4 table should be expanded, whether MCP tool references
+   need a more structured form, and how to handle tools that exist in only one client.
+3. **Agent mode semantics**: whether `primary` / `subagent` / `all` is sufficient given
+   divergent agent models across clients, or whether mode should be client-passthroughed entirely.
+4. **Bundle constraints**: whether `requires` should support semver ranges, platform predicates
+   (`requires-client: [claude >= 2.1]`), or conditional items.
+5. **Per-client partial overrides**: whether override files should support section-level overrides
+   (replacing only a specific heading's content) rather than full-body replacement.
+6. **Skill activation control**: whether `disable-model-invocation` and `user-invocable` from
+   the Agent Skills standard should be surfaced as neutral fields or remain client passthroughs.
+7. **Multi-repo item sources**: whether the specification should define a source-resolution
+   protocol or leave it entirely to implementations.
+8. **Content hashing**: whether items should carry a content hash for integrity verification
+   during distribution, independent of `metadata.version`.
+
+---
+
+## Appendix A: Complete frontmatter examples
+
+### A.1 Rule — always-on, all clients
+
+```yaml
+---
+schema: 1
+name: license-awareness
+description: Use when reviewing third-party code, AI suggestions, or external snippets to check licensing compatibility and avoid incorporating incompatible licensed code
+license: proprietary
+metadata:
+  version: "1.0.0"
+  author: platform-security
+---
+
+## Licensing rules
+
+- Never paste code from external sources without verifying the license.
+- When AI suggests code matching a recognizable upstream project, flag it before incorporating.
+- See [approved licenses](./allowed-licenses.txt) for the canonical SPDX list.
+- AGPL, SSPL, and BUSL code requires explicit approval from legal.
+```
+
+### A.2 Rule — path-scoped, with Copilot passthrough
+
+```yaml
+---
+schema: 1
+name: api-conventions
+description: Use when writing or modifying API handler files to ensure consistent request validation, error formatting, and response shape
+license: proprietary
+scope:
+  paths:
+    - "src/api/**/*.ts"
+    - "src/handlers/**/*.ts"
+copilot:
+  excludeAgent: code-review
+metadata:
+  version: "2.1.0"
+  author: platform-api
+---
+
+## API handler conventions
+
+- All endpoints include input validation using the project's schema library.
+- Use the standard error response format defined in `src/api/errors.ts`.
+- Never return raw database errors to the client.
+```
+
+### A.3 Skill — on-demand, with directive
+
+```yaml
+---
+schema: 1
+name: create-api-endpoint
+description: Use when scaffolding new REST API endpoints with Zod validation, following project conventions for handler structure, error handling, and test coverage
+license: proprietary
+metadata:
+  version: "1.0.0"
+  author: platform-api
+---
+
+## Create a new API endpoint
+
+Follow these steps to scaffold a complete endpoint:
+
+1. Create the handler file at `src/api/handlers/{resource}.ts`.
+2. Define the request schema using Zod in `src/api/schemas/{resource}.ts`.
+3. Register the route in `src/api/routes.ts`.
+4. Create the test file at `src/api/__tests__/{resource}.test.ts`.
+
+<!-- @client:claude -->
+When creating files, use the Write tool for new files rather than Edit.
+<!-- @endclient -->
+
+## Validation pattern
+
+All inputs MUST be validated against the Zod schema before processing.
+See [validation patterns](./references/validation-patterns.md) for examples.
+```
+
+### A.4 Agent — subagent with tools and preloaded skill
+
+```yaml
+---
+schema: 1
+name: security-reviewer
+description: Use when reviewing code for injection flaws, authentication issues, secret leaks, and insecure data handling
+license: proprietary
+mode: subagent
+model: sonnet
+tools:
+  - read
+  - grep
+  - glob
+  - bash
+preload-skills:
+  - security-baseline
+opencode:
+  temperature: 0.2
+metadata:
+  version: "1.0.0"
+  author: platform-security
+  audience:
+    - claude
+    - copilot
+    - opencode
+---
+
+## Security reviewer
+
+You are a security-focused code reviewer. When invoked:
+
+1. Identify injection vectors (SQL, command, path traversal, XSS).
+2. Verify authentication and authorization checks on every sensitive endpoint.
+3. Scan for hardcoded secrets, tokens, API keys, or credentials.
+4. Flag insecure data handling (unencrypted PII, weak cryptographic choices, improper logging of sensitive data).
+
+For each finding, report severity (critical/high/medium/low), file and line location, and a concrete remediation.
+```
+
+### A.5 Bundle — with dependency
+
+```yaml
+---
+schema: 1
+name: android
+description: Rules, skills, and agents for Android application development teams
+license: proprietary
+items:
+  rules:
+    - android-lifecycle
+    - kotlin-coroutines
+    - compose-conventions
+  skills:
+    - create-viewmodel
+    - migrate-to-compose
+  agents:
+    - android-reviewer
+requires:
+  - platform-baseline
+metadata:
+  version: "0.8.0"
+  author: android-platform
+---
+
+## Android bundle
+
+Layered on top of `platform-baseline`. Provides Android-specific development
+conventions, Jetpack Compose patterns, and a specialized code reviewer.
+```
+
+### A.6 Agent — with per-client override file
+
+Directory structure:
+
+```text
+agents/security-reviewer/
+├── AGENT.md                   # canonical
+├── AGENT.claude.md            # Claude-specific body
+└── AGENT.copilot.md           # Copilot-specific body
+```
+
+`AGENT.md` frontmatter is used for all clients. `AGENT.claude.md` body is used when generating
+for Claude Code. `AGENT.copilot.md` body is used when generating for Copilot. For opencode,
+the canonical `AGENT.md` body is used (with directives processed).
+
+---
+
+## Appendix B: Client frontmatter mapping reference
+
+This table summarizes how SSOT fields map to each client's frontmatter when generating output.
+This is informational and subject to change as clients evolve.
+
+| SSOT field       | Claude Code output          | Copilot output                   | opencode output            |
+| ---------------- | --------------------------- | -------------------------------- | -------------------------- |
+| `name`           | `name:`                     | `name:`                          | (in filename)              |
+| `description`    | `description:`              | `description:`                   | `description:`             |
+| `scope.paths`    | `paths:` (array)            | `applyTo:` (comma-joined string) | (not supported; always-on) |
+| `mode`           | (implicit in file location) | (agent definition)               | `mode:`                    |
+| `model`          | `model:` (alias)            | `model:` (full ID)               | `model:` (provider/ID)     |
+| `tools`          | Capitalized names           | Client tool names                | Lowercase names            |
+| `preload-skills` | `skills:` in agent          | —                                | —                          |
+| `copilot.*`      | (stripped)                  | Merged into frontmatter          | (stripped)                 |
+| `opencode.*`     | (stripped)                  | (stripped)                       | Merged into frontmatter    |
+| `claude.*`       | Merged into frontmatter     | (stripped)                       | (stripped)                 |
+| `metadata.*`     | (stripped from output)      | (stripped from output)           | (stripped from output)     |
+
+---
+
+## Appendix C: Directive quick reference
+
+```markdown
+<!-- @client:claude -->           Include only in Claude Code output
+<!-- @client:copilot -->          Include only in Copilot output
+<!-- @client:opencode -->         Include only in opencode output
+<!-- @client:claude,copilot -->   Include in Claude and Copilot, not opencode
+<!-- @client:!opencode -->        Include everywhere except opencode
+<!-- @endclient -->               Close any directive block (required)
+```
+
+Rules: one directive per line, no nesting, balanced open/close, known client identifiers only.


### PR DESCRIPTION
Documentation track of the v0.2 redesign. Sibling to feat/v0.2-skills-pipeline.

3 commits, one topic each:

1. AGENTS.md/CLAUDE.md merge — fold repo conventions (stack, install layout, source format, auth precedence, exit codes, testing) into AGENTS.md so agents have full orientation up front. CLAUDE.md is a single-line @AGENTS.md import.
2. Portable format spec — docs/format-spec.md (873 lines) defines the on-disk format for rules / skills / agents that v0.2 compiles to client-specific outputs.
3. ADR-0001 — records the v0.2 architectural reset, decisions, rejected alternatives, build order, Phase 0 spike outcome (embed dprint-plugin-markdown).

Branches off v0.2-redesign, which carries two prerequisite chore commits (markdownlintignore extension + git-std hook shim fixes) that unblock commits on either feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)