### PR TITLE
feat: v0.2 skills generation pipeline (model + parse + generate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,7 +203,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -284,7 +299,47 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dprint-core"
+version = "0.67.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1d827947704a9495f705d6aeed270fa21a67f825f22902c28f38dc3af7a9ae"
+dependencies = [
+ "anyhow",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "rustc-hash",
+ "serde",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "dprint-core-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1675ad2b358481f3cc46202040d64ac7a36c4ade414a696df32e0e45421a6e9f"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "dprint-plugin-markdown"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf049c9fa197cf1c327558f1bf28ba6a16bfce1be5ea681b0b5aeede395af951"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "dprint-core-macros",
+ "pulldown-cmark",
+ "regex",
+ "serde",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -350,6 +405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +443,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -687,7 +753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -698,6 +764,25 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
@@ -758,6 +843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +897,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,7 +935,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -852,6 +949,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -903,6 +1013,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -920,7 +1041,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -959,7 +1080,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -979,16 +1100,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -1004,9 +1149,12 @@ dependencies = [
  "assert_cmd",
  "clap",
  "ctrlc",
+ "dprint-plugin-markdown",
  "predicates",
+ "pulldown-cmark",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sha2",
  "tempfile",
  "thiserror",
@@ -1258,7 +1406,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1274,7 +1422,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1341,7 +1489,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1362,7 +1510,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1402,7 +1550,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ categories = ["command-line-utilities", "development-tools"]
 anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }
 ctrlc = "3.4"
+dprint-plugin-markdown = "=0.21.1"
+pulldown-cmark = "0.11"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+serde_yaml_ng = "0.10"
 sha2 = "0.11.0"
 thiserror = "2.0"
 ureq = { version = "2", features = ["json"] }

--- a/src/generate/claude.rs
+++ b/src/generate/claude.rs
@@ -1,0 +1,10 @@
+//! Claude Code generation (§7.1).
+
+use crate::model::Skill;
+use anyhow::Result;
+
+/// Skill frontmatter per §7.1: `name`, `description`, Agent Skills
+/// extended fields pass through.
+pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
+    super::build_skill_frontmatter(skill, skill.claude.as_ref())
+}

--- a/src/generate/copilot.rs
+++ b/src/generate/copilot.rs
@@ -1,0 +1,10 @@
+//! GitHub Copilot generation (§7.2).
+
+use crate::model::Skill;
+use anyhow::Result;
+
+/// Skill frontmatter per §7.2: `name`, `description`, follows Agent
+/// Skills open standard.
+pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
+    super::build_skill_frontmatter(skill, skill.copilot.as_ref())
+}

