### PR TITLE
docs: reconcile format-spec and ADRs with v0.2 design decisions

### DIFF
--- a/docs/adr/0002-portable-content-format.md
+++ b/docs/adr/0002-portable-content-format.md
@@ -57,6 +57,13 @@ A directory per item — for all three kinds — enables ancillary resources
 (templates, scripts, reference files) without future migration. Symmetry
 reduces cognitive load and simplifies tooling.
 
+This layout is the **source-registry form** — what authors edit and version
+in their item-source repos. Consumer projects (where developers run
+`upskill add`) never contain this SSOT layout; they only hold generated,
+client-specific outputs under `.claude/`, `.github/`, `.opencode/`, and
+`.agents/` (the last for opencode-style canonical-store outputs per
+[ADR-0003](./0003-generation-pipeline.md)).
+
 ### `metadata` block for governance
 
 A nested `metadata:` field carries versioning (`version`, quoted semver),

--- a/docs/adr/0002-portable-content-format.md
+++ b/docs/adr/0002-portable-content-format.md
@@ -47,7 +47,7 @@ upskill's own surface.
 ### Directory-per-item layout, symmetric across kinds
 
 ```text
-.agents/
+<source-registry-root>/
 ├── rules/<name>/RULE.md
 ├── skills/<name>/SKILL.md
 └── agents/<name>/AGENT.md
@@ -57,12 +57,17 @@ A directory per item — for all three kinds — enables ancillary resources
 (templates, scripts, reference files) without future migration. Symmetry
 reduces cognitive load and simplifies tooling.
 
-This layout is the **source-registry form** — what authors edit and version
-in their item-source repos. Consumer projects (where developers run
-`upskill add`) never contain this SSOT layout; they only hold generated,
-client-specific outputs under `.claude/`, `.github/`, `.opencode/`, and
-`.agents/` (the last for opencode-style canonical-store outputs per
-[ADR-0003](./0003-generation-pipeline.md)).
+The diagram is **illustrative**, not normative. Source registries
+organise their SSOT however the team prefers (`content/`, `skills-src/`,
+mixed kinds, etc.). The only constraint is that each item is a directory
+containing its kind-specific entrypoint file (`RULE.md`, `SKILL.md`, or
+`AGENT.md`).
+
+The `.agents/` path is **not** a source-registry convention. It is
+purely the consumer-side generated-output path for the opencode
+canonical-store pattern (per [ADR-0003](./0003-generation-pipeline.md)).
+Source registries SHOULD avoid `.agents/` as their root to prevent
+confusion with the consumer-side meaning.
 
 ### `metadata` block for governance
 

--- a/docs/adr/0003-generation-pipeline.md
+++ b/docs/adr/0003-generation-pipeline.md
@@ -80,30 +80,46 @@ symlink-first default is documented in
 
 ### Ancillary file handling
 
-Two ancillary files are managed idempotently:
+Three ancillary files are managed idempotently:
 
 - **`CLAUDE.md`** at repo root: created once with `@AGENTS.md` content if
   absent. Never overwritten — protects user customisations.
 - **`.vscode/settings.json`**: read existing file, set
   `chat.instructionsFilesLocations`, write back. Other keys preserved.
+- **`opencode.json`**: managed only on **first** opencode-rule install
+  in a consumer project. upskill adds `".agents/rules/**/RULE.md"` to
+  the `instructions[]` array (if not already present) and never mutates
+  the file thereafter. opencode's `instructions[]` glob expands to pick
+  up rule additions and removals automatically as files come and go
+  under `.agents/rules/`. Other config keys preserved; existing
+  `instructions[]` entries preserved.
 
-`opencode.json` is **not** managed by upskill: opencode reads rules
-from `.agents/rules/<name>/RULE.md` and skills from
-`.agents/skills/<name>/SKILL.md` natively (canonical-store pattern), so
-no `instructions[]` configuration is required. Users may still maintain
-`opencode.json` manually for other opencode settings; upskill leaves
-the file untouched.
+Skills do not require an `opencode.json` entry — opencode walks
+`.agents/skills/**/SKILL.md` natively (`EXTERNAL_SKILL_PATTERN` in
+opencode's source). Rules require the glob entry because opencode has
+no equivalent `EXTERNAL_RULE_PATTERN`; rules reach opencode only via
+`instructions[]`.
+
+> **Note for Phase 3 implementation.** `.agents/` is dot-prefixed; some
+> glob libraries exclude hidden directories by default. opencode's
+> `instructions[]` glob does not pass `dot: true` (verified in opencode
+> source). Phase 3 should include a fixture test that confirms
+> `.agents/rules/**/RULE.md` actually matches files under `.agents/`.
 
 ### State files and v0.1 lockfile migration
 
 State is split between two files:
 
 - **`.upskill.lock`** — **per-project**, lives at the consumer project
-  root, **committed alongside the project**. Records the bundles and
-  items added to this project: source registry URL, requested version
-  spec, resolved git ref, per-item content hash. Plays the same role
-  as `package-lock.json` — guarantees deterministic regeneration on
-  another developer's machine and in CI.
+  root, **committed alongside the project**. The consumer-side record
+  of installed state. Bundles themselves live only in source registries
+  (per [ADR-0002](./0002-portable-content-format.md) / format-spec
+  §3.7); the lock file captures, per installed bundle: bundle name,
+  source registry URL, requested version spec, resolved git ref, and
+  the per-item content hashes resolved from the bundle. Ad-hoc items
+  (installed without a bundle) are recorded similarly. Plays the same
+  role as `package-lock.json` — guarantees deterministic regeneration
+  on another developer's machine and in CI.
 - **`~/.upskill/installed.json`** — **per-user**, schema-versioned
   (`schema: 1`). Tracks the user-global view: which items the user has
   installed at the global scope, drift-detection state for the global

--- a/docs/adr/0003-generation-pipeline.md
+++ b/docs/adr/0003-generation-pipeline.md
@@ -64,11 +64,11 @@ moves here as part of the umbrella refactor.
 
 Per format-spec §7:
 
-| Item kind | Claude Code                             | Copilot                                                       | opencode                                       |
-| --------- | --------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------- |
-| Rule      | `.claude/rules/<name>.md` with `paths:` | `.github/instructions/<name>.instructions.md` with `applyTo:` | path entry in `opencode.json` `instructions[]` |
-| Skill     | `.claude/skills/<name>/SKILL.md`        | `.github/skills/<name>/SKILL.md`                              | `.agents/skills/<name>/SKILL.md` (native)      |
-| Agent     | `.claude/agents/<name>.md`              | `.github/agents/<name>.agent.md`                              | `.opencode/agents/<name>.md`                   |
+| Item kind | Claude Code                             | Copilot                                                       | opencode                                           |
+| --------- | --------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| Rule      | `.claude/rules/<name>.md` with `paths:` | `.github/instructions/<name>.instructions.md` with `applyTo:` | `.agents/rules/<name>/RULE.md` (canonical-store)   |
+| Skill     | `.claude/skills/<name>/SKILL.md`        | `.github/skills/<name>/SKILL.md`                              | `.agents/skills/<name>/SKILL.md` (canonical-store) |
+| Agent     | `.claude/agents/<name>.md`              | `.github/agents/<name>.agent.md`                              | `.opencode/agents/<name>.md`                       |
 
 ### Copy, not symlink
 
@@ -80,14 +80,19 @@ symlink-first default is documented in
 
 ### Ancillary file handling
 
-Three ancillary files are managed idempotently:
+Two ancillary files are managed idempotently:
 
 - **`CLAUDE.md`** at repo root: created once with `@AGENTS.md` content if
   absent. Never overwritten — protects user customisations.
-- **`opencode.json`**: read existing file, update `instructions[]` array
-  additively, write back. Other keys preserved.
 - **`.vscode/settings.json`**: read existing file, set
   `chat.instructionsFilesLocations`, write back. Other keys preserved.
+
+`opencode.json` is **not** managed by upskill: opencode reads rules
+from `.agents/rules/<name>/RULE.md` and skills from
+`.agents/skills/<name>/SKILL.md` natively (canonical-store pattern), so
+no `instructions[]` configuration is required. Users may still maintain
+`opencode.json` manually for other opencode settings; upskill leaves
+the file untouched.
 
 ### State files and v0.1 lockfile migration
 

--- a/docs/adr/0003-generation-pipeline.md
+++ b/docs/adr/0003-generation-pipeline.md
@@ -89,16 +89,29 @@ Three ancillary files are managed idempotently:
 - **`.vscode/settings.json`**: read existing file, set
   `chat.instructionsFilesLocations`, write back. Other keys preserved.
 
-### State file and v0.1 lockfile migration
+### State files and v0.1 lockfile migration
 
-State lives at `~/.upskill/installed.json`, schema-versioned (`schema: 1`).
-Tracks installed items, their source, and content hash for drift
-detection. Implementations refuse higher schema versions with a clear
-upgrade message and a reset offer.
+State is split between two files:
 
-v0.1's per-project `.upskill-lock.json` is read once by a translator that
-produces equivalent entries in `~/.upskill/installed.json`. Existing v0.1
-users are not silently broken.
+- **`.upskill.lock`** — **per-project**, lives at the consumer project
+  root, **committed alongside the project**. Records the bundles and
+  items added to this project: source registry URL, requested version
+  spec, resolved git ref, per-item content hash. Plays the same role
+  as `package-lock.json` — guarantees deterministic regeneration on
+  another developer's machine and in CI.
+- **`~/.upskill/installed.json`** — **per-user**, schema-versioned
+  (`schema: 1`). Tracks the user-global view: which items the user has
+  installed at the global scope, drift-detection state for the global
+  install location, source-registry caches.
+
+Both files are schema-versioned. Implementations refuse higher schema
+versions with a clear upgrade message and a reset offer.
+
+v0.1's per-project `.upskill-lock.json` is read once by a translator
+that produces equivalent entries in the new files: bundle/item entries
+go into `.upskill.lock`; any user-global state goes into
+`~/.upskill/installed.json`. Existing v0.1 users are not silently
+broken.
 
 ## Consequences
 

--- a/docs/adr/0004-cli-surface.md
+++ b/docs/adr/0004-cli-surface.md
@@ -92,6 +92,16 @@ tools don't overlap.
 current directory is not inside a git repo. Users can pass `--global`
 or `--project` explicitly to override.
 
+### Project lock file
+
+Consumer commands (`add`, `remove`, `update`) read and write
+**`.upskill.lock`** at the consumer project root. The lock file is
+**committed alongside the project** — it records the bundles and items
+added, their source-registry URLs, resolved git refs, and per-item
+content hashes. Plays the same role as `package-lock.json`: deterministic
+regeneration on another developer's machine or in CI. State design
+detailed in [ADR-0003](./0003-generation-pipeline.md).
+
 ### "Prolong" is a CLI behaviour contract
 
 Two distinct things, both surfaced through `update`:

--- a/docs/adr/0004-cli-surface.md
+++ b/docs/adr/0004-cli-surface.md
@@ -32,6 +32,25 @@ upskill lint [paths...]            Validate SSOT files.
 upskill fmt [paths...]             Canonicalise YAML frontmatter.
 ```
 
