### PR TITLE
feat(generate): extend pipeline to rules and agents

### DIFF
--- a/src/generate/claude.rs
+++ b/src/generate/claude.rs
@@ -1,10 +1,37 @@
 //! Claude Code generation (§7.1).
 
-use crate::model::Skill;
-use anyhow::Result;
+use crate::model::{Rule, Skill};
+use anyhow::{Context, Result};
+use serde_yaml_ng::{Mapping, Value};
 
 /// Skill frontmatter per §7.1: `name`, `description`, Agent Skills
 /// extended fields pass through.
 pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
     super::build_skill_frontmatter(skill, skill.claude.as_ref())
+}
+
+/// Rule frontmatter per §7.1: `name`, `description`, `paths:` (array)
+/// from `scope.paths` when present.
+pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
+    let mut map = Mapping::new();
+    map.insert(Value::from("name"), Value::from(rule.name.clone()));
+    map.insert(
+        Value::from("description"),
+        Value::from(rule.description.clone()),
+    );
+
+    if let Some(scope) = &rule.scope {
+        if !scope.paths.is_empty() {
+            let paths: Vec<Value> = scope.paths.iter().cloned().map(Value::from).collect();
+            map.insert(Value::from("paths"), Value::Sequence(paths));
+        }
+    }
+
+    if let Some(Value::Mapping(pt)) = rule.claude.as_ref() {
+        for (k, v) in pt {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+
+    serde_yaml_ng::to_string(&map).context("serializing claude rule frontmatter")
 }

--- a/src/generate/claude.rs
+++ b/src/generate/claude.rs
@@ -20,11 +20,11 @@ pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
         Value::from(rule.description.clone()),
     );
 
-    if let Some(scope) = &rule.scope {
-        if !scope.paths.is_empty() {
-            let paths: Vec<Value> = scope.paths.iter().cloned().map(Value::from).collect();
-            map.insert(Value::from("paths"), Value::Sequence(paths));
-        }
+    if let Some(scope) = &rule.scope
+        && !scope.paths.is_empty()
+    {
+        let paths: Vec<Value> = scope.paths.iter().cloned().map(Value::from).collect();
+        map.insert(Value::from("paths"), Value::Sequence(paths));
     }
 
     if let Some(Value::Mapping(pt)) = rule.claude.as_ref() {

--- a/src/generate/claude.rs
+++ b/src/generate/claude.rs
@@ -1,6 +1,6 @@
 //! Claude Code generation (§7.1).
 
-use crate::model::{Rule, Skill};
+use crate::model::{Agent, Rule, Skill, ToolCap};
 use anyhow::{Context, Result};
 use serde_yaml_ng::{Mapping, Value};
 
@@ -34,4 +34,62 @@ pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
     }
 
     serde_yaml_ng::to_string(&map).context("serializing claude rule frontmatter")
+}
+
+/// Agent frontmatter per §7.1 / Appendix B: `name`, `description`,
+/// `model:` (literal alias), `tools:` (capitalized), `skills:` (from
+/// `preload-skills`). `mode` is implicit by file location and not
+/// emitted.
+pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
+    let mut map = Mapping::new();
+    map.insert(Value::from("name"), Value::from(agent.name.clone()));
+    map.insert(
+        Value::from("description"),
+        Value::from(agent.description.clone()),
+    );
+
+    if let Some(model) = &agent.model {
+        map.insert(Value::from("model"), Value::from(model.clone()));
+    }
+
+    if !agent.tools.is_empty() {
+        let tools: Vec<Value> = agent
+            .tools
+            .iter()
+            .map(|t| Value::from(map_tool(*t)))
+            .collect();
+        map.insert(Value::from("tools"), Value::Sequence(tools));
+    }
+
+    if !agent.preload_skills.is_empty() {
+        let skills: Vec<Value> = agent
+            .preload_skills
+            .iter()
+            .cloned()
+            .map(Value::from)
+            .collect();
+        map.insert(Value::from("skills"), Value::Sequence(skills));
+    }
+
+    if let Some(Value::Mapping(pt)) = agent.claude.as_ref() {
+        for (k, v) in pt {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+
+    serde_yaml_ng::to_string(&map).context("serializing claude agent frontmatter")
+}
+
+/// Map a capability-level tool name to Claude's capitalized form.
+fn map_tool(t: ToolCap) -> &'static str {
+    match t {
+        ToolCap::Read => "Read",
+        ToolCap::Write => "Write",
+        ToolCap::Edit => "Edit",
+        ToolCap::Bash => "Bash",
+        ToolCap::Grep => "Grep",
+        ToolCap::Glob => "Glob",
+        ToolCap::WebFetch => "WebFetch",
+        ToolCap::WebSearch => "WebSearch",
+    }
 }

--- a/src/generate/copilot.rs
+++ b/src/generate/copilot.rs
@@ -50,12 +50,13 @@ pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
         map.insert(Value::from("model"), Value::from(model.clone()));
     }
 
