### PR TITLE
docs(adr): split v0.2 design into concern-focused ADRs

### DIFF
--- a/docs/adr/0001-v0.2-architectural-reset.md
+++ b/docs/adr/0001-v0.2-architectural-reset.md
@@ -5,153 +5,119 @@
 ## Context
 
 upskill v0.1 is a Rust CLI that installs Agent Skills (`SKILL.md` packages)
-from git source repos for use across multiple AI coding clients. Its surface
-is `add`, `list`, `remove`, `check`, `search`, `update`. Its fetch model is
-`owner/repo[@ref][:subfolder]`. Its state is a per-project lockfile.
+from git source repos for use across multiple AI coding clients. Its
+surface is `add`, `list`, `remove`, `check`, `search`, `update`. Its fetch
+model is `owner/repo[@ref][:subfolder]`. Its state is a per-project
+lockfile.
 
-The new requirement is broader. Rather than installing skills only, the tool
-should help authors **create, manage, and prolong** AI-assistance content of
-three kinds — rules, skills, agents — across three clients (Claude Code,
-Copilot, opencode). The companion [`docs/format-spec.md`](../format-spec.md)
-(also uncommitted) defines the portable on-disk format that drives this.
+The new requirement is broader: help authors **create, manage, and
+prolong** AI-assistance content of three kinds — rules, skills, agents —
+across three clients (Claude Code, Copilot, opencode). The expansion is
+not additive: the new central abstraction is **generation** (SSOT →
+per-client output), and v0.1's `install.rs` (fetch-and-copy) does not
+have a place in that pipeline.
 