+### Author commands vs consumer commands
+
+The nine commands split by where they run:
+
+- **Author commands** — run inside a **source registry** working tree
+  (where SSOT items live and are edited):
+  - `new <kind> <name>` scaffolds a new SSOT item into the source repo.
+  - `lint [paths...]` validates SSOT files.
+  - `fmt [paths...]` canonicalises SSOT YAML frontmatter.
+- **Consumer commands** — run inside a **consumer project** (where only
+  generated outputs live):
+  - `add`, `remove`, `update`, `list`, `info`, `doctor`.
+
+Per [ADR-0002](./0002-portable-content-format.md), SSOT items only exist
+in source registries; consumer projects never contain SSOT. Author
+commands therefore have no meaning in a consumer project, and consumer
+commands have no meaning in a source registry. Implementations MAY
+detect the wrong context and emit a clear error.
+
 ### `add` unifies bundle and ad-hoc installation
 
 Source resolution is automatic: upskill checks the registry index first;

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -547,11 +547,11 @@ to discover rules without file duplication.
 
 ### 7.3 opencode
 
-| Item kind | Output path                      | Frontmatter mapping                                                                                               |
-| --------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| Rule      | (no file generation)             | Path added to `opencode.json` `instructions[]` array. File stays at SSOT location.                                |
-| Skill     | `.agents/skills/<name>/SKILL.md` | No generation needed if SSOT is already at this path (opencode walks `.agents/skills/` natively). Otherwise copy. |
-| Agent     | `.opencode/agents/<name>.md`     | `description:`, `mode:`, `model:`. opencode-specific fields from passthrough block.                               |
+| Item kind | Output path                      | Frontmatter mapping                                                                                                                       |
+| --------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Rule      | `.agents/rules/<name>/RULE.md`   | `name:`, `description:`. opencode-specific fields from passthrough block. `scope.paths` dropped (no per-rule scoping per §3.2).           |
+| Skill     | `.agents/skills/<name>/SKILL.md` | `name:`, `description:`. Agent Skills extended fields and opencode-specific fields from passthrough block. opencode walks this directory. |
+| Agent     | `.opencode/agents/<name>.md`     | `description:`, `mode:`, `model:`. opencode-specific fields from passthrough block.                                                       |
 
 ### 7.4 Shared outputs
 