-    if !agent.tools.is_empty() {
-        let tools: Vec<Value> = agent
-            .tools
-            .iter()
-            .map(|t| Value::from(map_tool(*t)))
-            .collect();
+    let tools: Vec<Value> = agent
+        .tools
+        .iter()
+        .filter_map(|t| map_tool(*t))
+        .map(Value::from)
+        .collect();
+    if !tools.is_empty() {
         map.insert(Value::from("tools"), Value::Sequence(tools));
     }
 
@@ -70,19 +71,17 @@ pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
 
 /// Map a capability-level tool name to Copilot's form.
 ///
-/// Per spec §4: `bash` → `shell`, `web-fetch` → `fetch`,
-/// `web-search` → `web_search`. Other tools have no documented Copilot
-/// mapping (`—` in §4); pass them through using the kebab-case identifier
-/// so authors can rely on a sensible default while §4 evolves.
-fn map_tool(t: ToolCap) -> &'static str {
+/// Per spec §4, Copilot only has documented mappings for `bash → shell`,
+/// `web-fetch → fetch`, and `web-search → web_search`. Capabilities
+/// without a documented mapping (`read`, `write`, `edit`, `grep`, `glob`)
+/// return `None` and are dropped silently — emitting them as kebab-case
+/// would produce fields Copilot does not consume. Authors needing
+/// Copilot-specific tool names can use the `copilot:` passthrough block.
+fn map_tool(t: ToolCap) -> Option<&'static str> {
     match t {
-        ToolCap::Read => "read",
-        ToolCap::Write => "write",
-        ToolCap::Edit => "edit",
-        ToolCap::Bash => "shell",
-        ToolCap::Grep => "grep",
-        ToolCap::Glob => "glob",
-        ToolCap::WebFetch => "fetch",
-        ToolCap::WebSearch => "web_search",
+        ToolCap::Bash => Some("shell"),
+        ToolCap::WebFetch => Some("fetch"),
+        ToolCap::WebSearch => Some("web_search"),
+        ToolCap::Read | ToolCap::Write | ToolCap::Edit | ToolCap::Grep | ToolCap::Glob => None,
     }
 }

--- a/src/generate/copilot.rs
+++ b/src/generate/copilot.rs
@@ -1,10 +1,36 @@
 //! GitHub Copilot generation (§7.2).
 
-use crate::model::Skill;
-use anyhow::Result;
+use crate::model::{Rule, Skill};
+use anyhow::{Context, Result};
+use serde_yaml_ng::{Mapping, Value};
 
 /// Skill frontmatter per §7.2: `name`, `description`, follows Agent
 /// Skills open standard.
 pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
     super::build_skill_frontmatter(skill, skill.copilot.as_ref())
+}
+
+/// Rule frontmatter per §7.2: `name`, `description`, `applyTo:`
+/// (comma-joined from `scope.paths`, default `"**"`).
+pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
+    let mut map = Mapping::new();
+    map.insert(Value::from("name"), Value::from(rule.name.clone()));
+    map.insert(
+        Value::from("description"),
+        Value::from(rule.description.clone()),
+    );
+
+    let apply_to = match &rule.scope {
+        Some(scope) if !scope.paths.is_empty() => scope.paths.join(", "),
+        _ => "**".to_string(),
+    };
+    map.insert(Value::from("applyTo"), Value::from(apply_to));
+
+    if let Some(Value::Mapping(pt)) = rule.copilot.as_ref() {
+        for (k, v) in pt {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+
+    serde_yaml_ng::to_string(&map).context("serializing copilot rule frontmatter")
 }

--- a/src/generate/copilot.rs
+++ b/src/generate/copilot.rs
@@ -1,6 +1,6 @@
 //! GitHub Copilot generation (§7.2).
 
-use crate::model::{Rule, Skill};
+use crate::model::{Agent, Rule, Skill, ToolCap};
 use anyhow::{Context, Result};
 use serde_yaml_ng::{Mapping, Value};
 
@@ -33,4 +33,56 @@ pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
     }
 
     serde_yaml_ng::to_string(&map).context("serializing copilot rule frontmatter")
+}
+
+/// Agent frontmatter per §7.2: `name`, `description`, `model`, `tools`.
+/// `preload-skills` has no Copilot equivalent and is dropped. `mode` is
+/// not emitted (not in the §7.2 field list).
+pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
+    let mut map = Mapping::new();
+    map.insert(Value::from("name"), Value::from(agent.name.clone()));
+    map.insert(
+        Value::from("description"),
+        Value::from(agent.description.clone()),
+    );
+
+    if let Some(model) = &agent.model {
+        map.insert(Value::from("model"), Value::from(model.clone()));
+    }
+
+    if !agent.tools.is_empty() {
+        let tools: Vec<Value> = agent
+            .tools
+            .iter()
+            .map(|t| Value::from(map_tool(*t)))
+            .collect();
+        map.insert(Value::from("tools"), Value::Sequence(tools));
+    }
+
+    if let Some(Value::Mapping(pt)) = agent.copilot.as_ref() {
+        for (k, v) in pt {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+
+    serde_yaml_ng::to_string(&map).context("serializing copilot agent frontmatter")
+}
+
+/// Map a capability-level tool name to Copilot's form.
+///
+/// Per spec §4: `bash` → `shell`, `web-fetch` → `fetch`,
+/// `web-search` → `web_search`. Other tools have no documented Copilot
+/// mapping (`—` in §4); pass them through using the kebab-case identifier
+/// so authors can rely on a sensible default while §4 evolves.
+fn map_tool(t: ToolCap) -> &'static str {
+    match t {
+        ToolCap::Read => "read",
+        ToolCap::Write => "write",
+        ToolCap::Edit => "edit",
+        ToolCap::Bash => "shell",
+        ToolCap::Grep => "grep",
+        ToolCap::Glob => "glob",
+        ToolCap::WebFetch => "fetch",
+        ToolCap::WebSearch => "web_search",
+    }
 }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Pure rendering. No filesystem writes — those land in Phase 3.
 