--- a/src/generate/directives.rs
+++ b/src/generate/directives.rs
@@ -1,0 +1,223 @@
+//! Conditional content directives (§6).
+//!
+//! Parses `<!-- @client:X -->` ... `<!-- @endclient -->` blocks and
+//! emits a body with non-matching blocks stripped. Per §6.3:
+//!
+//! - non-matching block: strip delimiters AND content; collapse
+//!   surrounding blanks so we don't produce MD012 violations.
+//! - matching block: strip delimiter lines, keep content.
+//! - validate balanced opens/closes.
+//! - reject nested directives.
+//! - reject unknown client identifiers.
+
+use crate::generate::Client;
+use anyhow::{Result, bail};
+
+/// Process `@client:` directives in `body` for `target`.
+pub fn process(body: &str, target: Client) -> Result<String> {
+    let mut out = String::with_capacity(body.len());
+    let mut state = State::Outside;
+    let mut open_lineno = 0usize;
+
+    for (i, line) in body.split_inclusive('\n').enumerate() {
+        let lineno = i + 1;
+        let line_trimmed = line.trim_end_matches(['\r', '\n']);
+
+        if let Some(client_list) = parse_open(line_trimmed)? {
+            match state {
+                State::Outside => {
+                    state = State::InBlock {
+                        keep: client_list.matches(target),
+                    };
+                    open_lineno = lineno;
+                }
+                State::InBlock { .. } => {
+                    bail!(
+                        "line {lineno}: nested `@client:` directives are not allowed (outer opened at line {open_lineno})"
+                    );
+                }
+            }
+            continue;
+        }
+
+        if is_close(line_trimmed) {
+            match state {
+                State::InBlock { .. } => state = State::Outside,
+                State::Outside => {
+                    bail!("line {lineno}: `@endclient` without matching `@client:` open");
+                }
+            }
+            continue;
+        }
+
+        match state {
+            State::Outside => out.push_str(line),
+            State::InBlock { keep: true } => out.push_str(line),
+            State::InBlock { keep: false } => {}
+        }
+    }
+
+    if !matches!(state, State::Outside) {
+        bail!("unclosed `@client:` directive opened at line {open_lineno}");
+    }
+
+    Ok(collapse_blank_runs(&out))
+}
+
+#[derive(Debug, Clone, Copy)]
+enum State {
+    Outside,
+    InBlock { keep: bool },
+}
+
+#[derive(Debug)]
+struct ClientList {
+    negated: bool,
+    clients: Vec<Client>,
+}
+
+impl ClientList {
+    fn matches(&self, target: Client) -> bool {
+        let in_list = self.clients.contains(&target);
+        if self.negated { !in_list } else { in_list }
+    }
+}
+
+fn parse_open(line: &str) -> Result<Option<ClientList>> {
+    let trimmed = line.trim();
+    let Some(inner) = trimmed
+        .strip_prefix("<!--")
+        .and_then(|s| s.strip_suffix("-->"))
+    else {
+        return Ok(None);
+    };
+    let inner = inner.trim();
+    let Some(after) = inner.strip_prefix("@client:") else {
+        return Ok(None);
+    };
+    let after = after.trim();
+    let (negated, list) = match after.strip_prefix('!') {
+        Some(rest) => (true, rest.trim()),
+        None => (false, after),
+    };
+    let mut clients = Vec::new();
+    for tok in list.split(',') {
+        let name = tok.trim();
+        if name.is_empty() {
+            bail!("empty client identifier in `@client:` directive");
+        }
+        clients.push(name.parse::<Client>()?);
+    }
+    Ok(Some(ClientList { negated, clients }))
+}
+
+fn is_close(line: &str) -> bool {
+    let trimmed = line.trim();
+    let Some(inner) = trimmed
+        .strip_prefix("<!--")
+        .and_then(|s| s.strip_suffix("-->"))
+    else {
+        return false;
+    };
+    inner.trim() == "@endclient"
+}
+
+/// Collapse runs of 2+ blank lines into a single blank line.
+fn collapse_blank_runs(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_blank = false;
+    for line in s.split_inclusive('\n') {
+        let body = line.trim_end_matches(['\r', '\n']);
+        let is_blank = body.is_empty();
+        if is_blank && prev_blank {
+            continue;
+        }
+        out.push_str(line);
+        prev_blank = is_blank;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn positive_kept_for_listed_client() {
+        let body = "before\n<!-- @client:claude -->\ninner\n<!-- @endclient -->\nafter\n";
+        let claude = process(body, Client::Claude).unwrap();
+        assert!(claude.contains("inner"), "claude should keep:\n{claude}");
+        assert!(claude.contains("before") && claude.contains("after"));
+    }
+
+    #[test]
+    fn positive_stripped_for_other_clients() {
+        let body = "before\n<!-- @client:claude -->\ninner\n<!-- @endclient -->\nafter\n";
+        let copilot = process(body, Client::Copilot).unwrap();
+        let opencode = process(body, Client::OpenCode).unwrap();
+        assert!(!copilot.contains("inner"), "copilot should strip");
+        assert!(!opencode.contains("inner"), "opencode should strip");
+    }
+
+    #[test]
+    fn negative_strips_only_for_listed_client() {
+        let body = "before\n<!-- @client:!opencode -->\ninner\n<!-- @endclient -->\nafter\n";
+        let claude = process(body, Client::Claude).unwrap();
+        let copilot = process(body, Client::Copilot).unwrap();
+        let opencode = process(body, Client::OpenCode).unwrap();
+        assert!(claude.contains("inner"), "claude should keep");
+        assert!(copilot.contains("inner"), "copilot should keep");
+        assert!(!opencode.contains("inner"), "opencode should strip");
+    }
+
+    #[test]
+    fn unbalanced_unclosed_errors() {
+        let body = "<!-- @client:claude -->\nunclosed\n";
+        let err = process(body, Client::Claude).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unclosed"), "got: {msg}");
+    }
+
+    #[test]
+    fn unbalanced_close_without_open_errors() {
+        let body = "<!-- @endclient -->\n";
+        let err = process(body, Client::Claude).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("@endclient"), "got: {msg}");
+    }
+
+    #[test]
+    fn nested_directive_errors() {
+        let body = concat!(
+            "<!-- @client:claude -->\n",
+            "outer\n",
+            "<!-- @client:copilot -->\n",
+            "inner\n",
+            "<!-- @endclient -->\n",
+            "<!-- @endclient -->\n"
+        );
+        let err = process(body, Client::Claude).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("nested"), "got: {msg}");
+    }
+
+    #[test]
+    fn unknown_client_identifier_errors() {
+        let body = "<!-- @client:foo -->\nx\n<!-- @endclient -->\n";
+        let err = process(body, Client::Claude).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unknown client"), "got: {msg}");
+    }
+
+    #[test]
+    fn surrounding_blank_lines_collapsed_on_strip() {
+        let body = "para 1.\n\n<!-- @client:opencode -->\nopencode-only.\n<!-- @endclient -->\n\npara 2.\n";
+        let result = process(body, Client::Claude).unwrap();
+        assert!(
+            !result.contains("\n\n\n"),
+            "no triple-newline allowed; got:\n{result:?}"
+        );
+        assert!(result.contains("para 1."));
+        assert!(result.contains("para 2."));
+    }
+}