@@ -559,7 +559,6 @@ Implementations SHOULD also generate or maintain:
 
 - `AGENTS.md` at repo root: project-specific content, hand-maintained by teams. Implementations
   MUST NOT overwrite this file after initial creation.
-- `opencode.json`: updated `instructions[]` array for rules targeting opencode.
 
 ### 7.5 Formatting guarantee
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -93,8 +93,10 @@ Constraints:
 - `<item-root>` is the SSOT path within a **source registry** repository. SSOT items live only in
   source registries; consumer projects (where developers run `upskill add`) only ever hold
   generated, client-specific outputs and never SSOT items.
-- Within a source registry, `<item-root>` MAY be any path. Implementations SHOULD accept `.agents/`
-  as the default convention but MUST NOT require it.
+- Within a source registry, `<item-root>` MAY be any path that fits the team's organisation
+  (`content/`, `skills-src/`, etc.). Source registries SHOULD avoid `.agents/` as their
+  `<item-root>` to prevent confusion with the consumer-side opencode canonical-store path
+  (§7.3).
 
 ### 2.2 Bundle files
 
@@ -301,6 +303,11 @@ Implementations:
 
 ### 3.7 Bundle schema
 
+Bundles are **source-registry artifacts**. They reference items by `name`; the items themselves
+live in source registries (potentially the same repo, potentially others). Consumer projects do
+not contain bundle files — an implementation records which bundles a consumer project has
+installed in its own state file (e.g. `.upskill.lock` for the upskill CLI).
+
 ```yaml
 ---
 schema: 1
@@ -442,21 +449,31 @@ in canonical bodies.
 
 ### 5.5 Prohibited constructs in canonical bodies
 
-The following MUST NOT appear in canonical entrypoint bodies. Use per-client override files (§2.3)
-or conditional directives (§6) instead:
+The following constructs MUST NOT appear in **always-rendered** body content — that is, the
+portion of the canonical entrypoint body that reaches every client. They are explicitly
+**permitted** inside:
 
-| Construct                       | Why prohibited            | Client      |
-| ------------------------------- | ------------------------- | ----------- |
-| `$ARGUMENTS`, `$0`, `$1`        | Substitution variable     | Claude Code |
-| `${workspaceFolder}`, `${file}` | Substitution variable     | Copilot     |
-| `` !`command` ``                | Shell pre-execution       | Claude Code |
-| `@path/to/file`                 | File import               | Claude Code |
-| `#tool:name`                    | Tool reference            | Copilot     |
-| `#file:path`                    | File reference            | Copilot     |
-| `ultrathink`                    | Extended thinking trigger | Claude Code |
+- `<!-- @client:X -->` ... `<!-- @endclient -->` directive blocks (§6), when `X` matches the
+  construct's client. The directive processor strips the entire block from outputs targeting
+  any other client, so the construct never reaches a client that would not understand it.
+- Per-client override files (§2.3) — `RULE.claude.md`, `SKILL.copilot.md`, `AGENT.opencode.md`,
+  etc. — when the filename suffix matches the construct's client. Override files are loaded
+  only by the matching client's generator.
 