-use crate::model::Skill;
+use crate::model::{Rule, Skill};
 use anyhow::{Context, Result};
 use serde_yaml_ng::{Mapping, Value};
 
@@ -53,6 +53,26 @@ pub fn render_skill(skill: &Skill, body: &str, client: Client) -> Result<String>
         Client::Claude => claude::skill_frontmatter(skill)?,
         Client::Copilot => copilot::skill_frontmatter(skill)?,
         Client::OpenCode => opencode::skill_frontmatter(skill)?,
+    };
+    let combined = assemble(&frontmatter, &processed_body);
+    format::format_markdown(&combined)
+}
+
+/// Render a rule to its client-specific markdown string.
+///
+/// Per spec §7 / ADR-0003:
+/// - Claude: `paths:` array from `scope.paths`.
+/// - Copilot: `applyTo:` comma-joined string (default `"**"` if no scope).
+/// - opencode: scope is dropped (opencode does not support per-rule
+///   path-scoping per spec §3.2). The renderer still produces a string
+///   for API symmetry; the install layer (Phase 3) decides whether to
+///   write it or just register the SSOT path in `opencode.json`.
+pub fn render_rule(rule: &Rule, body: &str, client: Client) -> Result<String> {
+    let processed_body = directives::process(body, client)?;
+    let frontmatter = match client {
+        Client::Claude => claude::rule_frontmatter(rule)?,
+        Client::Copilot => copilot::rule_frontmatter(rule)?,
+        Client::OpenCode => opencode::rule_frontmatter(rule)?,
     };
     let combined = assemble(&frontmatter, &processed_body);
     format::format_markdown(&combined)

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Pure rendering. No filesystem writes — those land in Phase 3.
 
-use crate::model::{Rule, Skill};
+use crate::model::{Agent, Rule, Skill};
 use anyhow::{Context, Result};
 use serde_yaml_ng::{Mapping, Value};
 
@@ -73,6 +73,29 @@ pub fn render_rule(rule: &Rule, body: &str, client: Client) -> Result<String> {
         Client::Claude => claude::rule_frontmatter(rule)?,
         Client::Copilot => copilot::rule_frontmatter(rule)?,
         Client::OpenCode => opencode::rule_frontmatter(rule)?,
+    };
+    let combined = assemble(&frontmatter, &processed_body);
+    format::format_markdown(&combined)
+}
+
+/// Render an agent to its client-specific markdown string.
+///
+/// Per spec §7 / Appendix B:
+/// - Claude: `name`, `description`, `model`, `tools` (capitalized),
+///   `skills:` (renamed from `preload-skills`). `mode` is implicit by
+///   file location and not emitted.
+/// - Copilot: `name`, `description`, `model`, `tools` (per §4 mapping
+///   where defined, else passthrough). `mode` not emitted.
+///   `preload-skills` dropped (no equivalent).
+/// - opencode: `description`, `mode` (defaults to `subagent`), `model`,
+///   `tools` (lowercase). `name` is in filename per Appendix B and not
+///   emitted. `preload-skills` dropped (no equivalent).
+pub fn render_agent(agent: &Agent, body: &str, client: Client) -> Result<String> {
+    let processed_body = directives::process(body, client)?;
+    let frontmatter = match client {
+        Client::Claude => claude::agent_frontmatter(agent)?,
+        Client::Copilot => copilot::agent_frontmatter(agent)?,
+        Client::OpenCode => opencode::agent_frontmatter(agent)?,
     };
     let combined = assemble(&frontmatter, &processed_body);
     format::format_markdown(&combined)

--- a/src/generate/opencode.rs
+++ b/src/generate/opencode.rs
@@ -1,11 +1,37 @@
 //! opencode generation (§7.3).
 
-use crate::model::Skill;
-use anyhow::Result;
+use crate::model::{Rule, Skill};
+use anyhow::{Context, Result};
+use serde_yaml_ng::{Mapping, Value};
 
 /// Skill frontmatter per §7.3. opencode walks `.agents/skills/` natively;
 /// for the rendering layer we still produce the canonical content with
 /// the `opencode.*` passthrough merged.
 pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
     super::build_skill_frontmatter(skill, skill.opencode.as_ref())
+}
+
+/// Rule frontmatter per §7.3 / ADR-0003. opencode rules are referenced
+/// via a path entry in `opencode.json` `instructions[]`; no dedicated
+/// per-client file is generated.
+///
+/// For API symmetry with the other clients, this function still returns
+/// a string. The install layer (Phase 3) decides whether to write it or
+/// just register the SSOT path. `scope.paths` is silently dropped per
+/// spec §3.2 (opencode does not support per-rule path-scoping).
+pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
+    let mut map = Mapping::new();
+    map.insert(Value::from("name"), Value::from(rule.name.clone()));
+    map.insert(
+        Value::from("description"),
+        Value::from(rule.description.clone()),
+    );
+
+    if let Some(Value::Mapping(pt)) = rule.opencode.as_ref() {
+        for (k, v) in pt {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+
+    serde_yaml_ng::to_string(&map).context("serializing opencode rule frontmatter")
 }

--- a/src/generate/opencode.rs
+++ b/src/generate/opencode.rs
@@ -1,6 +1,6 @@
 //! opencode generation (§7.3).
 
-use crate::model::{Rule, Skill};
+use crate::model::{Agent, Mode, Rule, Skill, ToolCap};
 use anyhow::{Context, Result};
 use serde_yaml_ng::{Mapping, Value};
 
@@ -34,4 +34,67 @@ pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
     }
 
     serde_yaml_ng::to_string(&map).context("serializing opencode rule frontmatter")