--- a/src/generate/format.rs
+++ b/src/generate/format.rs
@@ -1,0 +1,69 @@
+//! dprint-plugin-markdown wrapper (§7.5).
+//!
+//! Default config leaves `text_wrap` at `Maintain` so prose is not
+//! re-wrapped. The formatter is invoked at the end of every render so
+//! generated output is idempotent.
+
+use anyhow::Result;
+use dprint_plugin_markdown::configuration::{Configuration, ConfigurationBuilder};
+use dprint_plugin_markdown::format_text;
+
+/// Format markdown using the project's default dprint config.
+///
+/// `Ok(None)` from dprint means input was already canonical — return
+/// it unchanged.
+pub fn format_markdown(text: &str) -> Result<String> {
+    format_with(text, &default_config())
+}
+
+/// Format markdown with an explicit dprint config.
+pub fn format_with(text: &str, config: &Configuration) -> Result<String> {
+    let result = format_text(text, config, |_lang, _code, _line| Ok(None))
+        .map_err(|e| anyhow::anyhow!("dprint formatting failed: {}", e))?;
+    Ok(result.unwrap_or_else(|| text.to_string()))
+}
+
+/// Default config — leaves `text_wrap` at `Maintain` per §7.5.
+pub fn default_config() -> Configuration {
+    ConfigurationBuilder::new().build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dprint_plugin_markdown::configuration::TextWrap;
+
+    #[test]
+    fn empty_input_clean() {
+        let r = format_markdown("").expect("format empty");
+        assert_eq!(r, "");
+    }
+
+    #[test]
+    fn already_canonical_idempotent() {
+        let canonical = "## Heading\n\nA paragraph.\n";
+        let pass1 = format_markdown(canonical).unwrap();
+        let pass2 = format_markdown(&pass1).unwrap();
+        assert_eq!(pass1, pass2, "format must be idempotent");
+    }
+
+    #[test]
+    fn wrap_width_config_takes_effect() {
+        let prose = "## H\n\nA single line of prose that is definitely longer than forty characters wide and will need to wrap.\n";
+        let cfg = ConfigurationBuilder::new()
+            .line_width(40)
+            .text_wrap(TextWrap::Always)
+            .build();
+        let out = format_with(prose, &cfg).unwrap();
+        let max = out
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.chars().count())
+            .max()
+            .unwrap_or(0);
+        assert!(
+            max <= 40,
+            "longest line should be <= 40 with line_width=40, got {max}:\n{out}"
+        );
+    }
+}

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,0 +1,102 @@
+//! Generation pipeline: SSOT model → per-client markdown string.
+//!
+//! Pure rendering. No filesystem writes — those land in Phase 3.
+
+use crate::model::Skill;
+use anyhow::{Context, Result};
+use serde_yaml_ng::{Mapping, Value};
+
+pub mod claude;
+pub mod copilot;
+pub mod directives;
+pub mod format;
+pub mod opencode;
+
+/// Target AI coding client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Client {
+    Claude,
+    Copilot,
+    OpenCode,
+}
+
+impl Client {
+    pub fn name(self) -> &'static str {
+        match self {
+            Client::Claude => "claude",
+            Client::Copilot => "copilot",
+            Client::OpenCode => "opencode",
+        }
+    }
+}
+
+impl std::str::FromStr for Client {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "claude" => Ok(Client::Claude),
+            "copilot" => Ok(Client::Copilot),
+            "opencode" => Ok(Client::OpenCode),
+            other => anyhow::bail!("unknown client identifier: {}", other),
+        }
+    }
+}
+
+/// Render a skill to its client-specific SKILL.md string.
+///
+/// Process directives in `body` for `client`, generate client-specific
+/// frontmatter from `skill`, concatenate, and run the result through the
+/// dprint formatter for §7.5 idempotence.
+pub fn render_skill(skill: &Skill, body: &str, client: Client) -> Result<String> {
+    let processed_body = directives::process(body, client)?;
+    let frontmatter = match client {
+        Client::Claude => claude::skill_frontmatter(skill)?,
+        Client::Copilot => copilot::skill_frontmatter(skill)?,
+        Client::OpenCode => opencode::skill_frontmatter(skill)?,
+    };
+    let combined = assemble(&frontmatter, &processed_body);
+    format::format_markdown(&combined)
+}
+
+/// Combine YAML frontmatter and body into a single markdown string.
+fn assemble(frontmatter: &str, body: &str) -> String {
+    let body = body.trim_start_matches('\n');
+    if body.is_empty() {
+        format!("---\n{}---\n", frontmatter)
+    } else {
+        format!("---\n{}---\n\n{}", frontmatter, body)
+    }
+}
+
+/// Build the client-shared skill frontmatter mapping.
+///
+/// Output field order: `name`, `description`, then `Skill.extra` keys
+/// (alphabetical via `BTreeMap`), then keys from the matching client
+/// passthrough block.
+///
+/// Stripped per §7 / Appendix B: `schema`, `metadata`, non-matching
+/// passthrough blocks, `license`. Only `name`, `description`, Agent
+/// Skills extended fields, and the matching passthrough survive.
+pub(crate) fn build_skill_frontmatter(
+    skill: &Skill,
+    passthrough: Option<&Value>,
+) -> Result<String> {
+    let mut map = Mapping::new();
+    map.insert(Value::from("name"), Value::from(skill.name.clone()));
+    map.insert(
+        Value::from("description"),
+        Value::from(skill.description.clone()),
+    );
+
+    for (k, v) in &skill.extra {
+        map.insert(Value::from(k.clone()), v.clone());
+    }
+
+    if let Some(Value::Mapping(m)) = passthrough {
+        for (k, v) in m {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+
+    serde_yaml_ng::to_string(&map).context("serializing skill frontmatter")
+}

--- a/src/generate/opencode.rs
+++ b/src/generate/opencode.rs
@@ -1,0 +1,11 @@
+//! opencode generation (§7.3).
+
+use crate::model::Skill;
+use anyhow::Result;
+
+/// Skill frontmatter per §7.3. opencode walks `.agents/skills/` natively;
+/// for the rendering layer we still produce the canonical content with
+/// the `opencode.*` passthrough merged.
+pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
+    super::build_skill_frontmatter(skill, skill.opencode.as_ref())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod agent;
 pub mod auth;
 pub mod fetch;
+pub mod generate;
 pub mod install;
 pub mod lockfile;
 pub mod model;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod auth;
 pub mod fetch;
 pub mod install;
 pub mod lockfile;
+pub mod model;
 pub mod search;
 pub mod source;
 pub mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod fetch;
 pub mod install;
 pub mod lockfile;
 pub mod model;
+pub mod parse;
 pub mod search;
 pub mod source;
 pub mod ui;

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -1,0 +1,65 @@
+//! Agent items (§3.4 + §3.1 common fields).
+
+use crate::model::common::{License, Metadata, SchemaVersion};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Agent run mode (§3.4). Spec default is `subagent`; the default is applied
+/// at generation time, not at parse time, so this field stays `Option`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Mode {
+    Primary,
+    Subagent,
+    All,
+}
+
+/// Capability-level tool name (§4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ToolCap {
+    Read,
+    Write,
+    Edit,
+    Bash,
+    Grep,
+    Glob,
+    WebFetch,
+    WebSearch,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Agent {
+    pub schema: SchemaVersion,
+    pub name: String,
+    pub description: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub license: Option<License>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<Mode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolCap>,
+    #[serde(
+        rename = "preload-skills",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub preload_skills: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<serde_yaml_ng::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub copilot: Option<serde_yaml_ng::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opencode: Option<serde_yaml_ng::Value>,
+
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml_ng::Value>,
+}

--- a/src/model/common.rs
+++ b/src/model/common.rs
@@ -1,0 +1,73 @@
+//! Common types shared across all item kinds.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+
+/// Highest schema version this implementation supports.
+pub const CURRENT_SCHEMA: u32 = 1;
+
+/// `schema` field with §8.1 rejection logic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaVersion(u32);
+
+impl SchemaVersion {
+    pub fn new(v: u32) -> anyhow::Result<Self> {
+        if v == 0 {
+            anyhow::bail!("schema version must be >= 1, got 0");
+        }
+        if v > CURRENT_SCHEMA {
+            anyhow::bail!(
+                "schema version {} is not supported (this build of upskill supports up to schema {}). Upgrade upskill.",
+                v,
+                CURRENT_SCHEMA
+            );
+        }
+        Ok(Self(v))
+    }
+
+    pub fn get(self) -> u32 {
+        self.0
+    }
+}
+
+impl Serialize for SchemaVersion {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(ser)
+    }
+}
+
+impl<'de> Deserialize<'de> for SchemaVersion {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let v = u32::deserialize(de)?;
+        Self::new(v).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Target client for an item or content block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Audience {
+    Claude,
+    Copilot,
+    OpenCode,
+}
+
+/// `license` field — SPDX identifier or custom string (§3.1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct License(pub String);
+
+/// `metadata` block (§3.6) — preserves unknown keys via the `extra` catchall.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Metadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audience: Option<Vec<Audience>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated: Option<String>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml_ng::Value>,
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,0 +1,11 @@
+//! Item models per the format spec — see `docs/format-spec.md`.
+
+pub mod agent;
+pub mod common;
+pub mod rule;
+pub mod skill;
+
+pub use agent::{Agent, Mode, ToolCap};
+pub use common::{Audience, CURRENT_SCHEMA, License, Metadata, SchemaVersion};
+pub use rule::{Rule, Scope};
+pub use skill::Skill;

--- a/src/model/rule.rs
+++ b/src/model/rule.rs
@@ -1,0 +1,36 @@
+//! Rule items (§3.2 + §3.1 common fields).
+
+use crate::model::common::{License, Metadata, SchemaVersion};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// `scope` block (§3.2). Empty `paths` means always-on.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Scope {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Rule {
+    pub schema: SchemaVersion,
+    pub name: String,
+    pub description: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<Scope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<serde_yaml_ng::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub copilot: Option<serde_yaml_ng::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opencode: Option<serde_yaml_ng::Value>,
+
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml_ng::Value>,
+}