-If an item genuinely requires any of these constructs, it SHOULD either be marked as single-client
-via `metadata.audience` or use a per-client override file.
+| Construct                       | Why prohibited (in always-rendered content) | Client      |
+| ------------------------------- | ------------------------------------------- | ----------- |
+| `$ARGUMENTS`, `$0`, `$1`        | Substitution variable                       | Claude Code |
+| `${workspaceFolder}`, `${file}` | Substitution variable                       | Copilot     |
+| `` !`command` ``                | Shell pre-execution                         | Claude Code |
+| `@path/to/file`                 | File import                                 | Claude Code |
+| `#tool:name`                    | Tool reference                              | Copilot     |
+| `#file:path`                    | File reference                              | Copilot     |
+| `ultrathink`                    | Extended thinking trigger                   | Claude Code |
+
+If an item needs one of these constructs in content that would otherwise reach every client,
+wrap it in a matching-client directive block (§6) or move it to a matching-client override
+file (§2.3). Items that genuinely target only one client end-to-end MAY instead be marked
+single-client via `metadata.audience` (§3.6).
 
 ---
 
@@ -571,6 +588,10 @@ Implementations SHOULD also generate or maintain:
 
 - `AGENTS.md` at repo root: project-specific content, hand-maintained by teams. Implementations
   MUST NOT overwrite this file after initial creation.