+}
+
+/// Agent frontmatter per §7.3 / Appendix B: `description`, `mode`,
+/// `model`, `tools` (lowercase). `name` is in filename per Appendix B
+/// and not emitted. `preload-skills` has no opencode equivalent and is
+/// dropped. `mode` defaults to `subagent` per spec §3.4 when absent.
+pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
+    let mut map = Mapping::new();
+    map.insert(
+        Value::from("description"),
+        Value::from(agent.description.clone()),
+    );
+
+    let mode = agent.mode.unwrap_or(Mode::Subagent);
+    map.insert(Value::from("mode"), Value::from(mode_str(mode)));
+
+    if let Some(model) = &agent.model {
+        map.insert(Value::from("model"), Value::from(model.clone()));
+    }
+
+    if !agent.tools.is_empty() {
+        let tools: Vec<Value> = agent
+            .tools
+            .iter()
+            .map(|t| Value::from(map_tool(*t)))
+            .collect();
+        map.insert(Value::from("tools"), Value::Sequence(tools));
+    }
+
+    if let Some(Value::Mapping(pt)) = agent.opencode.as_ref() {
+        for (k, v) in pt {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+
+    serde_yaml_ng::to_string(&map).context("serializing opencode agent frontmatter")
+}
+
+fn mode_str(m: Mode) -> &'static str {
+    match m {
+        Mode::Primary => "primary",
+        Mode::Subagent => "subagent",
+        Mode::All => "all",
+    }
+}
+
+/// Map a capability-level tool name to opencode's lowercase form.
+///
+/// Per spec §4: opencode has no documented mapping for `web-fetch` or
+/// `web-search` (both `—`). Pass them through as kebab-case identifiers
+/// rather than dropping them — opencode's tool registry may add support
+/// later, and dropping silently would surprise authors.
+fn map_tool(t: ToolCap) -> &'static str {
+    match t {
+        ToolCap::Read => "read",
+        ToolCap::Write => "write",
+        ToolCap::Edit => "edit",
+        ToolCap::Bash => "bash",
+        ToolCap::Grep => "grep",
+        ToolCap::Glob => "glob",
+        ToolCap::WebFetch => "web-fetch",
+        ToolCap::WebSearch => "web-search",
+    }
 }

--- a/src/generate/opencode.rs
+++ b/src/generate/opencode.rs
@@ -54,13 +54,15 @@ pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
         map.insert(Value::from("model"), Value::from(model.clone()));
     }
 
-    if !agent.tools.is_empty() {
-        let tools: Vec<Value> = agent
-            .tools
-            .iter()
-            .map(|t| Value::from(map_tool(*t)))
-            .collect();
-        map.insert(Value::from("tools"), Value::Sequence(tools));
+    let mut perms = Mapping::new();
+    for tool in &agent.tools {
+        let key = Value::from(permission_key(*tool));
+        if !perms.contains_key(&key) {
+            perms.insert(key, Value::from("allow"));
+        }
+    }
+    if !perms.is_empty() {
+        map.insert(Value::from("permission"), Value::Mapping(perms));
     }
 
     if let Some(Value::Mapping(pt)) = agent.opencode.as_ref() {
@@ -80,21 +82,24 @@ fn mode_str(m: Mode) -> &'static str {
     }
 }
 
-/// Map a capability-level tool name to opencode's lowercase form.
+/// Map a capability-level tool name to opencode's `permission:` map key.
 ///