--- a/src/model/skill.rs
+++ b/src/model/skill.rs
@@ -1,0 +1,29 @@
+//! Skill items (§3.3 + §3.1 common fields).
+
+use crate::model::common::{License, Metadata, SchemaVersion};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Skill {
+    pub schema: SchemaVersion,
+    pub name: String,
+    pub description: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub license: Option<License>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+
+    /// §3.5 client-specific passthrough block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<serde_yaml_ng::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub copilot: Option<serde_yaml_ng::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opencode: Option<serde_yaml_ng::Value>,
+
+    /// §3.3: pass-through unknown top-level fields preserved during processing.
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml_ng::Value>,
+}

--- a/src/parse/frontmatter.rs
+++ b/src/parse/frontmatter.rs
@@ -1,0 +1,247 @@
+//! YAML frontmatter parsing for portable-format markdown files.
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+
+/// Split a markdown file into its YAML frontmatter and body.
+///
+/// Returns `Some((yaml, body))` when the input begins with a `---` fence on
+/// its own line and a closing `---` fence is found later, also on its own
+/// line. Returns `None` otherwise.
+///
+/// Strips a leading UTF-8 BOM. Accepts both LF and CRLF line endings.
+pub fn split(text: &str) -> Option<(&str, &str)> {
+    let text = text.strip_prefix('\u{FEFF}').unwrap_or(text);
+    let (first, rest) = split_first_line(text)?;
+    if first.trim_end_matches('\r') != "---" {
+        return None;
+    }
+
+    let mut consumed = 0usize;
+    for line in rest.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed == "---" {
+            let yaml = &rest[..consumed];
+            let body = &rest[consumed + line.len()..];
+            return Some((yaml, body));
+        }
+        consumed += line.len();
+    }
+    None
+}
+
+fn split_first_line(s: &str) -> Option<(&str, &str)> {
+    s.find('\n').map(|i| (&s[..i], &s[i + 1..]))
+}
+
+/// Parse YAML frontmatter into a typed value, returning the value and body.
+///
+/// Errors when frontmatter is missing or YAML is invalid (which includes
+/// schema-version rejection per §8.1, surfaced via the `SchemaVersion`
+/// custom deserializer).
+pub fn parse<T: DeserializeOwned>(text: &str) -> Result<(T, &str)> {
+    let (yaml, body) =
+        split(text).context("missing YAML frontmatter (file must begin with `---` fence)")?;
+    let value: T = serde_yaml_ng::from_str(yaml).context("parsing YAML frontmatter")?;
+    Ok((value, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Agent, License, Mode, Rule, Skill, ToolCap};
+
+    #[test]
+    fn split_basic() {
+        let input = "---\nname: foo\n---\nbody text\n";
+        let (yaml, body) = split(input).unwrap();
+        assert_eq!(yaml, "name: foo\n");
+        assert_eq!(body, "body text\n");
+    }
+
+    #[test]
+    fn split_strips_bom() {
+        let input = "\u{FEFF}---\nname: foo\n---\nbody\n";
+        let (yaml, body) = split(input).unwrap();
+        assert_eq!(yaml, "name: foo\n");
+        assert_eq!(body, "body\n");
+    }
+
+    #[test]
+    fn split_empty_frontmatter() {
+        let input = "---\n---\nbody\n";
+        let (yaml, body) = split(input).unwrap();
+        assert_eq!(yaml, "");
+        assert_eq!(body, "body\n");
+    }
+
+    #[test]
+    fn split_no_fence_returns_none() {
+        assert!(split("# just markdown\n").is_none());
+        assert!(split("not a fence\n---\n").is_none());
+        // 4-dash line is not a fence
+        assert!(split("----\nname: foo\n----\n").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_missing_frontmatter() {
+        let result = parse::<Skill>("# just markdown\n");
+        assert!(result.is_err(), "expected error for missing frontmatter");
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("missing YAML frontmatter"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_schema_2() {
+        let input = concat!(
+            "---\n",
+            "schema: 2\n",
+            "name: too-new\n",
+            "description: from a future version\n",
+            "---\nbody\n"
+        );
+        let result = parse::<Skill>(input);
+        assert!(result.is_err(), "expected error for schema 2");
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("schema version 2") && msg.contains("not supported"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn skill_appendix_a3_round_trip() {
+        // From docs/format-spec.md Appendix A.3.
+        let input = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: create-api-endpoint\n",
+            "description: Use when scaffolding new REST API endpoints with Zod validation\n",
+            "license: proprietary\n",
+            "metadata:\n",
+            "  version: \"1.0.0\"\n",
+            "  author: platform-api\n",
+            "---\n",
+            "body\n",
+        );
+        let (skill, body) = parse::<Skill>(input).unwrap();
+        assert_eq!(skill.schema.get(), 1);
+        assert_eq!(skill.name, "create-api-endpoint");
+        assert_eq!(skill.license, Some(License("proprietary".into())));
+        assert_eq!(body, "body\n");
+        let metadata = skill.metadata.as_ref().unwrap();
+        assert_eq!(metadata.version.as_deref(), Some("1.0.0"));
+        round_trip(&skill);
+    }
+
+    #[test]
+    fn rule_appendix_a2_round_trip() {
+        // From docs/format-spec.md Appendix A.2.
+        let input = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: api-conventions\n",
+            "description: Use when writing or modifying API handler files\n",
+            "license: proprietary\n",
+            "scope:\n",
+            "  paths:\n",
+            "    - \"src/api/**/*.ts\"\n",
+            "    - \"src/handlers/**/*.ts\"\n",
+            "copilot:\n",
+            "  excludeAgent: code-review\n",
+            "metadata:\n",
+            "  version: \"2.1.0\"\n",
+            "  author: platform-api\n",
+            "---\n",
+            "body\n",
+        );
+        let (rule, _body) = parse::<Rule>(input).unwrap();
+        assert_eq!(rule.name, "api-conventions");
+        let scope = rule.scope.as_ref().unwrap();
+        assert_eq!(scope.paths, vec!["src/api/**/*.ts", "src/handlers/**/*.ts"]);
+        assert!(rule.copilot.is_some(), "copilot passthrough must be parsed");
+        round_trip(&rule);
+    }
+
+    #[test]
+    fn agent_appendix_a4_round_trip() {
+        // From docs/format-spec.md Appendix A.4.
+        let input = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: security-reviewer\n",
+            "description: Use when reviewing code for injection flaws\n",
+            "license: proprietary\n",
+            "mode: subagent\n",
+            "model: sonnet\n",
+            "tools:\n",
+            "  - read\n",
+            "  - grep\n",
+            "  - glob\n",
+            "  - bash\n",
+            "preload-skills:\n",
+            "  - security-baseline\n",
+            "opencode:\n",
+            "  temperature: 0.2\n",
+            "metadata:\n",
+            "  version: \"1.0.0\"\n",
+            "  author: platform-security\n",
+            "  audience:\n",
+            "    - claude\n",
+            "    - copilot\n",
+            "    - opencode\n",
+            "---\n",
+            "body\n",
+        );
+        let (agent, _body) = parse::<Agent>(input).unwrap();
+        assert_eq!(agent.name, "security-reviewer");
+        assert_eq!(agent.mode, Some(Mode::Subagent));
+        assert_eq!(agent.model.as_deref(), Some("sonnet"));
+        assert_eq!(
+            agent.tools,
+            vec![ToolCap::Read, ToolCap::Grep, ToolCap::Glob, ToolCap::Bash]
+        );
+        assert_eq!(agent.preload_skills, vec!["security-baseline".to_string()]);
+        assert!(
+            agent.opencode.is_some(),
+            "opencode passthrough must be parsed"
+        );
+        round_trip(&agent);
+    }
+
+    #[test]
+    fn metadata_unknown_keys_preserved() {
+        let input = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: foo\n",
+            "description: test unknown keys\n",
+            "metadata:\n",
+            "  version: \"1.0.0\"\n",
+            "  author: bar\n",
+            "  custom-key: custom-value\n",
+            "  team:\n",
+            "    name: alpha\n",
+            "    lead: jdoe\n",
+            "---\n",
+        );
+        let (skill, _) = parse::<Skill>(input).unwrap();
+        let metadata = skill.metadata.as_ref().unwrap();
+        assert_eq!(metadata.version.as_deref(), Some("1.0.0"));
+        assert!(metadata.extra.contains_key("custom-key"));
+        assert!(metadata.extra.contains_key("team"));
+        round_trip(&skill);
+    }
+
+    fn round_trip<T>(value: &T)
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+    {
+        let yaml = serde_yaml_ng::to_string(value).expect("serialize");
+        let back: T = serde_yaml_ng::from_str(&yaml).expect("deserialize");
+        assert_eq!(value, &back, "round-trip mismatch");
+    }
+}

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,0 +1,3 @@
+//! Parsing helpers for portable-format files.
+
+pub mod frontmatter;

--- a/tests/fixtures/expected/claude/create-api-endpoint.SKILL.md
+++ b/tests/fixtures/expected/claude/create-api-endpoint.SKILL.md
@@ -1,0 +1,20 @@
+---
+name: create-api-endpoint
+description: Use when scaffolding new REST API endpoints with Zod validation, following project conventions for handler structure, error handling, and test coverage
+---
+
+## Create a new API endpoint
+
+Follow these steps to scaffold a complete endpoint:
+
+1. Create the handler file at `src/api/handlers/{resource}.ts`.
+2. Define the request schema using Zod in `src/api/schemas/{resource}.ts`.
+3. Register the route in `src/api/routes.ts`.
+4. Create the test file at `src/api/__tests__/{resource}.test.ts`.
+
+When creating files, use the Write tool for new files rather than Edit.
+
+## Validation pattern
+
+All inputs MUST be validated against the Zod schema before processing.
+See [validation patterns](./references/validation-patterns.md) for examples.

--- a/tests/fixtures/expected/copilot/create-api-endpoint.SKILL.md
+++ b/tests/fixtures/expected/copilot/create-api-endpoint.SKILL.md
@@ -1,0 +1,18 @@
+---
+name: create-api-endpoint
+description: Use when scaffolding new REST API endpoints with Zod validation, following project conventions for handler structure, error handling, and test coverage
+---
+
+## Create a new API endpoint
+
+Follow these steps to scaffold a complete endpoint:
+
+1. Create the handler file at `src/api/handlers/{resource}.ts`.
+2. Define the request schema using Zod in `src/api/schemas/{resource}.ts`.
+3. Register the route in `src/api/routes.ts`.
+4. Create the test file at `src/api/__tests__/{resource}.test.ts`.
+
+## Validation pattern
+
+All inputs MUST be validated against the Zod schema before processing.
+See [validation patterns](./references/validation-patterns.md) for examples.

--- a/tests/fixtures/expected/opencode/create-api-endpoint.SKILL.md
+++ b/tests/fixtures/expected/opencode/create-api-endpoint.SKILL.md
@@ -1,0 +1,18 @@
+---
+name: create-api-endpoint
+description: Use when scaffolding new REST API endpoints with Zod validation, following project conventions for handler structure, error handling, and test coverage
+---
+
+## Create a new API endpoint
+
+Follow these steps to scaffold a complete endpoint:
+
+1. Create the handler file at `src/api/handlers/{resource}.ts`.
+2. Define the request schema using Zod in `src/api/schemas/{resource}.ts`.
+3. Register the route in `src/api/routes.ts`.
+4. Create the test file at `src/api/__tests__/{resource}.test.ts`.
+
+## Validation pattern
+
+All inputs MUST be validated against the Zod schema before processing.
+See [validation patterns](./references/validation-patterns.md) for examples.

--- a/tests/fixtures/skills/create-api-endpoint/SKILL.md
+++ b/tests/fixtures/skills/create-api-endpoint/SKILL.md
@@ -1,0 +1,29 @@
+---
+schema: 1
+name: create-api-endpoint
+description: Use when scaffolding new REST API endpoints with Zod validation, following project conventions for handler structure, error handling, and test coverage
+license: proprietary
+metadata:
+  version: "1.0.0"
+  author: platform-api
+---
+
+## Create a new API endpoint
+
+Follow these steps to scaffold a complete endpoint:
+
+1. Create the handler file at `src/api/handlers/{resource}.ts`.
+2. Define the request schema using Zod in `src/api/schemas/{resource}.ts`.
+3. Register the route in `src/api/routes.ts`.
+4. Create the test file at `src/api/__tests__/{resource}.test.ts`.
+
+<!-- @client:claude -->
+
+When creating files, use the Write tool for new files rather than Edit.
+
+<!-- @endclient -->
+
+## Validation pattern
+
+All inputs MUST be validated against the Zod schema before processing.
+See [validation patterns](./references/validation-patterns.md) for examples.

--- a/tests/generate_skills.rs
+++ b/tests/generate_skills.rs
@@ -1,0 +1,56 @@
+//! Golden-file tests for skill generation across all three clients.
+//!
+//! Input: `tests/fixtures/skills/<name>/SKILL.md`
+//! Expected: `tests/fixtures/expected/<client>/<name>.SKILL.md`
+
+use std::fs;
+use upskill::generate::{Client, render_skill};
+use upskill::model::Skill;
+use upskill::parse::frontmatter;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn load_skill(name: &str) -> (Skill, String) {
+    let path = format!("{FIXTURES}/skills/{name}/SKILL.md");
+    let raw = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let (skill, body) = frontmatter::parse::<Skill>(&raw).expect("parse fixture");
+    (skill, body.to_string())
+}
+
+fn load_expected(client: &str, name: &str) -> String {
+    let path = format!("{FIXTURES}/expected/{client}/{name}.SKILL.md");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn assert_byte_equal(actual: &str, expected: &str, label: &str) {
+    if actual == expected {
+        return;
+    }
+    eprintln!("=== {label}: actual ===\n{actual}");
+    eprintln!("=== {label}: expected ===\n{expected}");
+    panic!("{label} mismatch (see stderr above)");
+}
+
+#[test]
+fn create_api_endpoint_claude() {
+    let (skill, body) = load_skill("create-api-endpoint");
+    let actual = render_skill(&skill, &body, Client::Claude).expect("render");
+    let expected = load_expected("claude", "create-api-endpoint");
+    assert_byte_equal(&actual, &expected, "claude/create-api-endpoint");
+}
+
+#[test]
+fn create_api_endpoint_copilot() {
+    let (skill, body) = load_skill("create-api-endpoint");
+    let actual = render_skill(&skill, &body, Client::Copilot).expect("render");
+    let expected = load_expected("copilot", "create-api-endpoint");
+    assert_byte_equal(&actual, &expected, "copilot/create-api-endpoint");
+}
+
+#[test]
+fn create_api_endpoint_opencode() {
+    let (skill, body) = load_skill("create-api-endpoint");
+    let actual = render_skill(&skill, &body, Client::OpenCode).expect("render");
+    let expected = load_expected("opencode", "create-api-endpoint");
+    assert_byte_equal(&actual, &expected, "opencode/create-api-endpoint");
+}


### PR DESCRIPTION
Phase 1 of the ADR-0001 build order. Pure library code; no CLI subcommand wiring yet (Phase 3). Sibling to feat/v0.2-docs (#70).

4 commits, each compiles independently (bisect-friendly):

1. **chore(deps)** — dprint-plugin-markdown =0.21.1 (exact pin per ADR-0001 spike), serde_yaml_ng 0.10, pulldown-cmark 0.11.
2. **feat(model)** — SSOT data model for rules / skills / agents with §8.1 schema-version rejection and unknown-key preservation.
3. **feat(parse)** — YAML frontmatter parser. 10 unit tests including round-trips of format-spec Appendix A.2 / A.3 / A.4.
4. **feat(generate)** — skill rendering pipeline for Claude / Copilot / opencode (directive processing per §6.3, per-client frontmatter, dprint formatting per §7.5). 8 directive tests + 3 format tests + 3 golden-file tests.

141 tests pass on HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)