+- `opencode.json`: at first opencode-rule install in a consumer project, implementations add
+  `".agents/rules/**/RULE.md"` to the `instructions[]` array (if not already present). Subsequent
+  rule installs/uninstalls MUST NOT mutate the file — opencode's `instructions[]` glob picks up
+  rule additions and removals automatically. Other config keys preserved.
 
 ### 7.5 Formatting guarantee
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -384,6 +384,18 @@ This vocabulary is intentionally small. It covers the tools common to all three 
 Future specification versions may extend it. For tools not covered, item bodies SHOULD describe the
 desired capability in natural language rather than naming a client-specific tool.
 
+**Generation behavior for the agent `tools:` field.** When generating a client-specific agent
+output, implementations process each entry in the SSOT `tools:` list per the table above:
+
+- Capabilities **with** a documented client mapping are emitted using the client's name.
+- Capabilities **without** a documented mapping for a client (`—` cells above) are **dropped
+  silently** from that client's output. They are not passed through under the SSOT name —
+  emitting an unrecognized identifier would produce a field the client does not consume.
+
+Authors who need client-specific tool names beyond the documented mappings use that client's
+passthrough block (`claude:`, `copilot:`, `opencode:` per §3.5). The passthrough mechanism is
+the supported way to surface non-spec tooling in generated output.
+
 ---
 
 ## 5. Body content conventions