-/// Per spec §4: opencode has no documented mapping for `web-fetch` or
-/// `web-search` (both `—`). Pass them through as kebab-case identifiers
-/// rather than dropping them — opencode's tool registry may add support
-/// later, and dropping silently would surprise authors.
-fn map_tool(t: ToolCap) -> &'static str {
+/// Per opencode docs (https://opencode.ai/docs/agents), agents declare
+/// allowed capabilities via a `permission:` map (allow|ask|deny per key)
+/// rather than a `tools:` array. `write` rolls into `edit` since opencode
+/// has no separate write key. Other opencode-only permission keys
+/// (`task`, `external_directory`, `todowrite`, `lsp`, `skill`, `list`)
+/// have no neutral capability — authors who need them use the
+/// `opencode:` passthrough block.
+fn permission_key(t: ToolCap) -> &'static str {
     match t {
         ToolCap::Read => "read",
-        ToolCap::Write => "write",
+        ToolCap::Write => "edit",
         ToolCap::Edit => "edit",
         ToolCap::Bash => "bash",
         ToolCap::Grep => "grep",
         ToolCap::Glob => "glob",
-        ToolCap::WebFetch => "web-fetch",
-        ToolCap::WebSearch => "web-search",
+        ToolCap::WebFetch => "webfetch",
+        ToolCap::WebSearch => "websearch",
     }
 }

--- a/src/generate/opencode.rs
+++ b/src/generate/opencode.rs
@@ -36,12 +36,16 @@ pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
     serde_yaml_ng::to_string(&map).context("serializing opencode rule frontmatter")
 }
 
-/// Agent frontmatter per §7.3 / Appendix B: `description`, `mode`,
-/// `model`, `tools` (lowercase). `name` is in filename per Appendix B
-/// and not emitted. `preload-skills` has no opencode equivalent and is
-/// dropped. `mode` defaults to `subagent` per spec §3.4 when absent.
+/// Agent frontmatter per §7.3 — emits `name`, `description`, `mode`,
+/// `model`, `permission` map. `name` is emitted explicitly for cross-kind
+/// consistency with skills/rules and to support bookkeeping
+/// (`upskill list`/`doctor`, human readability), even though Appendix B
+/// originally suggested filename-only; opencode tolerates the redundant
+/// field. `preload-skills` has no opencode equivalent and is dropped.
+/// `mode` defaults to `subagent` per spec §3.4 when absent.
 pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
     let mut map = Mapping::new();