-The expansion is not additive. The new central abstraction is **generation**:
-SSOT → per-client output, via frontmatter mapping, directive processing
-(`<!-- @client:X -->`), override files, and a dprint-formatted body. v0.1's
-`install.rs` (fetch-and-copy) does not have a place in that pipeline.
+This ADR is the **umbrella** for the v0.2 redesign. The substantive
+design is split across four concern-focused child ADRs:
+
+- [ADR-0002](./0002-portable-content-format.md) — Portable content format
+  (the on-disk SSOT contract).
+- [ADR-0003](./0003-generation-pipeline.md) — Generation pipeline (SSOT
+  → per-client output mechanics, including the dprint embedding decision
+  that originated as Phase 0's spike).
+- [ADR-0004](./0004-cli-surface.md) — CLI surface (the user-facing
+  contract).
+- [ADR-0005](./0005-vercel-skills-sh-interop.md) — Compatibility with the
+  Vercel/skills.sh ecosystem (cross-cutting strategic alignment).
+
+This ADR records the project-level decisions only: the pivot itself, the
+dependency philosophy shift, the build-order plan. Read the children for
+"what exactly we're doing"; read this for "why we're doing it and how
+the work is sequenced."
 
 ## Decision
 
-1. **Tag and branch.** Tag current `main` as v0.1.0 and rebuild for v0.2 on a
-   `v0.2-redesign` branch. v0.1 stays supported via patch releases for the
-   skills-installer use case.
+### 1. Tag and branch
 
-2. **MVP scope.** Three kinds (rules, skills, agents), three clients (Claude
-   Code, Copilot, opencode), generation pipeline as the central abstraction,
-   plus install / update / remove / sync, lint / fmt, and `new` for
-   scaffolding. **Bundles deferred** to a later release.
+Tag current `main` as `v0.1.0` and rebuild for v0.2 on a `v0.2-redesign`
+branch. v0.1 stays supported via patch releases for the
+skills-installer use case.
 
-3. **Vocabulary.** Spec terms — rules, skills, agents — stay throughout
-   schema, CLI, and docs. Client-specific words (Copilot's "instructions",
-   Claude's "subagent") appear only in generated output and per-client
-   documentation, never in upskill's own surface.
+### 2. Redesign as a multi-kind portable-format compiler
 
-4. **"Prolong" defined.**
-   - **Absorb client drift.** When Copilot or Claude Code change a path or
-     frontmatter field, `upskill sync` regenerates outputs from the same
-     SSOT; authors don't have to react.
-   - **Track upstream evolution.** `upskill update` git-pulls source repos
-     and regenerates items whose source hash changed.
+The substantive design — content format, generation pipeline, CLI
+surface, ecosystem alignment — is delegated to ADR-0002 through ADR-0005.
+At the project level, the decision is to redesign rather than extend:
+v0.1's mental model (fetch-and-copy of `SKILL.md`) does not fit rules
+and agents at all, so any extension would have required this redesign
+anyway.
 
-5. **Dependency philosophy relaxed.** [AGENTS.md](../../AGENTS.md) currently
-   lists `tokio`, `reqwest`, `git2`, `walkdir`, `dialoguer`, `serde_yaml`,
-   `toml` as deliberately not used. v0.2 admits `serde_yaml`, `walkdir`,
-   `pulldown-cmark`, `dprint-plugin-markdown`, and similar. `reqwest` may
-   replace `ureq` if multi-host fetching demands it. `git2` stays out (shell
-   out to `git`). The "no runtime deps, size-optimized" framing in AGENTS.md
-   is revised to "minimal but reasonable — prefer one focused dep over
-   hand-rolled equivalents."
+### 3. Dependency philosophy relaxed
 
-6. **State migration.** v0.1's per-project lockfile maps to v0.2's
-   `~/.upskill/installed.json` via a one-time translator. Existing users are
-   not silently broken.
-
-7. **CLI surface.** `add` aliased to `install`; `remove` aliased to
-   `uninstall`. Both aliases held for one minor version, then removed.
-   `search` and `update` keep their names. `check` either rolls into
-   `doctor` or stays as a lint subset (decided in Phase 5). New verbs:
-   `new`, `sync`, `lint`, `fmt`, `info`, `doctor`.
+[AGENTS.md](../../AGENTS.md) previously listed `tokio`, `reqwest`,
+`git2`, `walkdir`, `dialoguer`, `serde_yaml`, `toml` as deliberately not
+used. v0.2 admits `serde_yaml_ng`, `walkdir`, `pulldown-cmark`,
+`dprint-plugin-markdown`, and similar. `git2` stays out (shell out to
+`git`). The "no runtime deps, size-optimized" framing in AGENTS.md is
+revised to "minimal but reasonable — prefer one focused dep over
+hand-rolled equivalents."
 
 ## Consequences
 
-**Positive.** Single tool covers the full lifecycle of rules/skills/agents
-across all three clients. SSOT insulates authors from client conventions.
-Lint/fmt provide hygiene. Sync delivers prolong cheaply.
+**Positive.** Single tool covers the full lifecycle of rules / skills /
+agents across all three clients. Migration story for existing v0.1 users
+is explicit (translator from per-project lockfile to global state file
+per [ADR-0003](./0003-generation-pipeline.md)).
 
-**Negative.** ~7 engineer-weeks. Binary size grows. Small migration for v0.1
-users. README and architecture docs need rewrite. The generation pipeline
-introduces edge cases (override × directive interaction) that need careful
-test coverage.
-
-**Risk.** `dprint-plugin-markdown` crate API stability is unverified. The
-Phase 0 spike will determine whether to embed the crate or shell out to
-`dprint` at runtime.
+**Negative.** ~7 engineer-weeks. Binary size grows. Small migration for
+v0.1 users. README and architecture docs need rewrite. The redesign
+introduces concrete trade-offs documented per concern in the child ADRs.
 
 ## Alternatives considered
 
-**(a) Layer rules and agents onto v0.1's existing model without a redesign.**
-Rejected: the generation pipeline is fundamentally different from
-fetch-and-copy; grafting onto `install.rs` produces churn without clarity.
+**(a) Layer rules and agents onto v0.1's existing model without a
+redesign.** Rejected: the generation pipeline is fundamentally different
+from fetch-and-copy; grafting onto `install.rs` produces churn without
+clarity.
 
 **(b) Keep size-optimized minimalism strict, hand-roll YAML / markdown
 traversal.** Rejected: high cost, low benefit. The deps in question are
 well-maintained and individually small.
 
-**(c) Include bundles in MVP.** Rejected: manifest format, transitive
-resolution, ref-counted uninstall, registry index — significant complexity
-orthogonal to create/manage/prolong. Better as a v0.3 increment.
+**(c) Defer the redesign and continue extending v0.1.** Rejected: v0.1's
+fetch-and-copy mental model does not accommodate rules or agents.
+Extension would have required this redesign anyway, just later and with
+more sunk cost.
 
 ## Build order
 
 - **Phase 0** (1w) — tag, branch, deps, this ADR, dprint spike, model
-  skeleton.
+  skeleton. **Done.**
 - **Phase 1** (1.5w) — SSOT parser + generation pipeline for skills × all
-  three clients.
+  three clients. **Done.**
 - **Phase 2** (1w) — extend pipeline to rules and agents.
-- **Phase 3** (1.5w) — install / update / remove on top of pipeline, with
-  v0.1 lockfile migration.
-- **Phase 4** (0.5w) — sync.
-- **Phase 5** (1w) — lint + fmt.
+- **Phase 3** (~2.5w) — install / update / remove on top of pipeline;
+  bundle support; v0.1 lockfile migration; ancillary file generation
+  (CLAUDE.md, opencode.json, .vscode/settings.json). Original estimate
+  was 1.5w; bundles promoted from "deferred" to MVP per
+  [ADR-0002](./0002-portable-content-format.md), and ancillary file
+  handling per [ADR-0003](./0003-generation-pipeline.md) added scope.
+- **Phase 4** — _deleted._ `sync` absorbed into `update` per
+  [ADR-0004](./0004-cli-surface.md).
+- **Phase 5** (1w) — `lint` + `fmt`.
 - **Phase 6** (0.5w) — scaffold / `new`.
 - **Phase 7** (~1w) — polish + release of v0.2.0.
 
-## Phase 0 spike: dprint formatting strategy
-
-**Decision.** Embed `dprint-plugin-markdown` as a direct Rust crate
-dependency, pinned exactly (`=0.21.1`, not caret). Bump deliberately on
-each minor release after re-running golden-file fixtures. Align
-`dprint.json`'s WASM plugin pin to match the embedded crate version so
-contributors running `just lint` see the same output as CI.
-
-**Rationale.**
-
-- Output is byte-identical to the `dprint` CLI on the 36 KB
-  `docs/format-spec.md` test.
-- Byte-identity holds across 4 minor versions (`0.17.8` → `0.21.1`,
-  ~18 months apart), so the formatter is effectively output-stable
-  even though its API isn't.
-- Marginal binary cost is ~+1 MB after dep overlap — stays inside the
-  architecture target (~2-3 MB).
-- Removes the `dprint` CLI as a runtime dependency for upskill users.
-
-**Rejected alternatives.**
-
-- **Shell-out to `dprint`.** Forces a 6-9 MB Homebrew dependency on
-  users, turns formatting into a subprocess dance with stdin/stdout
-  error handling, and leaves the plugin-version-vs-test-target gap
-  unmanaged.
-- **Wasmtime-host the `.wasm` plugin.** Pulls a 5-10 MB wasmtime
-  runtime and a second runtime to debug, and reimplements what
-  `dprint` already does.
-
-**Phase 1 implementation notes.**
-
-- Real signature:
-  `format_text(text: &str, config: &Configuration, callback: impl FnMut(...) -> Result<Option<String>>) -> Result<Option<String>>`.
-  No `file_path` argument (the prompt's assumed signature was wrong).
-- `Ok(None)` means "input was already canonical, hand it back as-is" —
-  must not be misread as "no output." A naive `unwrap()` will panic on
-  already-formatted files.
-- Default `text_wrap` is `Maintain`. `line_width` alone does not
-  trigger re-wrapping; set `TextWrap::Always` to wrap.
-- Pass `|_, _, _| Ok(None)` for the code-block callback to leave
-  fenced blocks untouched.
-
 ## Open questions
 
-- Does `check` survive as a separate command or merge into `doctor`/`lint`?
-  — Phase 5.
-- Multi-host auth growth (GitLab + GitHub). — Phase 3.
-- ~~`dprint` embedding vs shell-out.~~ **Resolved** — see [Phase 0 spike:
-  dprint formatting strategy](#phase-0-spike-dprint-formatting-strategy).
-- Whether v0.1 tests carry forward or are rewritten. — Start of Phase 1.
+Project-level only. Concern-specific opens live in the child ADRs.
+
+- **Multi-host auth growth (GitLab + GitHub).** Phase 3 — when
+  `add`/`update` need to authenticate against multiple host families.
+- **v0.2.0 release timing relative to internal rollout phases.** Phase 7
+  — coordinated with documentation cutover and v0.1 patch-release
+  sunset.
+- **Windows support level for v0.2.0.** Stretch goal; not blocking MVP.
+  Copy-only installation per [ADR-0003](./0003-generation-pipeline.md)
+  removes the main symlink obstacle, but full Windows CI verification
+  is deferred.

--- a/docs/adr/0002-portable-content-format.md
+++ b/docs/adr/0002-portable-content-format.md
@@ -1,0 +1,150 @@
+# Portable content format for AI-assistance items and bundles
+
+**Status**: Proposed (2026-05-01)
+
+## Context
+
+AI-assistance content — rules, skills, agents — targets multiple clients
+(Claude Code, Copilot, opencode), each with its own on-disk conventions.
+Maintaining parallel content per client does not scale.
+
+The Agent Skills open standard ([agentskills.io](https://agentskills.io))
+provides a stable base for skills, but does not cover always-on rules or
+agent personas. We need one format that:
+
+- handles all three item kinds with a shared base schema,
+- supports bundle distribution without duplicating item content,
+- allows minor per-client deviations without forking entire files,
+- is self-describing so it can evolve without silently breaking older
+  consumers.
+
+This ADR is one of four child ADRs of [ADR-0001](./0001-v0.2-architectural-reset.md).
+It owns the on-disk SSOT contract; [ADR-0003](./0003-generation-pipeline.md)
+owns how that SSOT becomes per-client output.
+
+The authoritative specification lives at [`docs/format-spec.md`](../format-spec.md).
+This ADR records the design decisions; the spec records the contract.
+
+## Decision
+
+### Three item kinds, one base schema
+
+Rules (`RULE.md`), skills (`SKILL.md`), and agents (`AGENT.md`) share a
+common frontmatter shape: `schema`, `name`, `description`, `license`,
+`metadata`. Kind-specific fields are minimal:
+
+- **Rules** add optional `scope.paths` for path-scoping.
+- **Skills** add nothing — they follow the Agent Skills standard as-is.
+- **Agents** add `mode`, `model`, `tools`, `preload-skills`.
+
+### Vocabulary
+
+The words **rules, skills, agents** stay throughout the schema, CLI, and
+docs. Client-specific words (Copilot's "instructions", Claude's "subagent")
+appear only in generated output and per-client documentation, never in
+upskill's own surface.
+
+### Directory-per-item layout, symmetric across kinds
+
+```text
+.agents/
+├── rules/<name>/RULE.md
+├── skills/<name>/SKILL.md
+└── agents/<name>/AGENT.md
+```
+
+A directory per item — for all three kinds — enables ancillary resources
+(templates, scripts, reference files) without future migration. Symmetry
+reduces cognitive load and simplifies tooling.
+
+### `metadata` block for governance
+
+A nested `metadata:` field carries versioning (`version`, quoted semver),
+ownership (`author`), audience targeting (`audience`), and arbitrary
+unknown keys. Implementations preserve unknown keys through round-trips so
+external governance systems can layer on top without forking the schema.
+
+### Client-specific passthrough blocks
+
+Top-level `claude:`, `copilot:`, `opencode:` blocks carry fields that have
+no neutral equivalent (Copilot's `excludeAgent`, opencode's `temperature`).
+The generator merges each block only into the matching client's output;
+non-matching blocks are stripped.
+
+### Conditional content directives
+
+`<!-- @client:X -->` / `<!-- @endclient -->` HTML comment blocks enable
+minor per-client body variations without separate files. Comma-separated
+client lists. Negation via `!` (`!opencode`). No nesting. Known client
+identifiers: `claude`, `copilot`, `opencode`.
+
+### Per-client override files
+
+When directives become unwieldy, authors provide complete body overrides:
+`RULE.claude.md`, `SKILL.copilot.md`, `AGENT.opencode.md`. Override files
+contain body only; frontmatter always comes from the canonical entrypoint.
+
+### Bundle as pure manifest
+
+A bundle is a single `<name>.bundle.md` file listing items by their `name`
+slug. Items live in separate item-source repos; bundles reference them,
+never contain them. Bundles compose cleanly (installing multiple bundles
+produces their union) and avoid content duplication.
+
+### Schema versioning
+
+Every entrypoint carries `schema: 1`. Implementations reject unknown
+future versions with a clear upgrade message. Minor additions (new
+optional fields) do not bump the schema; breaking changes (removed
+fields, renamed fields, changed semantics, new required fields) do.
+
+### Body content conventions
+
+For portability across clients:
+
+- **No H1 in body.** The generator produces an H1 from `name` for clients
+  that require one.
+- **Describe capability, not specific tools.** "Search the codebase" — not
+  "use the `Read` tool."
+- **MCP tools in `ServerName:tool_name` form.** Portable across clients;
+  client-specific internal forms (`mcp__server__tool`) stay out of SSOT.
+- **No client-specific constructs.** No `$ARGUMENTS`, no `` !`cmd` ``,
+  no `@path` imports, no `#tool:` references.
+- **File references via standard markdown links** with relative paths.
+- **Fenced code blocks require language hints.** Use `text` when no
+  specific language applies.
+
+## Consequences
+
+**Positive.** Authors maintain content once; tooling does the per-client
+mapping. Open-standard interop: agentskills.io-compatible tools consume
+our skill output unchanged. Schema versioning means we can evolve without
+silently breaking older toolchains.
+
+**Negative.** Schema evolution requires version-aware handling. Adding a
+required field is a breaking change forcing a schema bump. The spec is a
+living document; keeping it and the implementation in sync requires
+discipline.
+
+## Alternatives considered
+
+**(a) Custom proprietary schema unrelated to Agent Skills.** Rejected:
+fragments the ecosystem; the open standard already covers skills well and
+the `metadata` block provides sufficient extension surface for org-specific
+concerns.
+
+**(b) File-per-client with no SSOT.** Rejected: drift between client files
+is inevitable at scale.
+
+**(c) Inline content in bundles.** Rejected: forces bundles to grow with
+every item change. Pure-manifest bundles compose cleanly and decouple item
+versioning from bundle versioning.
+
+## References
+
+- Authoritative spec: [`docs/format-spec.md`](../format-spec.md)
+- Parent ADR: [ADR-0001](./0001-v0.2-architectural-reset.md)
+- Sibling ADRs: [ADR-0003](./0003-generation-pipeline.md),
+  [ADR-0004](./0004-cli-surface.md),
+  [ADR-0005](./0005-vercel-skills-sh-interop.md)
+- Agent Skills open standard: <https://agentskills.io>

--- a/docs/adr/0003-generation-pipeline.md
+++ b/docs/adr/0003-generation-pipeline.md
@@ -1,0 +1,141 @@
+# SSOT-to-client generation pipeline
+
+**Status**: Proposed (2026-05-01)
+
+## Context
+
+[ADR-0002](./0002-portable-content-format.md) defines the portable on-disk
+format. This ADR addresses how SSOT becomes per-client output: paths,
+frontmatter mapping, ancillary file handling, and the formatting guarantee
+required by the spec.
+
+Generation must be cheap (so it can run on every install/update),
+deterministic (idempotent across re-runs), and produce output that passes
+markdown linting without manual touch-up.
+
+## Decision
+
+### On-the-fly generation, not committed `dist/`
+
+SSOT → per-client output happens on the developer's machine when they run
+an install or update command. No CI generation step. No committed `dist/`
+artifacts. Per-developer client detection works because generation runs
+locally.
+
+Transform cost is negligible (milliseconds per item). Committing generated
+output produces diff noise on every item change and makes per-developer
+client targeting impossible.
+
+### Embed `dprint-plugin-markdown`, exact-pinned at `=0.21.1`
+
+`dprint-plugin-markdown` is added as a direct Rust crate dependency with
+an exact version requirement (`=0.21.1`, not caret). Bumps are deliberate,
+each gated on re-running golden-file fixtures. `dprint.json`'s WASM
+plugin pin is aligned with the embedded crate version so contributors
+running `just lint` see the same output as CI.
+
+This decision originated as the Phase 0 spike outcome under ADR-0001 and
+moves here as part of the umbrella refactor.
+
+**Rationale.**
+
+- Output is byte-identical to the `dprint` CLI on the 36 KB
+  `docs/format-spec.md` test.
+- Byte-identity holds across 4 minor versions (`0.17.8` → `0.21.1`,
+  ~18 months apart) — formatter is effectively output-stable even though
+  the API isn't.
+- Marginal binary cost is ~+1 MB after dep overlap — inside the
+  architecture target (~2-3 MB).
+- Removes the `dprint` CLI as a runtime dep for upskill users.
+
+**Phase 1 implementation notes.**
+
+- Real signature:
+  `format_text(text: &str, config: &Configuration, callback: impl FnMut(...) -> Result<Option<String>>) -> Result<Option<String>>`.
+- `Ok(None)` means "input was already canonical, hand it back as-is" —
+  must not be misread as "no output." A naive `unwrap()` will panic on
+  already-formatted files.
+- Default `text_wrap` is `Maintain`. `line_width` alone does not trigger
+  re-wrapping; set `TextWrap::Always` to wrap.
+- Pass `|_, _, _| Ok(None)` for the code-block callback to leave fenced
+  blocks untouched.
+
+### Per-client output paths and frontmatter mapping
+
+Per format-spec §7:
+
+| Item kind | Claude Code                             | Copilot                                                       | opencode                                       |
+| --------- | --------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------- |
+| Rule      | `.claude/rules/<name>.md` with `paths:` | `.github/instructions/<name>.instructions.md` with `applyTo:` | path entry in `opencode.json` `instructions[]` |
+| Skill     | `.claude/skills/<name>/SKILL.md`        | `.github/skills/<name>/SKILL.md`                              | `.agents/skills/<name>/SKILL.md` (native)      |
+| Agent     | `.claude/agents/<name>.md`              | `.github/agents/<name>.agent.md`                              | `.opencode/agents/<name>.md`                   |
+
+### Copy, not symlink
+
+All installation is file copy or generated output. No symlinks anywhere.
+One code path; Windows portability without Developer Mode or
+`core.symlinks=true`. The deliberate divergence from skills.sh's
+symlink-first default is documented in
+[ADR-0005](./0005-vercel-skills-sh-interop.md).
+
+### Ancillary file handling
+
+Three ancillary files are managed idempotently:
+
+- **`CLAUDE.md`** at repo root: created once with `@AGENTS.md` content if
+  absent. Never overwritten — protects user customisations.
+- **`opencode.json`**: read existing file, update `instructions[]` array
+  additively, write back. Other keys preserved.
+- **`.vscode/settings.json`**: read existing file, set
+  `chat.instructionsFilesLocations`, write back. Other keys preserved.
+
+### State file and v0.1 lockfile migration
+
+State lives at `~/.upskill/installed.json`, schema-versioned (`schema: 1`).
+Tracks installed items, their source, and content hash for drift
+detection. Implementations refuse higher schema versions with a clear
+upgrade message and a reset offer.
+
+v0.1's per-project `.upskill-lock.json` is read once by a translator that
+produces equivalent entries in `~/.upskill/installed.json`. Existing v0.1
+users are not silently broken.
+
+## Consequences
+
+**Positive.** Generated files are linter-clean by construction. dprint
+embedding removes the runtime `dprint` CLI dependency. Copy-only
+installation eliminates symlink portability issues. Schema-versioned
+state file enables future migrations without ambiguity.
+
+**Negative.** A generation bug forces a tool-wide release — no CI-side
+fix possible. Dual-state (state file + agent paths on disk) requires
+explicit `update` to refresh; not automatic via symlink. Manual dprint
+bumps with golden-file revalidation add a small but recurring maintenance
+cost.
+
+## Alternatives considered
+
+**(a) CI-generated, committed `dist/` output.** Rejected: noisy diffs on
+every item change, prevents per-developer client detection, requires CI
+infrastructure per item-source repo. On-the-fly generation is simpler
+given negligible transform cost.
+
+**(b) Symlink-first installation.** Rejected: Windows portability requires
+Developer Mode + `core.symlinks=true`, which cannot be guaranteed across
+all developer machines.
+
+**(c) Shell out to `dprint`.** Rejected (Phase 0 spike): forces a 6-9 MB
+Homebrew dependency on users, turns formatting into a subprocess dance
+with stdin/stdout error handling.
+
+**(d) Wasmtime-host the `.wasm` plugin.** Rejected: pulls a 5-10 MB
+wasmtime runtime, adds a second runtime to debug, reimplements what
+`dprint` already does.
+
+## References
+
+- Format spec §7 (generation): [`docs/format-spec.md`](../format-spec.md)
+- Parent ADR: [ADR-0001](./0001-v0.2-architectural-reset.md)
+- Sibling ADRs: [ADR-0002](./0002-portable-content-format.md),
+  [ADR-0004](./0004-cli-surface.md),
+  [ADR-0005](./0005-vercel-skills-sh-interop.md)

--- a/docs/adr/0004-cli-surface.md
+++ b/docs/adr/0004-cli-surface.md
@@ -1,0 +1,130 @@
+# upskill CLI surface
+
+**Status**: Proposed (2026-05-01)
+
+## Context
+
+upskill is the developer-facing tool for the entire content lifecycle:
+authoring, validating, distributing, installing. The CLI surface is the
+contract developers actually touch — it must be discoverable, predictable,
+and free of overlapping verbs.
+
+v0.1's surface (`add` / `list` / `remove` / `check` / `search` / `update`)
+was shaped around the skills-installer use case. v0.2's broader scope
+(create, manage, prolong content for three kinds across three clients)
+needs a surface that fits author workflows and bundle composition.
+
+This ADR is one of four child ADRs of [ADR-0001](./0001-v0.2-architectural-reset.md).
+
+## Decision
+
+### Nine commands, no overlap
+
+```text
+upskill add <source> [items...]    Install content from any source.
+upskill remove [<name>]            Remove installed content.
+upskill update [<name>]            Pull latest, regenerate changed items.
+upskill list [--available]         Show installed (or available) content.
+upskill info <name>                Show item/bundle details.
+upskill new <kind> <name>          Scaffold a new rule/skill/agent.
+upskill doctor                     Verify installation consistency.
+upskill lint [paths...]            Validate SSOT files.
+upskill fmt [paths...]             Canonicalise YAML frontmatter.
+```
+
+### `add` unifies bundle and ad-hoc installation
+
+Source resolution is automatic: upskill checks the registry index first;
+if no match, treats the source as a git repo or local path. Developers
+never decide between two install verbs. Source format parity with
+`npx skills add` is the subject of
+[ADR-0005](./0005-vercel-skills-sh-interop.md).
+
+### Install all by default
+
+`upskill add <source>` installs everything the source contains. Item
+names after the source filter to a subset. No interactive picker, no
+confirmation prompts. Bundles are curated — their contents belong
+together.
+
+### `update` absorbs sync
+
+`update` always fetches latest sources before regenerating. There is no
+separate `sync` command. No `--offline` flag in v1; offline use is
+covered by passing local paths to `add`/`update`.
+
+### `lint` absorbs validate
+
+`upskill lint --strict` is the CI mode (warnings become errors). No
+separate `validate` command. Lint scope is deliberately small (schema +
+structural markdown checks; cross-file consistency); content-quality
+review is delegated to AI workflows outside upskill.
+
+### `fmt` is frontmatter only
+
+`upskill fmt` canonicalises YAML frontmatter (key ordering, version
+quoting, indentation). Markdown body formatting is dprint's job. The two
+tools don't overlap.
+
+### Default scope: `--project`, fall back to `--global`
+
+`upskill add` writes into the current repo's `.agents/...` by default
+(`--project`). Falls back to `$HOME/.agents/...` (`--global`) if the
+current directory is not inside a git repo. Users can pass `--global`
+or `--project` explicitly to override.
+
+### "Prolong" is a CLI behaviour contract
+
+Two distinct things, both surfaced through `update`:
+
+- **Absorb client drift.** When Copilot or Claude Code change a path or
+  frontmatter field, `update` regenerates outputs from the same SSOT.
+  Authors don't have to react.
+- **Track upstream evolution.** `update` git-pulls source repos and
+  regenerates items whose source hash changed.
+
+A single command covers both because both rerun the same generation
+pipeline; differentiating them at the CLI level would force users to
+remember which one they want.
+
+### Aliases
+
+`add` does **not** alias to `install`. `remove` does **not** alias to
+`uninstall`. v0.1's `install` and `uninstall` are dropped — the unified
+verb names are the canonical ones. Migration covered in v0.2.0 release
+notes.
+
+## Consequences
+
+**Positive.** Predictable surface; no decision burden between two install
+verbs. Bundle install is just `add <bundle>`. Small command count is
+discoverable from `upskill --help`.
+
+**Negative.** v0.1 users who scripted `upskill install ...` need to
+update. Some users may expect interactive prompts (Vercel's `npx skills
+add` doesn't have them either, so this aligns with the wider ecosystem).
+
+## Alternatives considered
+
+**(a) Keep `install`/`uninstall` aliases for one minor version**
+(original ADR-0001 plan). Rejected: keeping aliases prolongs migration
+ambiguity; better a clean break with release notes.
+
+**(b) Separate `sync` and `update`.** Rejected: `update` is always-fetch;
+`--offline` is not a v1 use case. Splitting forces users to learn two
+verbs for what's effectively one operation.
+
+**(c) Separate `validate` and `lint`.** Rejected: `--strict` is
+sufficient differentiation; one command is easier to document and
+discover.
+
+**(d) Interactive multi-select prompt for partial install.** Rejected:
+install-all-by-default fits bundle curation. Named-item filter handles
+partial cases without TTY interaction (also: scriptable, CI-friendly).
+
+## References
+
+- Parent ADR: [ADR-0001](./0001-v0.2-architectural-reset.md)
+- Sibling ADRs: [ADR-0002](./0002-portable-content-format.md),
+  [ADR-0003](./0003-generation-pipeline.md),
+  [ADR-0005](./0005-vercel-skills-sh-interop.md)

--- a/docs/adr/0005-vercel-skills-sh-interop.md
+++ b/docs/adr/0005-vercel-skills-sh-interop.md
@@ -1,0 +1,139 @@
+# Compatibility with the Vercel/skills.sh ecosystem
+
+**Status**: Proposed (2026-05-01)
+
+## Context
+
+Vercel's `npx skills` CLI ([skills.sh](https://skills.sh)) is the de facto
+distribution tool for the open Agent Skills ecosystem. It supports 40+
+agents and uses `SKILL.md` as the standard format on the same
+[agentskills.io](https://agentskills.io) base spec we adopted in
+[ADR-0002](./0002-portable-content-format.md).
+
+Org-internal tooling that competes with this would fragment the
+ecosystem and force developers to choose. Interoperating preserves both
+worlds: developers get one tool that works with our internal SSOT
+content **and** with anything published to skills.sh.
+
+This ADR is one of four child ADRs of [ADR-0001](./0001-v0.2-architectural-reset.md).
+It is the cross-cutting strategic alignment decision; the impact lands
+in [ADR-0002](./0002-portable-content-format.md) (format compatibility),
+[ADR-0003](./0003-generation-pipeline.md) (no behavioural surprises),
+and [ADR-0004](./0004-cli-surface.md) (source-format parity).
+
+## Decision
+
+### We participate, we don't compete
+
+upskill interoperates with skills.sh content; it does not replace it.
+Where the open standard already covers a concern (skill schema, source
+formats, on-disk paths), upskill follows it.
+
+### Source format parity for `add`
+
+`upskill add <source>` accepts the same source forms as `npx skills add`:
+
+- `owner/repo` (GitHub shorthand)
+- `owner/repo@ref` (pinned ref)
+- Full git URLs (HTTPS, SSH)
+- Local paths (`./...`, `../...`, absolute, `~/...`)
+
+Developers running both tools in the same repo see source resolution
+behave the same way.
+
+### Generated SKILL.md is agentskills.io-compliant
+
+For skill output:
+
+- `name` and `description` pass through unchanged.
+- Agent Skills extended fields (`allowed-tools`, `when_to_use`,
+  `disable-model-invocation`, `context`, `agent`, `argument-hint`,
+  `paths`) pass through unchanged when present in SSOT.
+- No upskill-specific fields appear in generated `SKILL.md`. Schema
+  versioning, metadata block, and passthrough blocks are SSOT-side
+  concerns; they are stripped or merged at generation time per
+  [ADR-0003](./0003-generation-pipeline.md).
+
+Any agentskills.io-compatible client consumes upskill-generated skills
+unchanged.
+
+### Discovery convention parity
+
+upskill discovers `RULE.md`, `SKILL.md`, and `AGENT.md` files in the
+same well-known directories as skills.sh:
+
+- `.agents/{rules,skills,agents}/<name>/`
+- `.claude/{rules,skills,agents}/<name>/` (Claude Code convention)
+- `.github/{instructions,skills,agents}/` (Copilot convention)
+- `.opencode/agents/<name>.md` (opencode convention)
+
+### Bundle format is additive
+
+The `<name>.bundle.md` manifest is an upskill-specific extension layered
+on top of the open standard. It does not replace, redefine, or break
+any existing standard field. Tools that don't understand `.bundle.md`
+(including `npx skills`) simply ignore them — bundles never appear in
+their output, and nothing else degrades.
+
+Bundle authors who want their bundles consumable by skills.sh need a
+separate publishing path (skills.sh doesn't currently understand the
+manifest format). This is acceptable: bundles are for org curation, not
+public distribution.
+
+## Deliberate divergence: copy, not symlink
+
+skills.sh defaults to symlink installation. upskill uses copy
+**everywhere**, documented in
+[ADR-0003](./0003-generation-pipeline.md). This is the one place we
+deliberately diverge from the open ecosystem.
+
+**Reason.** Symlink installation requires Developer Mode +
+`core.symlinks=true` on Windows, which can't be guaranteed across the
+range of developer machines we support. Copy-only eliminates this class
+of support issues at the cost of one cosmetic difference.
+
+**Practical impact.** Cosmetic. Installed content behaves identically.
+A user running both `upskill add` and `npx skills add` in the same repo
+sees the same content reach the same paths via different mechanisms.
+The only observable difference is whether the destination file is a
+symlink or a copy — invisible to the consuming agent tool.
+
+**Surfacing.** This divergence is documented in v0.2.0 release notes
+and `upskill --help` for `add`/`update`/`remove`.
+
+## Consequences
+
+**Positive.** Developers use one tool. upskill SSOT content reaches any
+agentskills.io-compatible client without modification. Org investment
+in upskill doesn't trap users into a closed system. The interop story
+makes upskill cheap to adopt for teams already using `npx skills`.
+
+**Negative.** Constrains schema evolution: we can't change required
+fields in the open standard's frontmatter without breaking interop.
+Bundle authors who want public distribution need a separate path.
+Maintaining source-format parity means tracking changes to
+`npx skills`'s accepted source forms.
+
+## Alternatives considered
+
+**(a) Reimplement Vercel's distribution model, ignore interop.**
+Rejected: forces users to choose, fragments ecosystem, doesn't help
+skills.sh-distributed content reach our developers.
+
+**(b) Build only on top of skills.sh as a thin layer.** Rejected:
+doesn't handle rules or agents, doesn't support SSOT-with-generation,
+doesn't integrate with org-internal sources or governance.
+
+**(c) Match skills.sh symlink default.** Rejected: Windows portability
+requires guarantees we can't make. The cosmetic divergence is worth the
+support-cost reduction.
+
+## References
+
+- Parent ADR: [ADR-0001](./0001-v0.2-architectural-reset.md)
+- Sibling ADRs: [ADR-0002](./0002-portable-content-format.md),
+  [ADR-0003](./0003-generation-pipeline.md),
+  [ADR-0004](./0004-cli-surface.md)
+- Agent Skills open standard: <https://agentskills.io>
+- Vercel skills CLI: <https://github.com/vercel-labs/skills>
+- skills.sh directory: <https://skills.sh>


### PR DESCRIPTION
Refactors ADR-0001 from a single-monolithic decision record into an umbrella
plus four concern-focused child ADRs. The strategic pivot stays in ADR-0001;
substance moves out:

- ADR-0002 — Portable content format (on-disk SSOT contract; spec at docs/format-spec.md)
- ADR-0003 — Generation pipeline (SSOT → per-client; dprint embedding; ancillary files; state)
- ADR-0004 — CLI surface (nine commands, no overlap, install-all-by-default)
- ADR-0005 — Vercel/skills.sh interop (we participate; copy-not-symlink as the one divergence)

ADR-0001 retains: tag/branch decision, dep philosophy, project-level
consequences/alternatives, build order (updated: bundles promoted to MVP,
Phase 4 deleted as sync absorbed into update), project-level open questions.

Five commits, one per ADR file change. No code changes; no impact on Phase 1
work already merged.