@@ -535,11 +547,11 @@ to bridge Claude Code to the project's `AGENTS.md` (which Claude Code does not r
 
 ### 7.2 GitHub Copilot
 
-| Item kind | Output path                                   | Frontmatter mapping                                                                                                       |
-| --------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Rule      | `.github/instructions/<name>.instructions.md` | `applyTo:` (comma-joined from `scope.paths`, default `"**"`), `name:`, `description:`. `copilot.excludeAgent` if present. |
-| Skill     | `.github/skills/<name>/SKILL.md`              | `name:`, `description:` pass through. Follows Agent Skills open standard.                                                 |
-| Agent     | `.github/agents/<name>.agent.md`              | `name:`, `description:`, `model:`, `tools:`. Copilot-specific fields from passthrough block.                              |
+| Item kind | Output path                                   | Frontmatter mapping                                                                                                                                                                                                                  |
+| --------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Rule      | `.github/instructions/<name>.instructions.md` | `applyTo:` (comma-joined from `scope.paths`, default `"**"`), `name:`, `description:`. `copilot.excludeAgent` if present.                                                                                                            |
+| Skill     | `.github/skills/<name>/SKILL.md`              | `name:`, `description:` pass through. Follows Agent Skills open standard.                                                                                                                                                            |
+| Agent     | `.github/agents/<name>.agent.md`              | `name:`, `description:`, `model:`, `tools:` (only documented §4 mappings — `bash → shell`, `web-fetch → fetch`, `web-search → web_search` — survive; unmapped capabilities dropped). Copilot-specific fields from passthrough block. |
 
 Additionally, implementations SHOULD generate or update `.vscode/settings.json` with
 `chat.instructionsFilesLocations` pointing to the item source directory, enabling VS Code Copilot
@@ -860,19 +872,19 @@ the canonical `AGENT.md` body is used (with directives processed).
 This table summarizes how SSOT fields map to each client's frontmatter when generating output.
 This is informational and subject to change as clients evolve.
 
-| SSOT field       | Claude Code output          | Copilot output                   | opencode output                                                 |
-| ---------------- | --------------------------- | -------------------------------- | --------------------------------------------------------------- |
-| `name`           | `name:`                     | `name:`                          | `name:`                                                         |
-| `description`    | `description:`              | `description:`                   | `description:`                                                  |
-| `scope.paths`    | `paths:` (array)            | `applyTo:` (comma-joined string) | (not supported; always-on)                                      |
-| `mode`           | (implicit in file location) | (agent definition)               | `mode:`                                                         |
-| `model`          | `model:` (alias)            | `model:` (full ID)               | `model:` (provider/ID)                                          |
-| `tools` (agent)  | `tools:` capitalized names  | `tools:` client names            | `permission:` map (allow per capability; write rolls into edit) |
-| `preload-skills` | `skills:` in agent          | —                                | —                                                               |
-| `copilot.*`      | (stripped)                  | Merged into frontmatter          | (stripped)                                                      |
-| `opencode.*`     | (stripped)                  | (stripped)                       | Merged into frontmatter                                         |
-| `claude.*`       | Merged into frontmatter     | (stripped)                       | (stripped)                                                      |
-| `metadata.*`     | (stripped from output)      | (stripped from output)           | (stripped from output)                                          |
+| SSOT field       | Claude Code output          | Copilot output                              | opencode output                                                 |
+| ---------------- | --------------------------- | ------------------------------------------- | --------------------------------------------------------------- |
+| `name`           | `name:`                     | `name:`                                     | `name:`                                                         |
+| `description`    | `description:`              | `description:`                              | `description:`                                                  |
+| `scope.paths`    | `paths:` (array)            | `applyTo:` (comma-joined string)            | (not supported; always-on)                                      |
+| `mode`           | (implicit in file location) | (agent definition)                          | `mode:`                                                         |
+| `model`          | `model:` (alias)            | `model:` (full ID)                          | `model:` (provider/ID)                                          |
+| `tools` (agent)  | `tools:` capitalized names  | `tools:` mapped only (§4); unmapped dropped | `permission:` map (allow per capability; write rolls into edit) |
+| `preload-skills` | `skills:` in agent          | —                                           | —                                                               |
+| `copilot.*`      | (stripped)                  | Merged into frontmatter                     | (stripped)                                                      |
+| `opencode.*`     | (stripped)                  | (stripped)                                  | Merged into frontmatter                                         |
+| `claude.*`       | Merged into frontmatter     | (stripped)                                  | (stripped)                                                      |
+| `metadata.*`     | (stripped from output)      | (stripped from output)                      | (stripped from output)                                          |
 
 ---
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -53,6 +53,15 @@ which client-specific outputs are derived.
 **Client-specific output**: a file or configuration entry written for a particular client's expected
 location, layout, and frontmatter conventions. Generated from the SSOT by an implementing tool.
 