+    map.insert(Value::from("name"), Value::from(agent.name.clone()));
     map.insert(
         Value::from("description"),
         Value::from(agent.description.clone()),

--- a/tests/fixtures/agents/security-reviewer/AGENT.md
+++ b/tests/fixtures/agents/security-reviewer/AGENT.md
@@ -1,0 +1,35 @@
+---
+schema: 1
+name: security-reviewer
+description: Use when reviewing code for injection flaws, authentication issues, secret leaks, and insecure data handling
+license: proprietary
+mode: subagent
+model: sonnet
+tools:
+  - read
+  - grep
+  - glob
+  - bash
+preload-skills:
+  - security-baseline
+opencode:
+  temperature: 0.2
+metadata:
+  version: "1.0.0"
+  author: platform-security
+  audience:
+    - claude
+    - copilot
+    - opencode
+---
+
+## Security reviewer
+
+You are a security-focused code reviewer. When invoked:
+
+1. Identify injection vectors (SQL, command, path traversal, XSS).
+2. Verify authentication and authorization checks on every sensitive endpoint.
+3. Scan for hardcoded secrets, tokens, API keys, or credentials.
+4. Flag insecure data handling (unencrypted PII, weak cryptographic choices, improper logging of sensitive data).
+
+For each finding, report severity (critical/high/medium/low), file and line location, and a concrete remediation.

--- a/tests/fixtures/expected/claude/api-conventions.RULE.md
+++ b/tests/fixtures/expected/claude/api-conventions.RULE.md
@@ -1,0 +1,13 @@
+---
+name: api-conventions
+description: Use when writing or modifying API handler files to ensure consistent request validation, error formatting, and response shape
+paths:
+- src/api/**/*.ts
+- src/handlers/**/*.ts
+---
+
+## API handler conventions
+
+- All endpoints include input validation using the project's schema library.
+- Use the standard error response format defined in `src/api/errors.ts`.
+- Never return raw database errors to the client.

--- a/tests/fixtures/expected/claude/license-awareness.RULE.md
+++ b/tests/fixtures/expected/claude/license-awareness.RULE.md
@@ -1,0 +1,11 @@
+---
+name: license-awareness
+description: Use when reviewing third-party code, AI suggestions, or external snippets to check licensing compatibility and avoid incorporating incompatible licensed code
+---
+
+## Licensing rules
+
+- Never paste code from external sources without verifying the license.
+- When AI suggests code matching a recognizable upstream project, flag it before incorporating.
+- See [approved licenses](./allowed-licenses.txt) for the canonical SPDX list.
+- AGPL, SSPL, and BUSL code requires explicit approval from legal.

--- a/tests/fixtures/expected/claude/security-reviewer.AGENT.md
+++ b/tests/fixtures/expected/claude/security-reviewer.AGENT.md
@@ -1,0 +1,23 @@
+---
+name: security-reviewer
+description: Use when reviewing code for injection flaws, authentication issues, secret leaks, and insecure data handling
+model: sonnet
+tools:
+- Read
+- Grep
+- Glob
+- Bash
+skills:
+- security-baseline
+---
+
+## Security reviewer
+
+You are a security-focused code reviewer. When invoked:
+
+1. Identify injection vectors (SQL, command, path traversal, XSS).
+2. Verify authentication and authorization checks on every sensitive endpoint.
+3. Scan for hardcoded secrets, tokens, API keys, or credentials.
+4. Flag insecure data handling (unencrypted PII, weak cryptographic choices, improper logging of sensitive data).
+
+For each finding, report severity (critical/high/medium/low), file and line location, and a concrete remediation.

--- a/tests/fixtures/expected/copilot/api-conventions.RULE.md
+++ b/tests/fixtures/expected/copilot/api-conventions.RULE.md
@@ -1,0 +1,12 @@
+---
+name: api-conventions
+description: Use when writing or modifying API handler files to ensure consistent request validation, error formatting, and response shape
+applyTo: src/api/**/*.ts, src/handlers/**/*.ts
+excludeAgent: code-review
+---
+
+## API handler conventions
+
+- All endpoints include input validation using the project's schema library.
+- Use the standard error response format defined in `src/api/errors.ts`.
+- Never return raw database errors to the client.

--- a/tests/fixtures/expected/copilot/license-awareness.RULE.md
+++ b/tests/fixtures/expected/copilot/license-awareness.RULE.md
@@ -1,0 +1,12 @@
+---
+name: license-awareness
+description: Use when reviewing third-party code, AI suggestions, or external snippets to check licensing compatibility and avoid incorporating incompatible licensed code
+applyTo: '**'
+---
+
+## Licensing rules
+
+- Never paste code from external sources without verifying the license.
+- When AI suggests code matching a recognizable upstream project, flag it before incorporating.
+- See [approved licenses](./allowed-licenses.txt) for the canonical SPDX list.
+- AGPL, SSPL, and BUSL code requires explicit approval from legal.

--- a/tests/fixtures/expected/copilot/security-reviewer.AGENT.md
+++ b/tests/fixtures/expected/copilot/security-reviewer.AGENT.md
@@ -3,9 +3,6 @@ name: security-reviewer
 description: Use when reviewing code for injection flaws, authentication issues, secret leaks, and insecure data handling
 model: sonnet
 tools:
-- read
-- grep
-- glob
 - shell
 ---
 

--- a/tests/fixtures/expected/copilot/security-reviewer.AGENT.md
+++ b/tests/fixtures/expected/copilot/security-reviewer.AGENT.md
@@ -1,0 +1,21 @@
+---
+name: security-reviewer
+description: Use when reviewing code for injection flaws, authentication issues, secret leaks, and insecure data handling
+model: sonnet
+tools:
+- read
+- grep
+- glob
+- shell
+---
+
+## Security reviewer
+
+You are a security-focused code reviewer. When invoked:
+
+1. Identify injection vectors (SQL, command, path traversal, XSS).
+2. Verify authentication and authorization checks on every sensitive endpoint.
+3. Scan for hardcoded secrets, tokens, API keys, or credentials.
+4. Flag insecure data handling (unencrypted PII, weak cryptographic choices, improper logging of sensitive data).
+
+For each finding, report severity (critical/high/medium/low), file and line location, and a concrete remediation.

--- a/tests/fixtures/expected/opencode/api-conventions.RULE.md
+++ b/tests/fixtures/expected/opencode/api-conventions.RULE.md
@@ -1,0 +1,10 @@
+---
+name: api-conventions
+description: Use when writing or modifying API handler files to ensure consistent request validation, error formatting, and response shape
+---
+
+## API handler conventions
+
+- All endpoints include input validation using the project's schema library.
+- Use the standard error response format defined in `src/api/errors.ts`.
+- Never return raw database errors to the client.

--- a/tests/fixtures/expected/opencode/license-awareness.RULE.md
+++ b/tests/fixtures/expected/opencode/license-awareness.RULE.md
@@ -1,0 +1,11 @@
+---
+name: license-awareness
+description: Use when reviewing third-party code, AI suggestions, or external snippets to check licensing compatibility and avoid incorporating incompatible licensed code
+---
+
+## Licensing rules
+
+- Never paste code from external sources without verifying the license.
+- When AI suggests code matching a recognizable upstream project, flag it before incorporating.
+- See [approved licenses](./allowed-licenses.txt) for the canonical SPDX list.
+- AGPL, SSPL, and BUSL code requires explicit approval from legal.

--- a/tests/fixtures/expected/opencode/security-reviewer.AGENT.md
+++ b/tests/fixtures/expected/opencode/security-reviewer.AGENT.md
@@ -1,0 +1,22 @@
+---
+description: Use when reviewing code for injection flaws, authentication issues, secret leaks, and insecure data handling
+mode: subagent
+model: sonnet
+tools:
+- read
+- grep
+- glob
+- bash
+temperature: 0.2
+---
+
+## Security reviewer
+
+You are a security-focused code reviewer. When invoked:
+
+1. Identify injection vectors (SQL, command, path traversal, XSS).
+2. Verify authentication and authorization checks on every sensitive endpoint.
+3. Scan for hardcoded secrets, tokens, API keys, or credentials.
+4. Flag insecure data handling (unencrypted PII, weak cryptographic choices, improper logging of sensitive data).
+
+For each finding, report severity (critical/high/medium/low), file and line location, and a concrete remediation.

--- a/tests/fixtures/expected/opencode/security-reviewer.AGENT.md
+++ b/tests/fixtures/expected/opencode/security-reviewer.AGENT.md
@@ -2,11 +2,11 @@
 description: Use when reviewing code for injection flaws, authentication issues, secret leaks, and insecure data handling
 mode: subagent
 model: sonnet
-tools:
-- read
-- grep
-- glob
-- bash
+permission:
+  read: allow
+  grep: allow
+  glob: allow
+  bash: allow
 temperature: 0.2
 ---
 

--- a/tests/fixtures/expected/opencode/security-reviewer.AGENT.md
+++ b/tests/fixtures/expected/opencode/security-reviewer.AGENT.md
@@ -1,4 +1,5 @@
 ---
+name: security-reviewer
 description: Use when reviewing code for injection flaws, authentication issues, secret leaks, and insecure data handling
 mode: subagent
 model: sonnet

--- a/tests/fixtures/rules/api-conventions/RULE.md
+++ b/tests/fixtures/rules/api-conventions/RULE.md
@@ -1,0 +1,21 @@
+---
+schema: 1
+name: api-conventions
+description: Use when writing or modifying API handler files to ensure consistent request validation, error formatting, and response shape
+license: proprietary
+scope:
+  paths:
+    - "src/api/**/*.ts"
+    - "src/handlers/**/*.ts"
+copilot:
+  excludeAgent: code-review
+metadata:
+  version: "2.1.0"
+  author: platform-api
+---
+
+## API handler conventions
+
+- All endpoints include input validation using the project's schema library.
+- Use the standard error response format defined in `src/api/errors.ts`.
+- Never return raw database errors to the client.

--- a/tests/fixtures/rules/license-awareness/RULE.md
+++ b/tests/fixtures/rules/license-awareness/RULE.md
@@ -1,0 +1,16 @@
+---
+schema: 1
+name: license-awareness
+description: Use when reviewing third-party code, AI suggestions, or external snippets to check licensing compatibility and avoid incorporating incompatible licensed code
+license: proprietary
+metadata:
+  version: "1.0.0"
+  author: platform-security
+---
+
+## Licensing rules
+
+- Never paste code from external sources without verifying the license.
+- When AI suggests code matching a recognizable upstream project, flag it before incorporating.
+- See [approved licenses](./allowed-licenses.txt) for the canonical SPDX list.
+- AGPL, SSPL, and BUSL code requires explicit approval from legal.

--- a/tests/generate_agents.rs
+++ b/tests/generate_agents.rs
@@ -1,0 +1,58 @@
+//! Golden-file tests for agent generation across all three clients.
+//!
+//! Input: `tests/fixtures/agents/<name>/AGENT.md`
+//! Expected: `tests/fixtures/expected/<client>/<name>.AGENT.md`
+
+use std::fs;
+use upskill::generate::{Client, render_agent};
+use upskill::model::Agent;
+use upskill::parse::frontmatter;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn load_agent(name: &str) -> (Agent, String) {
+    let path = format!("{FIXTURES}/agents/{name}/AGENT.md");
+    let raw = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let (agent, body) = frontmatter::parse::<Agent>(&raw).expect("parse fixture");
+    (agent, body.to_string())
+}
+
+fn load_expected(client: &str, name: &str) -> String {
+    let path = format!("{FIXTURES}/expected/{client}/{name}.AGENT.md");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn assert_byte_equal(actual: &str, expected: &str, label: &str) {
+    if actual == expected {
+        return;
+    }
+    eprintln!("=== {label}: actual ===\n{actual}");
+    eprintln!("=== {label}: expected ===\n{expected}");
+    panic!("{label} mismatch (see stderr above)");
+}
+
+// security-reviewer — mode/tools/preload-skills + opencode passthrough
+
+#[test]
+fn security_reviewer_claude() {
+    let (agent, body) = load_agent("security-reviewer");
+    let actual = render_agent(&agent, &body, Client::Claude).expect("render");
+    let expected = load_expected("claude", "security-reviewer");
+    assert_byte_equal(&actual, &expected, "claude/security-reviewer");
+}
+
+#[test]
+fn security_reviewer_copilot() {
+    let (agent, body) = load_agent("security-reviewer");
+    let actual = render_agent(&agent, &body, Client::Copilot).expect("render");
+    let expected = load_expected("copilot", "security-reviewer");
+    assert_byte_equal(&actual, &expected, "copilot/security-reviewer");
+}
+
+#[test]
+fn security_reviewer_opencode() {
+    let (agent, body) = load_agent("security-reviewer");
+    let actual = render_agent(&agent, &body, Client::OpenCode).expect("render");
+    let expected = load_expected("opencode", "security-reviewer");
+    assert_byte_equal(&actual, &expected, "opencode/security-reviewer");
+}

--- a/tests/generate_rules.rs
+++ b/tests/generate_rules.rs
@@ -1,0 +1,84 @@
+//! Golden-file tests for rule generation across all three clients.
+//!
+//! Input: `tests/fixtures/rules/<name>/RULE.md`
+//! Expected: `tests/fixtures/expected/<client>/<name>.RULE.md`
+
+use std::fs;
+use upskill::generate::{Client, render_rule};
+use upskill::model::Rule;
+use upskill::parse::frontmatter;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn load_rule(name: &str) -> (Rule, String) {
+    let path = format!("{FIXTURES}/rules/{name}/RULE.md");
+    let raw = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let (rule, body) = frontmatter::parse::<Rule>(&raw).expect("parse fixture");
+    (rule, body.to_string())
+}
+
+fn load_expected(client: &str, name: &str) -> String {
+    let path = format!("{FIXTURES}/expected/{client}/{name}.RULE.md");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn assert_byte_equal(actual: &str, expected: &str, label: &str) {
+    if actual == expected {
+        return;
+    }
+    eprintln!("=== {label}: actual ===\n{actual}");
+    eprintln!("=== {label}: expected ===\n{expected}");
+    panic!("{label} mismatch (see stderr above)");
+}
+
+// license-awareness — always-on, no scope, no client passthroughs
+
+#[test]
+fn license_awareness_claude() {
+    let (rule, body) = load_rule("license-awareness");
+    let actual = render_rule(&rule, &body, Client::Claude).expect("render");
+    let expected = load_expected("claude", "license-awareness");
+    assert_byte_equal(&actual, &expected, "claude/license-awareness");
+}
+
+#[test]
+fn license_awareness_copilot() {
+    let (rule, body) = load_rule("license-awareness");
+    let actual = render_rule(&rule, &body, Client::Copilot).expect("render");
+    let expected = load_expected("copilot", "license-awareness");
+    assert_byte_equal(&actual, &expected, "copilot/license-awareness");
+}
+
+#[test]
+fn license_awareness_opencode() {
+    let (rule, body) = load_rule("license-awareness");
+    let actual = render_rule(&rule, &body, Client::OpenCode).expect("render");
+    let expected = load_expected("opencode", "license-awareness");
+    assert_byte_equal(&actual, &expected, "opencode/license-awareness");
+}
+
+// api-conventions — path-scoped, has copilot.* passthrough
+
+#[test]
+fn api_conventions_claude() {
+    let (rule, body) = load_rule("api-conventions");
+    let actual = render_rule(&rule, &body, Client::Claude).expect("render");
+    let expected = load_expected("claude", "api-conventions");
+    assert_byte_equal(&actual, &expected, "claude/api-conventions");
+}
+
+#[test]
+fn api_conventions_copilot() {
+    let (rule, body) = load_rule("api-conventions");
+    let actual = render_rule(&rule, &body, Client::Copilot).expect("render");
+    let expected = load_expected("copilot", "api-conventions");
+    assert_byte_equal(&actual, &expected, "copilot/api-conventions");
+}
+
+#[test]
+fn api_conventions_opencode() {
+    let (rule, body) = load_rule("api-conventions");
+    let actual = render_rule(&rule, &body, Client::OpenCode).expect("render");
+    let expected = load_expected("opencode", "api-conventions");
+    assert_byte_equal(&actual, &expected, "opencode/api-conventions");
+}


### PR DESCRIPTION
Phase 2 of ADR-0001 build order. Pure rendering; no filesystem writes
(those land in Phase 3). Sibling to Phase 1 skills pipeline.

Six commits on the branch — two feat, three fix, one clippy chore:

- feat(generate): rules with path-scoping (Claude `paths:` array,
  Copilot `applyTo:` comma-joined with default `'**'`, opencode drops
  scope per spec §3.2). 6 goldens from Appendix A.1 and A.2.
- feat(generate): agents with mode/tools/preload-skills. 3 goldens
  from Appendix A.4.
- fix(generate): correct opencode agent frontmatter to use permission
  map (opencode uses `permission:` allow/ask/deny per capability, not
  a `tools:` array — the prior commit emitted `tools:` which opencode
  silently ignored).
- fix(generate): always emit name: in rule and agent frontmatter
  (cross-kind consistency with skills agentskills.io convention;
  bookkeeping benefit outweighs negligible token cost).
- fix(generate): drop unmapped capabilities from copilot agent tools
  (per spec §4, only bash → shell, web-fetch → fetch, web-search →
  web_search are documented; previously unmapped capabilities passed
  through as kebab-case).
- chore(clippy): collapse nested if in claude rule_frontmatter (caught
  by `just verify` pre-push hook; let-chain fix, no behaviour change).

150 tests pass on HEAD. All 8 interpretive calls from the original
agent-rendering review are now resolved (1 by the SSOT-in-registry
direction, 5 by acceptance of original behaviour, 2 by the fix
commits).