+**Source registry**: a git repository (or local path used as one) that holds SSOT items in their
+canonical form. Source registries are the only place SSOT items exist. Authors edit items in source
+registries; consumers fetch from them.
+
+**Consumer project**: a developer's working repository where they run `upskill add` (or equivalent)
+to install items. Consumer projects only ever contain generated, client-specific outputs — never
+SSOT items. The same applies to a consumer's global install location (`~/.agents/` and per-client
+directories under `~/.config/`, `~/.claude/`, etc.): generated content only.
+
 ---
 
 ## 2. File layout
@@ -81,8 +90,11 @@ Constraints:
 - `<name>` MUST consist of lowercase letters (`a-z`), digits (`0-9`), and hyphens (`-`).
 - `<name>` MUST NOT start or end with a hyphen.
 - `<name>` MUST be at most 64 characters.
-- `<item-root>` MAY be any path. Implementations SHOULD accept `.agents/` as the default convention
-  but MUST NOT require it.
+- `<item-root>` is the SSOT path within a **source registry** repository. SSOT items live only in
+  source registries; consumer projects (where developers run `upskill add`) only ever hold
+  generated, client-specific outputs and never SSOT items.
+- Within a source registry, `<item-root>` MAY be any path. Implementations SHOULD accept `.agents/`
+  as the default convention but MUST NOT require it.
 
 ### 2.2 Bundle files
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -547,11 +547,11 @@ to discover rules without file duplication.
 
 ### 7.3 opencode
 
-| Item kind | Output path                      | Frontmatter mapping                                                                                                                       |
-| --------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Rule      | `.agents/rules/<name>/RULE.md`   | `name:`, `description:`. opencode-specific fields from passthrough block. `scope.paths` dropped (no per-rule scoping per §3.2).           |
-| Skill     | `.agents/skills/<name>/SKILL.md` | `name:`, `description:`. Agent Skills extended fields and opencode-specific fields from passthrough block. opencode walks this directory. |
-| Agent     | `.opencode/agents/<name>.md`     | `description:`, `mode:`, `model:`. opencode-specific fields from passthrough block.                                                       |
+| Item kind | Output path                      | Frontmatter mapping                                                                                                                                           |
+| --------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rule      | `.agents/rules/<name>/RULE.md`   | `name:`, `description:`. opencode-specific fields from passthrough block. `scope.paths` dropped (no per-rule scoping per §3.2).                               |
+| Skill     | `.agents/skills/<name>/SKILL.md` | `name:`, `description:`. Agent Skills extended fields and opencode-specific fields from passthrough block. opencode walks this directory.                     |
+| Agent     | `.opencode/agents/<name>.md`     | `name:`, `description:`, `mode:`, `model:`, `permission:` map (allow per capability; write rolls into edit). opencode-specific fields from passthrough block. |
 
 ### 7.4 Shared outputs
 
@@ -860,19 +860,19 @@ the canonical `AGENT.md` body is used (with directives processed).
 This table summarizes how SSOT fields map to each client's frontmatter when generating output.
 This is informational and subject to change as clients evolve.
 
-| SSOT field       | Claude Code output          | Copilot output                   | opencode output            |
-| ---------------- | --------------------------- | -------------------------------- | -------------------------- |
-| `name`           | `name:`                     | `name:`                          | (in filename)              |
-| `description`    | `description:`              | `description:`                   | `description:`             |
-| `scope.paths`    | `paths:` (array)            | `applyTo:` (comma-joined string) | (not supported; always-on) |
-| `mode`           | (implicit in file location) | (agent definition)               | `mode:`                    |
-| `model`          | `model:` (alias)            | `model:` (full ID)               | `model:` (provider/ID)     |
-| `tools`          | Capitalized names           | Client tool names                | Lowercase names            |
-| `preload-skills` | `skills:` in agent          | —                                | —                          |
-| `copilot.*`      | (stripped)                  | Merged into frontmatter          | (stripped)                 |
-| `opencode.*`     | (stripped)                  | (stripped)                       | Merged into frontmatter    |
-| `claude.*`       | Merged into frontmatter     | (stripped)                       | (stripped)                 |
-| `metadata.*`     | (stripped from output)      | (stripped from output)           | (stripped from output)     |
+| SSOT field       | Claude Code output          | Copilot output                   | opencode output                                                 |
+| ---------------- | --------------------------- | -------------------------------- | --------------------------------------------------------------- |
+| `name`           | `name:`                     | `name:`                          | `name:`                                                         |
+| `description`    | `description:`              | `description:`                   | `description:`                                                  |
+| `scope.paths`    | `paths:` (array)            | `applyTo:` (comma-joined string) | (not supported; always-on)                                      |
+| `mode`           | (implicit in file location) | (agent definition)               | `mode:`                                                         |
+| `model`          | `model:` (alias)            | `model:` (full ID)               | `model:` (provider/ID)                                          |
+| `tools` (agent)  | `tools:` capitalized names  | `tools:` client names            | `permission:` map (allow per capability; write rolls into edit) |
+| `preload-skills` | `skills:` in agent          | —                                | —                                                               |
+| `copilot.*`      | (stripped)                  | Merged into frontmatter          | (stripped)                                                      |
+| `opencode.*`     | (stripped)                  | (stripped)                       | Merged into frontmatter                                         |
+| `claude.*`       | Merged into frontmatter     | (stripped)                       | (stripped)                                                      |
+| `metadata.*`     | (stripped from output)      | (stripped from output)           | (stripped from output)                                          |
 
 ---
 


### PR DESCRIPTION
Reconciles format-spec.md and the v0.2 ADRs with six design decisions
from this session. Six commits, no code changes:

1. SSOT in source registry only — consumer projects hold generated
   outputs only. Source registries organize SSOT freely; .agents/ is
   purely the consumer-side generated-output convention.
2. .upskill.lock per-project state file alongside ~/.upskill/installed.json,
   the per-user state file. Bundles live in source registries; consumer
   projects track installed bundles via .upskill.lock.
3. opencode rules generate to .agents/rules/<name>/RULE.md (canonical-store
   pattern). opencode does not walk this path natively — rules are reached
   via a single instructions[] glob entry in opencode.json, set once at
   first install and never re-touched.
4. opencode agents use permission map (not tools array); name always emitted.
5. Copilot tool mapping is strict — unmapped capabilities dropped.
6. §5.5 prohibitions scoped to always-rendered content. Constructs inside
   <!-- @client:X --> directive blocks or per-client override files are
   explicitly exempt — they only ever reach the matching client.

Brings docs in line with the Phase 2 code already merged via #73. No
code changes; nothing to test beyond the existing 150-test suite.