### PR TITLE
docs: align book with v0.2 ADRs and rename umbrella ADRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,31 +4,37 @@ Instructions for AI coding agents working in this repository.
 
 ## Project
 
-upskill is a Rust CLI project for managing Agent Skills packages across coding
-agents. It focuses on a lightweight binary workflow and shared repository
-conventions used across driftsys projects.
+upskill is a Rust CLI for authoring and distributing AI-assistance content
+(rules, skills, agents) across multiple AI coding clients (Claude Code,
+Copilot, opencode) from a single source of truth. The central abstraction is
+**generation** — SSOT in, per-client output out.
 
-**Design priority**: ultra-light single binary. No Node.js, no npm, no async
-runtime. Targets ~2–3 MB stripped release binary.
+**v0.2 redesign in progress.** The shipped binary (`v0.1.x`, on `main`) is a
+skills-installer with the old fetch-and-copy model. The current branch
+(`v0.2-redesign`) is rebuilding around the SSOT-to-client pipeline. See
+[ADR-0001](docs/adr/0001-multi-kind-compiler-architecture.md) for the
+umbrella decision and the rest of `docs/adr/` for concern-specific design.
 
-> The README still says "name reservation — real implementation coming soon."
-> That line is stale. The CLI is fully implemented (`add`, `list`, `remove`,
-> `check`, `search`, `update`) with 13 integration test files.
+**Design priority**: single static binary, ~3 MB target. No Node.js, no npm,
+no async runtime, no `git2` (shell out to `git` instead). Other deps are
+admitted on a case-by-case basis — see ADR-0001 §3 (dependency philosophy
+relaxed for `serde_yaml_ng`, `pulldown-cmark`, `dprint-plugin-markdown`).
 
 ## Stack
 
 - **Language**: Rust, edition 2024. **MSRV: 1.85** (first stable to support
   edition 2024).
 - **Crate**: `upskill` is both library (`lib.rs`) and binary (`main.rs`).
-- **Dependencies** (kept deliberately small):
-  - `clap` 4 (derive), `anyhow` 1, `thiserror` 2, `serde` 1, `serde_json` 1,
-    `sha2` 0.11, `ureq` 2, `ctrlc` 3.
-- **Deliberately NOT used**: `tokio`, `reqwest`, `git2`, `walkdir`,
-  `dialoguer`, `serde_yaml`, `toml`. Reasons in `docs/architecture.md`. Don't
-  reach for these without a strong reason — shell out to `git`, use
-  `std::fs::read_dir`, etc.
-- **Release profile**: `opt-level = "z"`, `lto`, `codegen-units = 1`, `strip`,
-  `panic = "abort"`.
+- **Dependencies**: `clap` 4 (derive), `anyhow` 1, `thiserror` 2, `serde` 1,
+  `serde_json` 1, `serde_yaml_ng` 0.10, `pulldown-cmark` 0.11,
+  `dprint-plugin-markdown` `=0.21.1` (exact pin — see
+  [ADR-0003](docs/adr/0003-generation-pipeline.md)), `sha2` 0.11, `ureq` 2,
+  `ctrlc` 3.
+- **Out**: `tokio`, `reqwest` (no async, `ureq` is sync), `git2` (~5 MB —
+  shell out to `git`), `dialoguer` (raw stdin is enough). Don't add these
+  without a strong reason recorded in an ADR.
+- **Release profile**: `opt-level = "z"`, `lto`, `codegen-units = 1`,
+  `strip`, `panic = "abort"`.
 
 ## Build commands
 
@@ -57,22 +63,33 @@ Primary crate:
 
 ```
 src/
-├── main.rs       CLI entry point, clap derive, command dispatch
-├── lib.rs        Module declarations and re-exports
-├── source.rs     Source URL parsing and classification
-├── fetch.rs      Git clone, shallow clone, local path resolution
-├── agent.rs      Agent detection, AGENT_DEFS, symlink/copy targets
-├── install.rs    Canonical target, persist, skill selection
-├── lockfile.rs   Lock file read/write, content hash
-├── ui.rs         Interactive prompts, TTY detection, colored output
-└── auth.rs       Token resolution (env vars, gh/glab CLI fallback)
+├── main.rs              CLI entry point, clap derive, command dispatch
+├── lib.rs               Module declarations and re-exports
+│
+├── model/               SSOT data model (Phase 0): Rule, Skill, Agent + common
+├── parse/               SSOT parsing (Phase 0): YAML frontmatter
+├── generate/            SSOT → per-client rendering (Phase 1–2):
+│                        Client enum + claude/copilot/opencode + directives + dprint
+│
+├── source.rs            Source URL parsing and classification (typed errors)
+├── fetch.rs             Git clone, shallow clone, local path resolution
+├── auth.rs              Token resolution (env vars, gh/glab CLI fallback)
+├── search.rs            skills.sh API search
+├── ui.rs                Interactive prompts, TTY detection, colored output
+│
+├── agent.rs             v0.1 agent detection / symlink targets (retired in Phase 3)
+├── install.rs           v0.1 install flow (replaced in Phase 3)
+└── lockfile.rs          v0.1 .upskill-lock.json (replaced in Phase 3 with
+                         .upskill.lock + ~/.upskill/installed.json)
 ```
 
 Core docs (published as mdBook at <https://driftsys.github.io/upskill/>):
 
-- `docs/specification.md` — behavioral spec
-- `docs/architecture.md` — implementation guide (data structures, algorithms)
-- `docs/usage.md` — user-facing guide
+- `docs/usage.md` — user-facing guide (entrypoint)
+- `docs/specification.md` — v0.2 behavioral spec
+- `docs/architecture.md` — implementation guide
+- `docs/format-spec.md` — portable on-disk content format
+- `docs/adr/` — architecture decision records (0001 umbrella + 0002–0005)
 
 ### Key conventions
 
@@ -89,15 +106,18 @@ Core docs (published as mdBook at <https://driftsys.github.io/upskill/>):
 
 ### Install layout
 
-| Scope   | Canonical skills target | Lockfile                   |
-| ------- | ----------------------- | -------------------------- |
-| Project | `.agents/skills`        | `{cwd}/.upskill-lock.json` |
-| Global  | `$HOME/.agents/skills`  | `~/.upskill-lock.json`     |
+**v0.1 (shipped on `main`).** Skills install to `.agents/skills/` (project)
+or `~/.agents/skills/` (global) with per-agent symlinks. State in
+`.upskill-lock.json`. `AGENT_DEFS` in `src/agent.rs` is the source of truth.
 
-Per-agent skill directories (symlinks or copies of the canonical target):
-`.claude/skills`, `.github/skills`, `.codex/skills`, `.cursor/skills`,
-`.kiro/skills`, `.windsurf/skills`, `.opencode/skills`. Source of truth:
-`AGENT_DEFS` in `src/agent.rs`.
+**v0.2 (this branch, Phase 3 in flight).** Per-item generated output, copy
+only (no symlinks). State split between `.upskill.lock` (per-project,
+committed) and `~/.upskill/installed.json` (per-user). v0.1 lockfiles are
+read once on first invocation for migration. Per-client output paths and
+ancillary files (`CLAUDE.md`, `.vscode/settings.json`, `opencode.json`) are
+specified in
+[ADR-0003](docs/adr/0003-generation-pipeline.md) and
+[format-spec §7](docs/format-spec.md).
 
 ### Source format
 
@@ -144,11 +164,14 @@ Token resolution order:
       .success();
   ```
 
-- Existing test files (one per concern): `cli_add`, `cli_check`, `cli_ci_mode`,
-  `cli_dryrun`, `cli_exit_codes`, `cli_gitlab`, `cli_global`, `cli_list`,
-  `cli_lockfile`, `cli_moddetect`, `cli_remove`, `cli_search`, `cli_update`.
-  When adding behavior, prefer extending the matching file or creating a new
-  `cli_<area>.rs`.
+- Existing test files:
+  - **CLI (v0.1 surface):** `cli_add`, `cli_check`, `cli_ci_mode`,
+    `cli_dryrun`, `cli_exit_codes`, `cli_gitlab`, `cli_global`, `cli_list`,
+    `cli_lockfile`, `cli_moddetect`, `cli_remove`, `cli_search`, `cli_update`.
+  - **Generation (v0.2 pipeline):** `generate_skills`, `generate_rules`,
+    `generate_agents`. Golden fixtures in `tests/fixtures/`.
+  - When adding behavior, prefer extending the matching file or creating a
+    new `cli_<area>.rs` / `generate_<area>.rs`.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,33 @@
 
 > Upskill your coding agents.
 
-Ultra-lightweight [Agent Skills](https://agentskills.io/) package manager in Rust — no Node.js, no npm, no runtime dependencies.
+A single Rust binary for authoring and distributing AI-assistance content
+— **rules**, **skills**, and **agents** — across multiple AI coding clients
+(Claude Code, GitHub Copilot, opencode) from a single source of truth.
 
-Install, list, update, and remove SKILL.md packages across all major coding agents (Claude Code, Copilot, Codex, Cursor, OpenCode).
+No Node.js. No npm. No runtime dependencies.
+
+```bash
+cargo install upskill
+
+upskill add owner/repo               # install everything from a source repo
+upskill update                       # pull latest, regenerate per-client files
+upskill list                         # see what's installed
+```
 
 ## Status
 
-Under active development. This is a name reservation — real implementation coming soon.
+- **v0.1.x** — shipped on `main`, `cargo install upskill`. Skills-only
+  installer with the original fetch-and-copy model.
+- **v0.2** — in progress on `v0.2-redesign`. Adds rules and agents alongside
+  skills, with an SSOT-to-client generation pipeline. Phases 0–2 (model,
+  parser, generation) have shipped on the branch; Phase 3+ (install / update
+  over the pipeline, bundles, lockfile migration) is in flight.
+
+See [`docs/specification.md`](docs/specification.md) for the v0.2 design and
+[`docs/adr/`](docs/adr/) for the architecture decisions
+([ADR-0001](docs/adr/0001-multi-kind-compiler-architecture.md) is the
+umbrella).
 
 ## License
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,4 +1,13 @@
-# upskill
+# Summary
 
-[upskill](usage.md)
+[Introduction](usage.md)
+[Specification](specification.md)
+[Architecture](architecture.md)
 [Portable format spec](format-spec.md)
+
+- [Architecture decisions](adr/README.md)
+  - [ADR-0001 — Multi-kind compiler architecture](adr/0001-multi-kind-compiler-architecture.md)
+  - [ADR-0002 — Portable content format](adr/0002-portable-content-format.md)
+  - [ADR-0003 — SSOT-to-client generation pipeline](adr/0003-generation-pipeline.md)
+  - [ADR-0004 — CLI surface](adr/0004-cli-surface.md)
+  - [ADR-0005 — skills.sh ecosystem interop](adr/0005-skills-sh-ecosystem-interop.md)

--- a/docs/adr/0001-multi-kind-compiler-architecture.md
+++ b/docs/adr/0001-multi-kind-compiler-architecture.md
@@ -1,4 +1,4 @@
-# v0.2 architectural reset — from skills installer to multi-kind portable-format compiler
+# Multi-kind compiler architecture — v0.2 redesign umbrella
 
 **Status**: Proposed (2026-05-01)
 
@@ -27,7 +27,7 @@ design is split across four concern-focused child ADRs:
   that originated as Phase 0's spike).
 - [ADR-0004](./0004-cli-surface.md) — CLI surface (the user-facing
   contract).
-- [ADR-0005](./0005-vercel-skills-sh-interop.md) — Compatibility with the
+- [ADR-0005](./0005-skills-sh-ecosystem-interop.md) — Compatibility with the
   Vercel/skills.sh ecosystem (cross-cutting strategic alignment).
 
 This ADR records the project-level decisions only: the pivot itself, the

--- a/docs/adr/0002-portable-content-format.md
+++ b/docs/adr/0002-portable-content-format.md
@@ -18,7 +18,7 @@ agent personas. We need one format that:
 - is self-describing so it can evolve without silently breaking older
   consumers.
 
-This ADR is one of four child ADRs of [ADR-0001](./0001-v0.2-architectural-reset.md).
+This ADR is one of four child ADRs of [ADR-0001](./0001-multi-kind-compiler-architecture.md).
 It owns the on-disk SSOT contract; [ADR-0003](./0003-generation-pipeline.md)
 owns how that SSOT becomes per-client output.
 
@@ -155,8 +155,8 @@ versioning from bundle versioning.
 ## References
 
 - Authoritative spec: [`docs/format-spec.md`](../format-spec.md)
-- Parent ADR: [ADR-0001](./0001-v0.2-architectural-reset.md)
+- Parent ADR: [ADR-0001](./0001-multi-kind-compiler-architecture.md)
 - Sibling ADRs: [ADR-0003](./0003-generation-pipeline.md),
   [ADR-0004](./0004-cli-surface.md),
-  [ADR-0005](./0005-vercel-skills-sh-interop.md)
+  [ADR-0005](./0005-skills-sh-ecosystem-interop.md)
 - Agent Skills open standard: <https://agentskills.io>

--- a/docs/adr/0003-generation-pipeline.md
+++ b/docs/adr/0003-generation-pipeline.md
@@ -76,7 +76,7 @@ All installation is file copy or generated output. No symlinks anywhere.
 One code path; Windows portability without Developer Mode or
 `core.symlinks=true`. The deliberate divergence from skills.sh's
 symlink-first default is documented in
-[ADR-0005](./0005-vercel-skills-sh-interop.md).
+[ADR-0005](./0005-skills-sh-ecosystem-interop.md).
 
 ### Ancillary file handling
 
@@ -169,7 +169,7 @@ wasmtime runtime, adds a second runtime to debug, reimplements what
 ## References
 
 - Format spec §7 (generation): [`docs/format-spec.md`](../format-spec.md)
-- Parent ADR: [ADR-0001](./0001-v0.2-architectural-reset.md)
+- Parent ADR: [ADR-0001](./0001-multi-kind-compiler-architecture.md)
 - Sibling ADRs: [ADR-0002](./0002-portable-content-format.md),
   [ADR-0004](./0004-cli-surface.md),
-  [ADR-0005](./0005-vercel-skills-sh-interop.md)
+  [ADR-0005](./0005-skills-sh-ecosystem-interop.md)

--- a/docs/adr/0004-cli-surface.md
+++ b/docs/adr/0004-cli-surface.md
@@ -14,7 +14,7 @@ was shaped around the skills-installer use case. v0.2's broader scope
 (create, manage, prolong content for three kinds across three clients)
 needs a surface that fits author workflows and bundle composition.
 
-This ADR is one of four child ADRs of [ADR-0001](./0001-v0.2-architectural-reset.md).
+This ADR is one of four child ADRs of [ADR-0001](./0001-multi-kind-compiler-architecture.md).
 
 ## Decision
 
@@ -57,7 +57,7 @@ Source resolution is automatic: upskill checks the registry index first;
 if no match, treats the source as a git repo or local path. Developers
 never decide between two install verbs. Source format parity with
 `npx skills add` is the subject of
-[ADR-0005](./0005-vercel-skills-sh-interop.md).
+[ADR-0005](./0005-skills-sh-ecosystem-interop.md).
 
 ### Install all by default
 
@@ -153,7 +153,7 @@ partial cases without TTY interaction (also: scriptable, CI-friendly).
 
 ## References
 
-- Parent ADR: [ADR-0001](./0001-v0.2-architectural-reset.md)
+- Parent ADR: [ADR-0001](./0001-multi-kind-compiler-architecture.md)
 - Sibling ADRs: [ADR-0002](./0002-portable-content-format.md),
   [ADR-0003](./0003-generation-pipeline.md),
-  [ADR-0005](./0005-vercel-skills-sh-interop.md)
+  [ADR-0005](./0005-skills-sh-ecosystem-interop.md)

--- a/docs/adr/0005-skills-sh-ecosystem-interop.md
+++ b/docs/adr/0005-skills-sh-ecosystem-interop.md
@@ -1,4 +1,4 @@
-# Compatibility with the Vercel/skills.sh ecosystem
+# skills.sh ecosystem interop
 
 **Status**: Proposed (2026-05-01)
 
@@ -15,7 +15,7 @@ ecosystem and force developers to choose. Interoperating preserves both
 worlds: developers get one tool that works with our internal SSOT
 content **and** with anything published to skills.sh.
 
-This ADR is one of four child ADRs of [ADR-0001](./0001-v0.2-architectural-reset.md).
+This ADR is one of four child ADRs of [ADR-0001](./0001-multi-kind-compiler-architecture.md).
 It is the cross-cutting strategic alignment decision; the impact lands
 in [ADR-0002](./0002-portable-content-format.md) (format compatibility),
 [ADR-0003](./0003-generation-pipeline.md) (no behavioural surprises),
@@ -130,7 +130,7 @@ support-cost reduction.
 
 ## References
 
-- Parent ADR: [ADR-0001](./0001-v0.2-architectural-reset.md)
+- Parent ADR: [ADR-0001](./0001-multi-kind-compiler-architecture.md)
 - Sibling ADRs: [ADR-0002](./0002-portable-content-format.md),
   [ADR-0003](./0003-generation-pipeline.md),
   [ADR-0004](./0004-cli-surface.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,10 @@
 
 > Implementation guide for the upskill CLI.
 
+**Status**: v0.2 redesign in progress. The v0.1 modules remain in tree
+(serving the shipped binary) and are listed alongside the v0.2 SSOT-pipeline
+modules added in Phase 0–2.
+
 ## 1. Stack
 
 ### 1.1 Language and edition
@@ -10,28 +14,31 @@ Rust 2024 edition. MSRV: 1.85 (first stable release to support edition 2024).
 
 ### 1.2 Dependencies
 
-| Crate        | Version | Purpose                 | Justification                                     |
-| ------------ | ------- | ----------------------- | ------------------------------------------------- |
-| `clap`       | 4.x     | CLI parsing             | Derive API, subcommands, auto `--help`.           |
-| `ctrlc`      | 3.x     | SIGINT handler          | Exit code 130 on Ctrl+C.                          |
-| `serde`      | 1.x     | Serialization framework | Lockfile serialization.                           |
-| `serde_json` | 1.x     | JSON serialization      | Lockfile read/write.                              |
-| `sha2`       | 0.11.x  | SHA-256 hashing         | Lockfile content hash for modification detection. |
-| `thiserror`  | 2.x     | Typed parse errors      | `SourceParseError` in `source.rs`.                |
-| `anyhow`     | 1.x     | Error handling          | Ergonomic error chains with `.context()`.         |
-| `ureq`       | 2.x     | HTTP client             | skills.sh API calls in `search.rs`.               |
+| Crate                    | Version   | Purpose                                  |
+| ------------------------ | --------- | ---------------------------------------- |
+| `clap`                   | 4.5       | CLI parsing (derive, subcommands).       |
+| `anyhow`                 | 1         | Ergonomic error chains via `.context()`. |
+| `thiserror`              | 2         | Typed parse errors (`source.rs`).        |
+| `serde`                  | 1         | Serialization framework.                 |
+| `serde_json`             | 1         | Lockfile and `installed.json` I/O.       |
+| `serde_yaml_ng`          | 0.10      | SSOT YAML frontmatter parsing.           |
+| `pulldown-cmark`         | 0.11      | Markdown body parsing for directives.    |
+| `dprint-plugin-markdown` | `=0.21.1` | Embedded markdown formatter (exact pin). |
+| `sha2`                   | 0.11      | Content hashing (lockfile, drift).       |
+| `ureq`                   | 2         | HTTP client (skills.sh API).             |
+| `ctrlc`                  | 3.4       | SIGINT handler — exit 130 on Ctrl+C.     |
 
-**Not included:**
+**Why exact-pin `dprint-plugin-markdown`.** Per
+[ADR-0003](./adr/0003-generation-pipeline.md), bumps are deliberate and gated
+on re-running golden-file fixtures. `dprint.json`'s WASM plugin pin is aligned
+with the embedded crate version so `just lint` matches CI.
 
-| Crate        | Why not                                                           |
-| ------------ | ----------------------------------------------------------------- |
-| `tokio`      | No async needed. All I/O is sequential: one fetch, one scan.      |
-| `reqwest`    | Pulls in tokio. Fetch delegates to `git clone`.                   |
-| `git2`       | Libgit2 binding is heavy (~5 MB). Shell out to `git` instead.     |
-| `walkdir`    | Not needed — `std::fs::read_dir` is sufficient for current depth. |
-| `dialoguer`  | Interactive prompts are simple enough with raw stdin.             |
-| `serde_yaml` | No SKILL.md frontmatter parsing yet (v0.4+).                      |
-| `toml`       | No `registries.toml` config yet (v0.4+).                          |
+**Deliberately excluded.** `tokio`, `reqwest` (no async needed; `ureq` is
+synchronous), `git2` (~5 MB binding — shell out to `git` instead), `dialoguer`
+(prompts are simple enough with raw stdin), `toml` (no config files yet).
+ADR-0001 §3 relaxed the older "no large deps" stance for the items above
+(notably `serde_yaml_ng`, `pulldown-cmark`, `dprint-plugin-markdown`,
+`walkdir` if needed); `git2` and async runtimes remain out.
 
 ### 1.3 Build profile
 
@@ -44,407 +51,205 @@ strip = true
 panic = "abort"
 ```
 
-Target: ~2-3 MB static binary. `panic = "abort"` saves ~200 KB by removing
+Target: ~3 MB static binary. `panic = "abort"` saves ~200 KB by removing
 unwind tables.
 
 ### 1.4 Crate layout
 
-```toml
-[lib]
-name = "upskill"
-
-[[bin]]
-name = "upskill"
-path = "src/main.rs"
-```
-
-Library crate (`lib.rs`) exposes all modules for integration testing. Binary
-crate (`main.rs`) is the CLI entry point.
+`upskill` is both a library (`lib.rs`) and a binary (`main.rs`). The library
+exposes all modules for integration testing.
 
 ## 2. Module structure
 
 ```
 src/
-├── main.rs       CLI entry point, clap derive, command dispatch
-├── lib.rs        Module declarations and re-exports
-├── source.rs     Source URL parsing and classification
-├── fetch.rs      Git clone, shallow clone, local path resolution
-├── agent.rs      Agent detection, AGENT_DEFS, symlink/copy targets
-├── install.rs    Canonical target, persist, skill selection
-├── lockfile.rs   Lock file read/write, content hash
-├── search.rs     skills.sh API search, registry URL resolution
-├── ui.rs         Interactive prompts, TTY detection, colored output
-└── auth.rs       Token resolution (env vars, gh/glab CLI fallback)
+├── main.rs              CLI entry point, clap derive, command dispatch.
+├── lib.rs               Module declarations and re-exports.
+│
+├── model/               SSOT data model (Phase 0).
+│   ├── mod.rs
+│   ├── common.rs        Schema, metadata, passthrough blocks shared by all kinds.
+│   ├── rule.rs          Rule item (RULE.md) with scope.paths.
+│   ├── skill.rs         Skill item (SKILL.md) — Agent Skills extended fields.
+│   └── agent.rs         Agent item (AGENT.md) with mode/model/tools/preload-skills.
+│
+├── parse/               SSOT parsing (Phase 0).
+│   ├── mod.rs
+│   └── frontmatter.rs   YAML frontmatter parser (--- delimiters).
+│
+├── generate/            SSOT → per-client output rendering (Phase 1–2).
+│   ├── mod.rs           Client enum, render_skill / render_rule / render_agent.
+│   ├── claude.rs        Claude Code frontmatter mapping.
+│   ├── copilot.rs       Copilot frontmatter mapping (instructions/skills/agents).
+│   ├── opencode.rs      opencode frontmatter mapping (permission map).
+│   ├── directives.rs    <!-- @client:X --> conditional content blocks.
+│   └── format.rs        Embedded dprint-plugin-markdown wrapper.
+│
+├── source.rs            Source URL parsing and classification (typed errors).
+├── fetch.rs             Git clone, shallow clone, local path resolution.
+├── agent.rs             Agent detection, AGENT_DEFS (v0.1 — to be retired in Phase 3).
+├── install.rs           v0.1 install flow (canonical target, persist, skill selection).
+├── lockfile.rs          v0.1 .upskill-lock.json read/write, content hash.
+├── search.rs            skills.sh API search, registry URL resolution.
+├── auth.rs              Token resolution (env vars, gh/glab CLI fallback).
+└── ui.rs                Interactive prompts, TTY detection, colored output.
 ```
 
-### 2.1 Dependency graph (modules)
+### 2.1 v0.2 module status
 
-```
-main.rs
-  ├── source.rs     (pure, no I/O)
-  ├── auth.rs       (reads env, shells out to gh/glab)
-  ├── fetch.rs      (uses: source, auth)
-  ├── agent.rs      (filesystem checks, symlink operations)
-  ├── install.rs    (uses: ui — canonical target, skill selection)
-  ├── lockfile.rs   (uses: serde_json, sha2 — file I/O)
-  ├── search.rs     (uses: ureq — HTTP GET to registry API)
-  └── ui.rs         (stdin/stdout — TTY detection, prompts)
-```
+| Module      | Status                                                                                                                                              |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model/`    | Done (Phase 0). Full schema for rules, skills, agents.                                                                                              |
+| `parse/`    | Done (Phase 0). YAML frontmatter parsing with `serde_yaml_ng`.                                                                                      |
+| `generate/` | Done (Phase 1–2). All three kinds × all three clients.                                                                                              |
+| `source`    | Reused from v0.1. Source format unchanged (parity with `npx skills`).                                                                               |
+| `fetch`     | Reused from v0.1. Git clone via shell-out.                                                                                                          |
+| `auth`      | Reused from v0.1. Token resolution unchanged.                                                                                                       |
+| `install`   | v0.1 logic. Phase 3 replaces with SSOT-pipeline install over `generate/`.                                                                           |
+| `lockfile`  | v0.1 schema. Phase 3 replaces with `.upskill.lock` (per-project) and `~/.upskill/installed.json` (per-user); v0.1 lockfile read once for migration. |
+| `agent`     | v0.1 symlink/copy targets. Phase 3 retires in favour of per-client output paths from the format spec.                                               |
+| `search`    | v0.1 skills.sh API. Carries forward unchanged.                                                                                                      |
 
-Rule: only `main.rs` and `ui.rs` write to stdout/stderr. All other modules
-return data structures or `Result`; presentation is in `main.rs`.
+## 3. Generation pipeline internals
 
-## 3. Data structures
+Per [ADR-0003](./adr/0003-generation-pipeline.md). Pure rendering: SSOT model
+→ per-client markdown string. No filesystem writes — those land in Phase 3.
 
-### 3.1 Source types (`source.rs`)
-
-```rust
-pub enum InstallSource {
-    Github(GithubRepo),
-    Gitlab(GitlabRepo),
-    LocalPath(PathBuf),
-}
-
-pub struct GithubRepo {
-    pub owner: String,
-    pub name: String,
-    pub git_ref: Option<String>,    // owner/repo@ref
-    pub subfolder: Option<String>,  // owner/repo:path
-}
-
-pub struct GitlabRepo {
-    pub host: String,               // "gitlab.com" or custom
-    pub owner: String,
-    pub name: String,
-    pub git_ref: Option<String>,
-    pub subfolder: Option<String>,
-}
-
-#[derive(Debug, Error)]
-pub enum SourceParseError { ... }
+```text
+SSOT file (RULE.md / SKILL.md / AGENT.md)
+  │
+  ▼
+parse::frontmatter::extract  (split --- frontmatter from body)
+  │
+  ▼
+serde_yaml_ng → model::{Rule, Skill, Agent}
+  │
+  ▼
+generate::render_{rule,skill,agent}(item, body, Client)
+  │
+  ├── directives::process(body, client)   process @client conditionals
+  ├── {claude,copilot,opencode}::*_frontmatter(item)   build YAML
+  └── format::format_markdown(combined)   dprint formatter
+       │
+       ▼
+    String (idempotent under dprint)
 ```
 
-### 3.2 Agent table (`agent.rs`)
+### 3.1 The `Client` enum
 
-```rust
-struct AgentDef {
-    name: &'static str,       // "claude"
-    skill_link: &'static str, // ".claude/skills"
-}
+`generate::Client` has three variants — `Claude`, `Copilot`, `OpenCode`. Each
+client owns one module (`claude.rs`, `copilot.rs`, `opencode.rs`) that
+implements `*_frontmatter(item)` for each kind. The dispatch lives in
+`generate::render_*`.
 
-const AGENT_DEFS: [AgentDef; 7] = [
-    AgentDef { name: "claude",    skill_link: ".claude/skills"    },
-    AgentDef { name: "copilot",   skill_link: ".github/skills"    },
-    AgentDef { name: "codex",     skill_link: ".codex/skills"     },
-    AgentDef { name: "cursor",    skill_link: ".cursor/skills"    },
-    AgentDef { name: "kiro",      skill_link: ".kiro/skills"      },
-    AgentDef { name: "windsurf",  skill_link: ".windsurf/skills"  },
-    AgentDef { name: "opencode",  skill_link: ".opencode/skills"  },
-];
-```
+### 3.2 Frontmatter mapping rules
 
-### 3.3 Lockfile types (`lockfile.rs`)
+Per format-spec Appendix B and ADR-0003 §"Per-client output paths":
 
-```rust
-#[derive(Serialize, Deserialize)]
-pub struct Lockfile {
-    pub skills: Vec<LockedSkill>,
-}
+- **Claude.** `name`, `description`, plus extended Agent Skills fields. Rules
+  emit `paths:` array from `scope.paths`. Agents emit `model`, `tools`
+  (capitalized), `skills:` (renamed from `preload-skills`).
+- **Copilot.** `name`, `description`. Rules emit `applyTo:` (comma-joined
+  from `scope.paths`, default `"**"`). Agents emit `tools` filtered by the
+  documented §4 capability mapping (unmapped tools dropped, not
+  passed through). `copilot.*` passthrough block merged when present.
+- **opencode.** `name`, `description`. Rules drop scope (no per-rule scoping
+  in opencode). Agents emit `mode` (default `subagent`), `model`,
+  `permission` (capability → allow map; `write` rolls into `edit`). `name` is
+  in the filename per Appendix B and not emitted in agent frontmatter.
 
-#[derive(Serialize, Deserialize)]
-pub struct LockedSkill {
-    pub name: String,
-    pub source: String,             // "github:owner/repo@ref"
-    #[serde(rename = "ref")]
-    pub git_ref: Option<String>,
-    pub hash: Option<String>,       // SHA-256 of all files in skill dir
-}
-```
+### 3.3 Idempotence (dprint embedding)
 
-**File locations:**
+`format::format_markdown` calls
+`dprint-plugin-markdown::format_text(combined, &cfg, |_, _, _| Ok(None))`.
+Notes:
 
-| Scope   | Path                       |
-| ------- | -------------------------- |
-| Project | `{cwd}/.upskill-lock.json` |
-| Global  | `~/.upskill-lock.json`     |
+- Returns `Ok(None)` when input was already canonical — must be unwrapped to
+  the original string, not panicked on.
+- Default `text_wrap` is `Maintain`; we leave it that way to avoid surprising
+  body re-wrapping.
+- Code-block callback returns `Ok(None)` to leave fenced blocks untouched.
 
-## 4. Algorithms
+## 4. Key conventions
 
-### 4.1 Source parsing (`source.rs`)
+- **Error handling.** `anyhow::Result<T>` with `.with_context()` everywhere
+  except `source.rs`, which uses `thiserror` for typed `SourceParseError`
+  (callers branch on the error variant).
+- **`main.rs` only does I/O orchestration.** Call modules, handle errors,
+  print results. Business logic lives in library modules.
+- **Only `main.rs` and `ui.rs` write to stdout/stderr.** Every other module
+  returns data structures or `Result<T>`.
+- **Zero warnings.** Compiler, clippy, docs tooling. `-D warnings` enforced
+  in CI.
+- **Clippy `too_many_arguments`.** Group related flags into structs (e.g.
+  `AddContext`) when a function would exceed 7 params.
+- **No comments explaining what code does.** Comments only for the WHY of
+  non-obvious logic.
 
-Input: raw string from CLI argument.
+## 5. Testing strategy
 
-```
-parse_install_source(input: &str) -> Result<InstallSource, SourceParseError>
+### 5.1 Unit tests
 
-1. if input starts with "./", "../", "/", "~"
-     → InstallSource::LocalPath(PathBuf::from(input))
+Live alongside modules. Coverage focuses on pure logic:
 
-2. if input starts with "gitlab:" or is a URL with a gitlab host
-     → parse owner/repo, optional @ref and :subfolder
-     → InstallSource::Gitlab(GitlabRepo { host, owner, name, git_ref, subfolder })
+- `source.rs` — parsing exhaustively (every format variant, every error).
+- `model/` — round-trip serde for each item kind, schema-version handling.
+- `parse/frontmatter.rs` — delimiter edge cases, missing/malformed YAML.
+- `generate/{claude,copilot,opencode}.rs` — frontmatter mapping per kind.
+- `generate/directives.rs` — conditional block parsing, negation, nesting.
+- `generate/format.rs` — dprint idempotence on already-formatted input.
+- `lockfile.rs`, `auth.rs` — flag resolution, env-var precedence, etc.
 
-3. if input starts with "https://github.com/"
-     → extract owner/repo from URL
-     → parse optional @ref and :subfolder
-     → InstallSource::Github(GithubRepo { ... })
+### 5.2 Integration tests
 
-4. if input matches owner/repo pattern (with optional @ref and :subfolder)
-     → InstallSource::Github(GithubRepo { ... })
-
-5. else: SourceParseError
-```
-
-**Ref and subfolder extraction:**
+Live in `tests/` as one file per concern:
 
 ```
-input: "owner/repo@v1.0:skills/my-tool"
-         ^^^^^^^^^^  ^^^^  ^^^^^^^^^^^^^^
-         owner/repo   ref   subfolder
-
-Split on "@" first (max 2 parts).
-Split remainder on ":" (max 2 parts).
+tests/
+├── cli_add.rs           v0.1 add behaviour
+├── cli_check.rs         v0.1 check
+├── cli_ci_mode.rs       TTY detection, no-color, no-prompt
+├── cli_dryrun.rs        --dry-run for update
+├── cli_exit_codes.rs    0 / 1 / 2 / 130
+├── cli_gitlab.rs        GitLab fetch and auth
+├── cli_global.rs        --global scope
+├── cli_list.rs
+├── cli_lockfile.rs      v0.1 lockfile read/write
+├── cli_moddetect.rs     content-hash drift detection
+├── cli_remove.rs
+├── cli_search.rs        skills.sh API
+├── cli_update.rs
+│
+├── generate_skills.rs   render_skill across all clients
+├── generate_rules.rs    render_rule across all clients
+├── generate_agents.rs   render_agent across all clients
+│
+└── fixtures/            golden SSOT files and expected per-client output
 ```
 
-### 4.2 Authentication (`auth.rs`)
+Pattern: `assert_cmd::Command::cargo_bin("upskill")` + `tempfile::TempDir`.
 
-```
-resolve_github_token() -> GitHubAuth
+When adding behaviour, prefer extending the matching file or creating a new
+`cli_<area>.rs` / `generate_<kind>.rs`.
 
-1. env::var("GITHUB_TOKEN") → GitHubAuth::Token(token)
-2. env::var("GH_TOKEN")     → GitHubAuth::Token(token)
-3. Command::new("gh").args(["auth", "token"])
-   → if exit 0 and non-empty stdout → GitHubAuth::Token(stdout.trim())
-4. GitHubAuth::None
-```
+## 6. Build and verify
 
-Same pattern for GitLab with `GITLAB_TOKEN`, `GL_TOKEN`, `glab auth token`.
-
-### 4.3 Fetch (`fetch.rs`)
-
-```
-clone_github_repo(repo: &GithubRepo, auth: &GitHubAuth) -> Result<TempDir>
-
-1. url = "https://github.com/{owner}/{repo}.git"
-   if token: inject credentials via GIT_ASKPASS or token URL
-
-2. shallow_clone(url, git_ref, tmpdir)
-   → git clone --depth 1 [--branch ref] url tmpdir/repo
-
-3. if subfolder: resolve_subfolder(tmpdir/repo, subfolder)
-
-4. return tmpdir (caller keeps alive)
+```bash
+just assemble    # cargo build
+just test        # cargo test
+just lint        # cargo clippy + fmt --check + dprint check
+just check       # test + lint
+just build       # assemble + check
+just verify      # commit check + build (run before opening a PR)
+just fmt         # cargo fmt + dprint fmt
 ```
 
-Same structure for `clone_gitlab_repo`.
+After `git clone` or `git worktree add`, run `./bootstrap` once. It installs
+`git-std` from `driftsys/git-std` and runs `git std bootstrap`. Release
+tagging (`just release`) uses `git std bump`.
 
-### 4.4 Agent resolution (`agent.rs`)
+## 7. References
 
-```
-ensure_agent_targets(claude, copilot, all, copy, canonical_target) -> Result<()>
-
-if all:
-  → create_agent_target for every entry in AGENT_DEFS
-
-else if claude || copilot:
-  → create_agent_target only for flagged agents
-
-else (auto-detect):
-  → for each agent in AGENT_DEFS:
-      parent = agent.skill_link parent directory (e.g. ".claude")
-      if parent.exists():
-        → create_agent_target(agent.skill_link, copy, canonical_target)
-```
-
-`create_agent_target` either creates a symlink (Unix) or copies the directory
-(`--copy` mode). Non-Unix platforms require `--copy`.
-
-### 4.5 Install (`install.rs`)
-
-```
-canonical_target(global) -> Result<PathBuf>
-  → if global: $HOME/.agents/skills
-  → else: .agents/skills (relative to CWD)
-
-persist_installed_skills(canonical_target, skills, source_label) -> Result<()>
-  → for each skill:
-      mkdir -p canonical_target/skill
-      write canonical_target/skill/.upskill-source = source_label
-
-resolve_requested_skills(cli_skills, default_skill) -> Result<Vec<String>>
-  → if --skill flags given: return those
-  → else if TTY: prompt for comma-separated selection
-  → else: return [default_skill]
-```
-
-### 4.6 Lockfile (`lockfile.rs`)
-
-**Content hash** (for modification detection):
-
-```
-hash_skill_dir(dir: &Path) -> Option<String>
-
-Walk all files in dir, sorted by relative path.
-For each file: feed (relative_path + file_content) into SHA-256.
-Return hex digest.
-```
-
-**Upsert on install:**
-
-```
-lockfile.upsert(LockedSkill { name, source, git_ref, hash })
-  → remove existing entry with same name
-  → push new entry
-  → sort by name (deterministic output)
-  → save to disk
-```
-
-### 4.7 Error handling
-
-All non-parsing functions return `anyhow::Result<T>`. Errors are chained:
-
-```rust
-std::fs::read_to_string(&path)
-    .with_context(|| format!("failed to read {}", path.display()))?;
-```
-
-`source.rs` uses `thiserror` for `SourceParseError` because callers match on
-specific parse failures.
-
-`main()` translates `Result` to exit codes:
-
-| Outcome       | Exit code |
-| ------------- | --------- |
-| Success       | 0         |
-| General error | 1         |
-| Usage error   | 2         |
-| SIGINT        | 130       |
-
-## 5. CLI structure (`main.rs`)
-
-```rust
-#[derive(Parser)]
-#[command(name = "upskill", about = "Upskill your coding agents")]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    Add {
-        source: String,
-        #[arg(long = "skill", short = 's')] skills: Vec<String>,
-        #[arg(long)] claude: bool,
-        #[arg(long)] copilot: bool,
-        #[arg(long)] all: bool,
-        #[arg(long)] copy: bool,
-        #[arg(short = 'g', long = "global")] global: bool,
-    },
-    List   { #[arg(short = 'g', long = "global")] global: bool },
-    Remove { skill: String, #[arg(long)] yes: bool, #[arg(short = 'g')] global: bool },
-    Check  { #[arg(short = 'g', long = "global")] global: bool },
-    Update { names: Vec<String>, #[arg(long = "dry-run")] dry_run: bool,
-             #[arg(short = 'f')] force: bool, #[arg(short = 'g')] global: bool },
-}
-```
-
-Agent flags are grouped into `AddContext` inside `run_add` to keep `finish_install`
-under clippy's argument limit.
-
-## 6. Command dispatch flow
-
-### 6.1 `add` flow
-
-```
-run_add
-  → parse_install_source(source_arg)
-  → resolve_requested_skills(skills, default)
-  → persist_installed_skills(canonical_target, skills, source_label)
-  → ensure_agent_targets(flags, canonical_target)          [if !global]
-  → lockfile.upsert(skill) for each skill
-  → lockfile.save()
-  → print_selected_skills(skills)
-```
-
-### 6.2 `list` flow
-
-```
-run_list
-  → read_dir(canonical_target)
-  → for each skill dir: read .upskill-source
-  → detect_active_agents()
-  → print: name  source=...  symlinks=...
-```
-
-### 6.3 `check` flow
-
-```
-run_check
-  → lockfile.load()
-  → for each skill: print name, source, pinned ref
-```
-
-### 6.4 `update` flow
-
-```
-run_update
-  → lockfile.load()
-  → filter to requested names (or all)
-  → if dry_run: print preview, return
-  → for each skill:
-      if !force: compare hash_skill_dir vs lockfile.hash
-        → if differs: warn and skip
-      persist_installed_skills(canonical_target, [skill], source)
-```
-
-### 6.5 `remove` flow
-
-```
-run_remove
-  → confirm_removal if TTY and !--yes
-  → remove_dir_all(canonical_target/skill)
-  → lockfile.remove(skill)
-  → cleanup_agent_symlinks_if_empty(canonical_target)
-```
-
-## 7. Testing strategy
-
-### 7.1 Unit tests
-
-| Module        | What to test                                            |
-| ------------- | ------------------------------------------------------- |
-| `source.rs`   | Parsing all source formats, edge cases, error messages. |
-| `agent.rs`    | Flag resolution, auto-detect logic.                     |
-| `lockfile.rs` | Read/write/upsert, content hash computation.            |
-| `auth.rs`     | Env var resolution order (mock env).                    |
-| `fetch.rs`    | Clone with subfolder, copy, cleanup.                    |
-
-`source.rs` is pure — no I/O, easy to test exhaustively.
-
-### 7.2 Integration tests
-
-CLI integration tests live in `tests/cli_*.rs` and use `assert_cmd` +
-`tempfile`. Each test creates an isolated temp directory and runs the binary:
-
-```rust
-Command::cargo_bin("upskill")
-    .unwrap()
-    .current_dir(&tmp)
-    .args(["add", "owner/repo", "--claude"])
-    .assert()
-    .success();
-```
-
-Test files by area: `cli_add`, `cli_list`, `cli_remove`, `cli_check`,
-`cli_update`, `cli_lockfile`, `cli_moddetect`, `cli_dryrun`, `cli_global`,
-`cli_gitlab`, `cli_ci_mode`, `cli_exit_codes`, `cli_search`.
-
-## 8. Planned (v0.4+)
-
-Features not yet implemented but tracked in the backlog:
-
-- **Skill discovery** (`skill.rs`) — `SKILL.md` frontmatter scanning, validation, name/description extraction.
-- **Custom registries** (`registry.rs`) — `.upskill/registries.toml` for project and global registry config.
-- **Named registry install** — `upskill add <registry> --skill <name>`.
-- **Local search cache** — 1-hour TTL cache per registry in platform cache dir (relevant once git-based registries are added).
+- Behavioural spec: [`docs/specification.md`](./specification.md)
+- Format contract: [`docs/format-spec.md`](./format-spec.md)
+- Architecture decisions: [`docs/adr/`](./adr/README.md)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2,482 +2,262 @@
 
 > Upskill your coding agents.
 
+**Status**: v0.2 design (in progress). Phases 0–2 implemented; Phase 3+ pending
+— see [§7 Implementation status](#7-implementation-status).
+
 ## 1. Overview
 
-`upskill` is a cross-agent skills package manager for the
-[Agent Skills][agent-skills-spec] ecosystem. It installs,
-lists, searches, removes, and scaffolds `SKILL.md` packages across all major
-coding agents from a single static Rust binary.
+`upskill` is a single-binary CLI that lets authors **create, manage, and
+prolong** AI-assistance content — rules, skills, agents — across multiple AI
+coding clients (Claude Code, GitHub Copilot, opencode) from a single source of
+truth.
 
-### 1.1 Design principles
+The central abstraction is **generation**: the SSOT (Single Source of Truth)
+on disk is portable; per-client output is produced on demand by a generation
+pipeline. v0.1's fetch-and-copy installer model is replaced with this
+SSOT-to-client pipeline; see [ADR-0001](./adr/0001-multi-kind-compiler-architecture.md)
+for the umbrella decision.
 
-- **Canonical target**: `.agents/skills/` is always the install destination.
-  Agent-specific directories receive symlinks.
-- **Zero runtime**: single static binary, no Node.js, no Python, no npm, no npx.
-- **Any repo is a registry**: any GitHub repository containing `SKILL.md` files
-  is a valid source. No central registry required.
-- **Human-first CLI**: compliant with [clig.dev][clig] guidelines,
-  POSIX conventions, and GNU flag standards.
-- **Minimal footprint**: ~2-3 MB binary, instant startup, no background
-  processes, no telemetry.
+### 1.1 Three item kinds
 
-### 1.2 Features
+| Kind  | Purpose                             | Entrypoint file |
+| ----- | ----------------------------------- | --------------- |
+| Rule  | Always-on behavioural guidance.     | `RULE.md`       |
+| Skill | On-demand procedural content.       | `SKILL.md`      |
+| Agent | Persona definition with tool scope. | `AGENT.md`      |
 
-- [x] **Install from GitHub/GitLab** — fetch via `git clone --depth 1`; supports
-      GitHub shorthand, GitLab prefix, full URLs, self-hosted GitLab
-- [x] **Canonical `.agents/skills/` target** — always install to the cross-agent
-      standard directory
-- [x] **Agent symlinks** — auto-detect or explicitly target Claude Code (`--claude`)
-      and Copilot (`--copilot`); `--all` targets all 7 supported agents
-- [x] **Selective install** — pick specific skills by name (`--skill`) or
-      interactive multi-select in a TTY
-- [x] **Install from local path** — use a local directory as source for testing
-      or monorepo workflows
-- [x] **List installed skills** — show name, source, and symlink status (`list`)
-- [x] **Remove skills** — clean removal of canonical copy and all agent symlinks
-      (`remove`)
-- [x] **Global install** — install to `~/.agents/skills/` for cross-project
-      availability (`-g`)
-- [x] **CI-friendly mode** — no prompts in non-TTY, TTY detection for color
-- [x] **Lockfile** — track installed skills with source, pinned ref, and content hash
-- [x] **Branch/tag/commit pinning** — install a specific ref with `owner/repo@v1.0`
-- [x] **Private repos** — authenticate via `GITHUB_TOKEN` / `GITLAB_TOKEN` env
-      vars, or reuse existing `gh` / `glab` CLI login
-- [x] **Update** — re-fetch skills from their recorded source; hash-based local
-      modification detection skips modified skills unless `--force` is passed
-- [x] **Registry search** — `upskill search <query>` hits the skills.sh public API
-- [ ] **Custom registries** — configure private or internal skill sources via
-      `.upskill/registries.toml` (v0.4)
+The on-disk contract is defined by the [portable format spec](./format-spec.md).
+This document describes upskill's behaviour against that contract.
 
-## 2. Installation
+### 1.2 Two scopes
 
-```bash
-# From crates.io
-cargo install upskill
+| Scope   | Lives at         | Use                                            |
+| ------- | ---------------- | ---------------------------------------------- |
+| Project | `<cwd>/.agents/` | Content shared across the team via git.        |
+| Global  | `$HOME/.agents/` | Content available to a single user, all repos. |
 
-# From source
-git clone https://github.com/TODO/upskill
-cd upskill
-cargo install --path .
+### 1.3 Two roles
 
-# Pre-built binary (GitHub Releases)
-curl -fsSL https://github.com/TODO/upskill/releases/latest/download/upskill-$(uname -m)-$(uname -s | tr A-Z a-z) -o ~/.local/bin/upskill
-chmod +x ~/.local/bin/upskill
+Per [ADR-0004](./adr/0004-cli-surface.md):
+
+- **Source registry** — repository where SSOT items are authored. Holds the
+  canonical `RULE.md` / `SKILL.md` / `AGENT.md` files. Author commands
+  (`new`, `lint`, `fmt`) operate here.
+- **Consumer project** — repository where generated outputs are installed
+  for use by AI clients. Holds only generated per-client files. Consumer
+  commands (`add`, `remove`, `update`, `list`, `info`, `doctor`) operate
+  here.
+
+The same repository can be both, but SSOT and generated outputs do not mix
+in the same tree.
+
+## 2. CLI surface
+
+Per [ADR-0004](./adr/0004-cli-surface.md). Nine commands, no overlap.
+
+| Command  | Role     | Purpose                                                 |
+| -------- | -------- | ------------------------------------------------------- |
+| `add`    | Consumer | Install content from any source.                        |
+| `remove` | Consumer | Remove installed content.                               |
+| `update` | Consumer | Pull latest, regenerate changed items.                  |
+| `list`   | Consumer | Show installed content (or `--available` from sources). |
+| `info`   | Consumer | Show item or bundle details.                            |
+| `doctor` | Consumer | Verify installation consistency.                        |
+| `new`    | Author   | Scaffold a new rule, skill, or agent.                   |
+| `lint`   | Author   | Validate SSOT files against the format spec.            |
+| `fmt`    | Author   | Canonicalise YAML frontmatter (key order, quoting).     |
+
+### 2.1 `add`
+
+```text
+upskill add <source> [items...] [--global|--project]
 ```
 
-Uninstall: `cargo uninstall upskill` or delete the binary.
+`<source>` accepts (per [ADR-0005](./adr/0005-skills-sh-ecosystem-interop.md),
+parity with `npx skills add`):
 
-## 3. Commands
+- `owner/repo` — GitHub shorthand
+- `owner/repo@ref` — pinned ref (branch, tag, or commit SHA)
+- `owner/repo:path/to/item` — subfolder
+- `owner/repo@ref:path` — combined
+- `https://github.com/owner/repo[...]` — full HTTPS URL
+- `gitlab:owner/repo[...]` or `https://gitlab.com/[...]` — GitLab
+- `./path`, `../path`, `/abs/path`, `~/path` — local paths
+- `<bundle-name>` — a bundle resolved from configured registries
 
-### 3.1 `upskill add` — install skills
+Source resolution order: registry index first; if no match, treat as git repo
+or local path.
 
-```
-upskill add <source> [options]
-```
+`upskill add <source>` installs everything the source contains. Optional
+`items...` after the source filter to a subset. There is no interactive
+picker; install-all-by-default fits bundle curation.
 
-**Source formats:**
+Default scope is `--project` (write into the current repo's `.agents/...`),
+falling back to `--global` (`$HOME/.agents/...`) when the current directory
+is not inside a git repo. Either flag can be passed explicitly.
 
-| Format                  | Example                                |
-| ----------------------- | -------------------------------------- |
-| GitHub repo             | `microsoft/skills`                     |
-| GitHub repo + subfolder | `owner/repo:skills/my-tool`            |
-| Local directory         | `./path/to/skills` or `/absolute/path` |
+### 2.2 `update`
 
-**Options:**
-
-| Flag          | Short | Description                                    |
-| ------------- | ----- | ---------------------------------------------- |
-| `--skill <n>` | `-s`  | Specific skill name(s) to install. Repeatable. |
-| `--all`       |       | Symlink to all 7 supported agent directories.  |
-| `--global`    | `-g`  | Install to `~/.agents/skills/` (user-level).   |
-| `--copy`      |       | Independent copies instead of symlinks.        |
-| `--claude`    |       | Symlink to `.claude/skills/`.                  |
-| `--copilot`   |       | Symlink to `.github/skills/`.                  |
-
-No explicit flag: auto-detect from existing agent config directories in CWD.
-
-**Behavior:**
-
-1. Fetch the source (`git clone --depth 1` for GitHub/GitLab, direct read for
-   local).
-2. Resolve the subfolder if `:path` was specified.
-3. Select skills: `--skill <n>`, interactive prompt in a TTY, or default to repo
-   name in CI.
-4. Copy to `.agents/skills/<name>/` (canonical target).
-5. Create agent-specific symlinks:
-   - If `--claude` or `--copilot` flags given → symlink only those.
-   - If `--all` → symlink all 7 supported agent dirs.
-   - If no flags → auto-detect: walk CWD for existing agent config dirs, symlink
-     those.
-6. Write/update `.upskill-lock.json` with source, pinned ref, and content hash.
-7. For `--global`: install to `~/.agents/skills/`, no agent symlinks created.
-
-**Examples:**
-
-```bash
-# Interactive selection, auto-detect agents
-upskill add microsoft/skills
-
-# Specific skill, specific agents
-upskill add owner/repo --skill markspec --claude --cursor
-
-# List available skills
-upskill add microsoft/skills --list
-
-# CI-friendly
-upskill add owner/repo --skill my-skill --claude -y
-
-# From local path
-upskill add ./my-local-skills --skill my-tool
-
-# Global install
-upskill add owner/repo -s azure-cosmos-db-py -g --claude
+```text
+upskill update [name...] [--global|--project] [--dry-run]
 ```
 
-### 3.2 `upskill list` — list installed skills
+Always fetches the latest source before regenerating. Absorbs the role of a
+separate `sync` command — there is no `--offline` flag in v1; offline use is
+covered by passing local paths to `add` / `update`.
 
-```
-upskill list [options]
-```
+`update` covers two distinct behaviours:
 
-| Flag       | Short | Description              |
-| ---------- | ----- | ------------------------ |
-| `--global` | `-g`  | Show global skills only. |
+- **Absorb client drift.** When Copilot or Claude Code change a path or
+  frontmatter field, `update` regenerates outputs from the same SSOT.
+- **Track upstream evolution.** `update` git-pulls source repos and
+  regenerates items whose source hash changed.
 
-Lists all skills found in `.agents/skills/` (project) or `~/.agents/skills/`
-(global), with name, description, and symlink status.
+### 2.3 `remove`
 
-### 3.3 `upskill search` — search for skills
-
-```
-upskill search <query> [options]
+```text
+upskill remove [name...] [--global|--project]
 ```
 
-| Flag      | Default | Description                |
-| --------- | ------- | -------------------------- |
-| `--limit` | `10`    | Maximum number of results. |
+Removes installed items from the matching scope. Without arguments,
+implementations may prompt or require an explicit name list.
 
-Queries the [skills.sh](https://skills.sh) public search API (no auth required).
+### 2.4 `list` / `info` / `doctor`
 
-```
-$ upskill search rust
-rust-mcp-server-generator    7608 installs    upskill add awesome-copilot --skill rust-mcp-server-generator
-rust-analyzer                3200 installs    upskill add anthropics/skills --skill rust-analyzer
-```
+- `list [--available]` — show installed content, or available content from
+  configured sources.
+- `info <name>` — show item or bundle details (resolved source, version,
+  hash, generated paths).
+- `doctor` — verify on-disk state matches the lock file; report drift.
 
-Each result includes the install command to copy-paste directly.
+### 2.5 `new` / `lint` / `fmt`
 
-**Custom registries** (v0.4): once `.upskill/registries.toml` is supported,
-`upskill search` will also query configured private registries.
+Author commands. Run inside a source-registry working tree.
 
-### 3.4 `upskill remove` — remove skills
+- `new <kind> <name>` — scaffold a new SSOT item directory (`<kind>` is one
+  of `rule`, `skill`, `agent`).
+- `lint [paths...] [--strict]` — validate SSOT files. `--strict` is the CI
+  mode (warnings become errors).
+- `fmt [paths...]` — canonicalise YAML frontmatter only. Markdown body
+  formatting is dprint's responsibility.
 
-```
-upskill remove [name...] [options]
-```
+### 2.6 Aliases
 
-| Flag       | Description                  |
-| ---------- | ---------------------------- |
-| `--all`    | Remove all installed skills. |
-| `--global` | Target global scope.         |
+`add` does **not** alias to `install`. `remove` does **not** alias to
+`uninstall`. v0.1's `install` and `uninstall` verbs are dropped — the unified
+verb names are canonical. Migration is covered in v0.2.0 release notes.
 
-Removes the skill directory from `.agents/skills/` and any symlinks in
-agent-specific directories. Without arguments: interactive multi-select.
+## 3. Generation pipeline
 
-### 3.5 `upskill check` — show lockfile state
+Per [ADR-0003](./adr/0003-generation-pipeline.md). SSOT → per-client output
+runs on the developer's machine, on every install or update. No CI generation
+step. No committed `dist/` artifacts.
 
-```
-upskill check [options]
-```
+### 3.1 Per-client output paths
 
-| Flag       | Description               |
-| ---------- | ------------------------- |
-| `--global` | Check global skills only. |
+| Item kind | Claude Code                             | GitHub Copilot                                                | opencode                                           |
+| --------- | --------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| Rule      | `.claude/rules/<name>.md` with `paths:` | `.github/instructions/<name>.instructions.md` with `applyTo:` | `.agents/rules/<name>/RULE.md` (canonical-store)   |
+| Skill     | `.claude/skills/<name>/SKILL.md`        | `.github/skills/<name>/SKILL.md`                              | `.agents/skills/<name>/SKILL.md` (canonical-store) |
+| Agent     | `.claude/agents/<name>.md`              | `.github/agents/<name>.agent.md`                              | `.opencode/agents/<name>.md`                       |
 
-Reads `.upskill-lock.json` and prints each skill's recorded source and pinned ref.
+Per-client frontmatter mapping is defined in [format-spec §7](./format-spec.md#7-generation-client-specific-output)
+and Appendix B; behaviour rationale is in
+[ADR-0003](./adr/0003-generation-pipeline.md).
 
-```
-$ upskill check
-my-skill    github:owner/repo    pinned: latest
-other-skill github:owner/repo    pinned: v1.2
-```
+### 3.2 Copy, not symlink
 
-Does not make any network requests — use `upskill update` to re-fetch.
+All installation is file copy or generated output. No symlinks anywhere. One
+code path; Windows portability without Developer Mode or
+`core.symlinks=true`. The deliberate divergence from skills.sh's symlink
+default is documented in
+[ADR-0005](./adr/0005-skills-sh-ecosystem-interop.md).
 
-### 3.6 `upskill update` — re-install skills from recorded sources
+### 3.3 Markdown formatting
 
-```
-upskill update [name...] [options]
-```
+Generated output passes through embedded `dprint-plugin-markdown`
+(exact-pinned at `=0.21.1`) before writing. This guarantees idempotence under
+the same formatter in `dprint.json`. Authors who run `dprint` locally see no
+diffs on generated files. Rationale and version-pin discipline are in
+[ADR-0003](./adr/0003-generation-pipeline.md).
 
-| Flag        | Description                              |
-| ----------- | ---------------------------------------- |
-| `--global`  | Update global skills only.               |
-| `--force`   | Overwrite locally modified skills.       |
-| `--dry-run` | Show what would change without applying. |
+### 3.4 Ancillary file handling
 
-**Behavior:**
+Three files outside the per-item path tree are managed idempotently:
 
-1. Load `.upskill-lock.json`.
-2. Filter to requested names (or all if none given).
-3. If `--dry-run`: print what would be updated and return.
-4. For each skill:
-   - Compare SHA-256 content hash against the lockfile's stored hash.
-   - If hash differs and `--force` is not set: warn and skip.
-   - Otherwise: re-run `persist_installed_skills` from the recorded source.
-5. Print updated skill names; warn about skipped skills.
+- **`CLAUDE.md`** at repo root — created once with `@AGENTS.md` content if
+  absent. Never overwritten.
+- **`.vscode/settings.json`** — `chat.instructionsFilesLocations` is set;
+  other keys preserved.
+- **`opencode.json`** — managed only on **first** opencode-rule install.
+  The entry `".agents/rules/**/RULE.md"` is added to `instructions[]` if not
+  already present, then the file is never mutated again. opencode's glob
+  picks up subsequent rule additions and removals automatically.
 
-```
-$ upskill update
-updated: my-skill
-warning: other-skill has local modifications, skipping (use --force to overwrite)
-1 skill(s) skipped due to local modifications
-```
+## 4. State files
 
-**`--dry-run` output:**
+Per [ADR-0003](./adr/0003-generation-pipeline.md). State is split between
+two files, both schema-versioned (`schema: 1`).
 
-```
-$ upskill update --dry-run
-dry-run: would update my-skill from github:owner/repo (latest)
-```
+### 4.1 `.upskill.lock` (per-project, committed)
 
-## 4. Agent directory conventions
+Lives at the consumer-project root. Records what was installed, from where,
+at what resolved git ref, with what content hashes. Plays the same role as
+`package-lock.json`: deterministic regeneration on another developer's
+machine and in CI.
 
-### 4.1 Canonical install path
-
-All skills are always installed to:
-
-| Scope   | Path                       |
-| ------- | -------------------------- |
-| Project | `.agents/skills/<name>/`   |
-| Global  | `~/.agents/skills/<name>/` |
-
-### 4.2 Agent-specific symlinks
-
-| Agent       | Project symlink target    | Global symlink target               | Reads `.agents/` natively |
-| ----------- | ------------------------- | ----------------------------------- | ------------------------- |
-| Claude Code | `.claude/skills/<name>`   | `~/.claude/skills/<name>`           | No (planned)              |
-| Copilot     | `.github/skills/<name>`   | `~/.copilot/skills/<name>`          | Yes                       |
-| Codex       | `.codex/skills/<name>`    | `~/.codex/skills/<name>`            | Yes                       |
-| Cursor      | `.cursor/skills/<name>`   | `~/.cursor/skills/<name>`           | No                        |
-| Kiro        | `.kiro/skills/<name>`     | `~/.kiro/skills/<name>`             | No                        |
-| Windsurf    | `.windsurf/skills/<name>` | `~/.codeium/windsurf/skills/<name>` | Yes                       |
-| OpenCode    | `.opencode/skills/<name>` | `~/.config/opencode/skills/<name>`  | Yes                       |
-
-### 4.3 Symlink resolution order
-
-1. Explicit flags (`--claude`, `--cursor`, ...) → create those symlinks only.
-2. `--all` → create symlinks for all known agents.
-3. No flags → auto-detect: walk the project root for existing agent directories
-   (`.claude/`, `.github/`, `.cursor/`, etc.). Create symlinks only for those
-   found.
-
-### 4.4 Directory creation policy
-
-- `upskill` creates `.agents/skills/` if it does not exist.
-- `upskill` creates `<agent>/skills/` if `<agent>/` already exists.
-- `upskill` never creates an agent config directory from scratch (e.g., will not
-  create `.claude/` — only `.claude/skills/` if `.claude/` exists).
-
-### 4.5 Symlink vs copy
-
-Default: symlinks from agent dirs to `.agents/skills/`. One source of truth,
-updates propagate.
-
-`--copy`: independent copies in each agent dir. Use when symlinks are not
-supported (Windows without developer mode, read-only container mounts).
-
-## 5. Source fetch
-
-### 5.1 Source format
-
-The `<source>` argument determines where skills are fetched from. `upskill`
-detects the source type from the format of the string:
-
-| Format                          | Source type | Example                                         |
-| ------------------------------- | ----------- | ----------------------------------------------- |
-| `owner/repo`                    | GitHub      | `microsoft/skills`                              |
-| `owner/repo:path`               | GitHub      | `owner/repo:skills/my-tool`                     |
-| `owner/repo@ref`                | GitHub      | `owner/repo@v1.0` (v0.2)                        |
-| `owner/repo@ref:path`           | GitHub      | `owner/repo@main:skills/my-tool` (v0.2)         |
-| `https://github.com/owner/repo` | GitHub      | Full URL, same behavior as `owner/repo`         |
-| `https://gitlab.com/owner/repo` | GitLab      | Full GitLab URL (v0.2)                          |
-| `gitlab:owner/repo`             | GitLab      | Short prefix form (v0.2)                        |
-| `./path`, `/path`, `~/path`     | Local       | `./my-skills`, `/opt/skills`, `~/dev/my-skills` |
-
-**Detection rules** (evaluated in order):
-
-1. Starts with `./`, `../`, `/`, or `~` → **local path**.
-2. Starts with `https://github.com/` → **GitHub URL**, extract `owner/repo` from
-   path.
-3. Starts with `https://gitlab.com/` or `gitlab:` → **GitLab** (v0.2).
-4. Starts with `https://` → **unsupported host**, error with message.
-5. Matches `{owner}/{repo}` (with optional `@ref` and `:path`) → **GitHub
-   shorthand**.
-6. Otherwise → error.
-
-### 5.2 GitHub fetch
-
-**Mechanism:** `git clone --depth 1` into a temporary directory. Requires `git`
-on PATH. The clone is cleaned up after install.
-
-```
-git clone --depth 1 [--branch <ref>] https://github.com/{owner}/{repo}.git <tmpdir>
+```json
+{
+  "schema": 1,
+  "items": [
+    {
+      "kind": "skill",
+      "name": "code-review",
+      "source": "github:driftsys/skills",
+      "ref": "v1.2.0",
+      "hash": "sha256:..."
+    }
+  ],
+  "bundles": [
+    {
+      "name": "platform-defaults",
+      "source": "github:driftsys/bundles",
+      "ref": "v0.4.0",
+      "items": ["code-review", "secret-scanner"]
+    }
+  ]
+}
 ```
 
-**Ref support:** when `@ref` is specified, passed as `--branch <ref>`. Accepts
-branch names, tag names, and full commit SHAs.
+### 4.2 `~/.upskill/installed.json` (per-user)
 
-**Subfolder filtering:** when `:path` is specified, only the subtree at `path`
-within the cloned repo is used for install. The full shallow clone is still
-fetched.
+Tracks the user-global view: items installed at the global scope, drift
+state for the global location, and source-registry caches. Not committed.
 
-**Authentication (resolution order):**
+### 4.3 v0.1 lockfile migration
 
-| Priority | Method                 | Mechanism                                                        |
-| -------- | ---------------------- | ---------------------------------------------------------------- |
-| 1        | `GITHUB_TOKEN` env var | Injected into clone URL as `https://token@github.com/...`.       |
-| 2        | `GH_TOKEN` env var     | Same as above (matches `gh` CLI convention).                     |
-| 3        | `gh auth token` output | Shell out to `gh auth token`, use result.                        |
-| 4        | Unauthenticated        | Public repos only. Private repos fail with git credential error. |
+v0.1's per-project `.upskill-lock.json` is read once by a translator that
+produces equivalent entries in the new files. Existing v0.1 users are not
+silently broken. The translator runs on first invocation of any v0.2 command
+in a directory containing a v0.1 lockfile.
 
-The `gh` CLI fallback means: if the user already ran `gh auth login`, `upskill`
-reuses that session without any extra configuration.
+## 5. Source format and authentication
 
-### 5.3 GitLab fetch (v0.2)
+Source format: see [§2.1](#21-add).
 
-**Mechanism:** same principle, different URL format.
+Token resolution order:
 
-**URL construction:**
+| Host   | Order                                                             |
+| ------ | ----------------------------------------------------------------- |
+| GitHub | `GITHUB_TOKEN` → `GH_TOKEN` → `gh auth token` → unauthenticated   |
+| GitLab | `GITLAB_TOKEN` → `GL_TOKEN` → `glab auth token` → unauthenticated |
 
-```
-https://gitlab.com/{owner}/{repo}/-/archive/{branch}/{repo}-{branch}.tar.gz
-```
-
-**Detection:** source starts with `https://gitlab.com/` or `gitlab:` prefix.
-
-**Self-hosted GitLab:** full URL form supports arbitrary hosts:
-
-```bash
-upskill add https://gitlab.mycompany.com/team/skills-repo
-```
-
-**Authentication (resolution order):**
-
-| Priority | Method                   | Mechanism                                               |
-| -------- | ------------------------ | ------------------------------------------------------- |
-| 1        | `GITLAB_TOKEN` env var   | `PRIVATE-TOKEN` header (matches GitLab API convention). |
-| 2        | `GL_TOKEN` env var       | Same as above.                                          |
-| 3        | `glab auth token` output | Shell out to `glab auth token`, use result.             |
-| 4        | Unauthenticated          | Public repos only.                                      |
-
-### 5.4 Local path fetch
-
-**Detection:** source starts with `.`, `/`, or `~`.
-
-**Behavior:** no network request. The path is resolved to an absolute path and
-scanned directly for skills. Supports:
-
-- Relative paths: `./my-skills` (resolved from CWD).
-- Absolute paths: `/opt/company/skills`.
-- Home expansion: `~/dev/my-skills` (expanded via `dirs::home_dir()`).
-- Symlinks: followed transparently.
-
-**Use cases:**
-
-- Testing a skill before publishing.
-- Installing from a local git clone.
-- Sharing skills on a network mount or monorepo.
-
-```bash
-# From a local clone
-upskill add ~/dev/markspec
-
-# From a monorepo subfolder (: syntax not needed, just use the path)
-upskill add ./packages/markspec/skills
-
-# From a network mount
-upskill add /mnt/team-share/agent-skills
-```
-
-**Error handling:**
-
-| Condition           | Behavior                                           |
-| ------------------- | -------------------------------------------------- |
-| Path does not exist | Error: `"Source path does not exist: {path}"`.     |
-| Not a directory     | Error: `"Source path is not a directory: {path}"`. |
-| No SKILL.md found   | Warning: `"No skills found in {path}"`.            |
-| Permission denied   | Error: `"Cannot read {path}: permission denied"`.  |
-
-### 5.5 Skill discovery
-
-After the source is fetched (or resolved locally), `upskill` scans for skills:
-
-1. Walk the directory tree recursively, max depth 4.
-2. Skip `.git/` directories.
-3. For each `SKILL.md` file found: a. Parse YAML frontmatter (content between
-   first `---` pair). b. Deserialize into `SkillMeta` struct. c. Validate
-   required fields (`name`, `description`). d. On validation failure: warn to
-   stderr, skip this skill, continue.
-4. Sort discovered skills by name.
-
-**Why max depth 4:** covers all known layouts:
-
-```
-depth 1: skills/markspec/SKILL.md
-depth 2: .github/skills/markspec/SKILL.md
-depth 3: packages/foo/skills/markspec/SKILL.md
-depth 4: src/packages/foo/skills/markspec/SKILL.md
-```
-
-### 5.6 Frontmatter validation
-
-Per the [Agent Skills specification][agent-skills-spec]:
-
-| Field           | Required | Constraints                                                        |
-| --------------- | -------- | ------------------------------------------------------------------ |
-| `name`          | Yes      | 1-64 chars, lowercase alphanum + hyphens, matches parent dir name. |
-| `description`   | Yes      | 1-1024 chars, non-empty.                                           |
-| `license`       | No       | Informational.                                                     |
-| `compatibility` | No       | 1-500 chars.                                                       |
-| `metadata`      | No       | Arbitrary key-value map.                                           |
-| `allowed-tools` | No       | Experimental, passed through.                                      |
-
-**Validation strictness:** lenient. An invalid skill in one subdirectory
-produces a warning but does not abort the entire operation. Valid skills in the
-same source are still offered for installation.
-
-**Common validation failures:**
-
-| Issue                    | Severity | Message                                                 |
-| ------------------------ | -------- | ------------------------------------------------------- |
-| Missing `name`           | Error    | `"SKILL.md missing required 'name' field"`              |
-| Missing `description`    | Error    | `"SKILL.md missing required 'description' field"`       |
-| `name` has uppercase     | Warning  | `"Skill name should be lowercase: {name}"`              |
-| `name` doesn't match dir | Warning  | `"Skill name '{name}' doesn't match directory '{dir}'"` |
-| No YAML frontmatter      | Error    | `"No YAML frontmatter found in SKILL.md"`               |
-| YAML parse error         | Error    | `"Failed to parse frontmatter: {err}"`                  |
+Self-hosted GitLab is supported via full URL form
+(`https://gitlab.mycompany.com/team/repo`).
 
 ## 6. CLI compliance
 
-### 6.1 clig.dev guidelines
-
-`upskill` follows the [Command Line Interface Guidelines][clig]:
-
-| Guideline                                | Implementation                                                   |
-| ---------------------------------------- | ---------------------------------------------------------------- |
-| Human-first design                       | Natural subcommand verbs, clear `--help`, interactive fallbacks. |
-| Composability                            | Stdout for data, stderr for progress/errors. Pipe-friendly.      |
-| `--help` and `--version` on all commands | Provided by `clap` derive.                                       |
-| Standard flag names                      | `--yes`, `--all`, `--global`, `--version`, `--help`.             |
-| Short flags only for common options      | `-s` (skill), `-g` (global), `-y` (yes), `-l` (list).            |
-| Color and formatting                     | Honors `NO_COLOR` env var. Uses `console` crate for detection.   |
-| Error messages to stderr                 | All warnings and errors go to stderr via `eprintln!`.            |
-| Confirmation for destructive actions     | `remove` prompts unless `--yes` is passed.                       |
-| Single binary distribution               | Static Rust binary, no runtime dependencies.                     |
-| Easy uninstall                           | `cargo uninstall upskill` or delete binary.                      |
-
-### 6.2 Exit codes
+### 6.1 Exit codes
 
 | Code  | Meaning                              |
 | ----- | ------------------------------------ |
@@ -486,231 +266,60 @@ same source are still offered for installation.
 | `2`   | Usage error (invalid args or flags). |
 | `130` | Interrupted (Ctrl+C / SIGINT).       |
 
-### 6.3 POSIX / GNU conventions
+### 6.2 Conventions
 
-- Long flags: `--flag-name` (GNU double-dash).
-- Short flags: `-f` (POSIX single-dash, single letter).
-- `--` terminates flag parsing.
-- Subcommand aliases: `ls` for `list`, `rm` for `remove`, `i` for `add`.
-- No positional flag overloading.
+- POSIX/GNU long flags (`--flag-name`) and short flags (`-f`).
+- Stdout for data, stderr for progress and errors.
+- Honors `NO_COLOR` and TTY detection (no color in pipes/CI).
+- Single static binary, no runtime dependencies.
 
-### 6.4 Environment variables
+### 6.3 Environment variables
 
-| Variable               | Purpose                                                         |
-| ---------------------- | --------------------------------------------------------------- |
-| `NO_COLOR`             | Disable colored output.                                         |
-| `GITHUB_TOKEN`         | Authenticate GitHub requests (private repos).                   |
-| `GH_TOKEN`             | Fallback for `GITHUB_TOKEN` (matches `gh` CLI).                 |
-| `GITLAB_TOKEN`         | Authenticate GitLab requests (private repos).                   |
-| `GL_TOKEN`             | Fallback for `GITLAB_TOKEN` (matches `glab` CLI).               |
-| `UPSKILL_REGISTRY_URL` | Override the skills.sh base URL (default: `https://skills.sh`). |
-| `HTTPS_PROXY`          | HTTP proxy for network requests.                                |
+| Variable       | Purpose                                       |
+| -------------- | --------------------------------------------- |
+| `NO_COLOR`     | Disable colored output.                       |
+| `GITHUB_TOKEN` | Authenticate GitHub requests (private repos). |
+| `GH_TOKEN`     | Fallback for `GITHUB_TOKEN`.                  |
+| `GITLAB_TOKEN` | Authenticate GitLab requests (private repos). |
+| `GL_TOKEN`     | Fallback for `GITLAB_TOKEN`.                  |
+| `HTTPS_PROXY`  | HTTP proxy for network requests.              |
 
-If no token env var is set, `upskill` shells out to `gh auth token` or
-`glab auth token` as a final fallback before falling back to unauthenticated
-access.
+## 7. Implementation status
 
-### 6.5 Output modes
+Per [ADR-0001](./adr/0001-multi-kind-compiler-architecture.md).
 
-| Context         | Behavior                                                |
-| --------------- | ------------------------------------------------------- |
-| Interactive TTY | Colored output, progress spinners, interactive prompts. |
-| Piped / CI      | No color, no spinners, no prompts. Machine-parseable.   |
-| `--yes`         | Suppress all confirmation prompts.                      |
+| Phase | Scope                                                                                             | Status       |
+| ----- | ------------------------------------------------------------------------------------------------- | ------------ |
+| 0     | Tag, branch, deps, ADRs, model skeleton.                                                          | Done.        |
+| 1     | SSOT parser + generation pipeline for skills × all 3 clients.                                     | Done.        |
+| 2     | Pipeline extension to rules and agents.                                                           | Done.        |
+| 3     | `add` / `update` / `remove` over the pipeline; bundles; v0.1 lockfile migration; ancillary files. | In progress. |
+| 5     | `lint` + `fmt`.                                                                                   | Pending.     |
+| 6     | `new` (scaffolding).                                                                              | Pending.     |
+| 7     | Polish + v0.2.0 release.                                                                          | Pending.     |
 
-## 7. File layout
+The v0.1 CLI surface (`add` / `list` / `remove` / `check` / `search` /
+`update` against `.upskill-lock.json`) remains the **shipped** behaviour
+until v0.2.0. v0.1 is supported via patch releases of the `v0.1.x` line.
 
-### 7.1 Project structure after install
+## 8. Out of scope
 
-```
-project/
-├── .agents/
-│   └── skills/
-│       └── markspec/             ← canonical copy (always)
-│           ├── SKILL.md
-│           ├── references/
-│           └── scripts/
-├── .claude/
-│   └── skills/
-│       └── markspec → ../../.agents/skills/markspec    ← symlink
-├── .github/
-│   └── skills/
-│       └── markspec → ../../.agents/skills/markspec    ← symlink
-└── ...
-```
-
-### 7.2 Global structure after install
-
-```
-~/
-├── .agents/
-│   └── skills/
-│       └── markspec/             ← canonical copy
-├── .claude/
-│   └── skills/
-│       └── markspec → ../../.agents/skills/markspec
-├── .copilot/
-│   └── skills/
-│       └── markspec → ../../.agents/skills/markspec
-└── ...
-```
-
-### 7.3 Lockfile
-
-`.upskill-lock.json` in project root (or `~/.upskill-lock.json` for global):
-
-```json
-{
-  "skills": [
-    {
-      "name": "my-skill",
-      "source": "github:owner/repo@v1.2",
-      "ref": "v1.2",
-      "hash": "a3f8c2..."
-    }
-  ]
-}
-```
-
-| Field    | Description                                                               |
-| -------- | ------------------------------------------------------------------------- |
-| `name`   | Skill directory name.                                                     |
-| `source` | Full source label including prefix and ref.                               |
-| `ref`    | Pinned git ref (omitted if tracking latest).                              |
-| `hash`   | SHA-256 of all files in the skill directory (for modification detection). |
-
-Skills are sorted by name (deterministic output). Commit this file to track
-exact skill versions across environments.
-
-### 7.4 Registries configuration
-
-`upskill search` queries skill registries. Well-known public registries are
-built-in. Custom registries are configured via a `registries.toml` file.
-
-**File locations (merged, project overrides global):**
-
-| Scope   | Path                         |
-| ------- | ---------------------------- |
-| Project | `.upskill/registries.toml`   |
-| Global  | `~/.upskill/registries.toml` |
-
-**Format:**
-
-```toml
-# Custom registries (added to the built-in well-known list)
-
-[[registry]]
-name = "internal"
-source = "https://gitlab.mycompany.com/platform/agent-skills"
-token_env = "GITLAB_TOKEN"
-
-[[registry]]
-name = "team-tools"
-source = "myorg/team-skills"
-
-[[registry]]
-name = "vendor"
-source = "vendor/sdk-skills"
-branch = "stable"
-```
-
-**Fields:**
-
-| Field       | Required | Description                                                                           |
-| ----------- | -------- | ------------------------------------------------------------------------------------- |
-| `name`      | Yes      | Short identifier, used in `upskill search` output and `upskill add <name> --skill`.   |
-| `source`    | Yes      | GitHub shorthand (`owner/repo`), GitLab shorthand (`gitlab:owner/repo`), or full URL. |
-| `branch`    | No       | Branch to query. Default: `main`.                                                     |
-| `token_env` | No       | Environment variable holding the auth token for this registry.                        |
-
-**Built-in well-known registries** (always queried, no config needed):
-
-| Name            | Source                   |
-| --------------- | ------------------------ |
-| anthropic       | `anthropics/skills`      |
-| microsoft       | `microsoft/skills`       |
-| awesome-copilot | `github/awesome-copilot` |
-| skills.sh       | skills.sh index          |
-
-Custom registries are queried after the built-in ones. A custom registry with
-the same `name` as a built-in one overrides it.
-
-**Install from a named registry:**
-
-```bash
-# "internal" resolves to the source URL from registries.toml
-upskill add internal --skill k8s-deploy
-```
-
-### Deferred / as-needed
-
-| Feature                             | Trigger                                       |
-| ----------------------------------- | --------------------------------------------- |
-| New agent paths (Antigravity, etc.) | When agents ship SKILL.md support             |
-| `upskill publish` (PR-based)        | If manual PR workflow proves insufficient     |
-| Skill scaffolding (`init`)          | If `mkdir` + template copy proves too tedious |
-| `UPSKILL_HOME` override             | User request                                  |
-
-### Explicitly out of scope
-
-- Runtime skill invocation (each agent's responsibility).
+- Runtime invocation of installed content (each AI client's responsibility).
 - Hosting a registry server or central marketplace.
-- Skill validation beyond frontmatter (use `skills-ref validate`).
-- GUI or TUI beyond interactive prompts.
+- Content quality review (delegated to AI workflows outside upskill).
 - Telemetry, analytics, or usage tracking.
 - Publishing to non-Git destinations (npm, crates.io, PyPI).
-- Skill rating or ranking (no infrastructure for it).
 
-## 8. References
+## 9. References
 
-### Standards
-
-- [Agent Skills specification](https://agentskills.io/specification) — SKILL.md
-  format, progressive disclosure, validation rules.
-- [clig.dev](https://clig.dev) — Command Line Interface Guidelines.
-- [GNU Coding Standards — Command-Line Interfaces][gnu-cli]
-  — flag naming, `--help`, `--version`.
-- [POSIX Utility Conventions][posix-utility]
-  — argument syntax, exit codes.
-- [NO_COLOR][no-color] — color output control convention.
-- [XDG Base Directory Specification][xdg-basedir]
-  — config/data directory conventions.
-
-### Agent documentation
-
-- [Claude Code — Agent Skills][claude-skills]
-- [GitHub Copilot — Agent Skills][copilot-skills]
-- [OpenAI Codex — Skills][codex-skills]
-- [Kiro — Skills][kiro-skills]
-- [Windsurf — Cascade Skills][windsurf-skills]
-- [OpenCode — Skills][opencode-skills]
-- [Microsoft Agent Framework — Skills][ms-agent-skills]
-
-### Ecosystem
-
-- [Anthropic skills repo][anthropic-repo]
-- [Microsoft skills repo][microsoft-repo]
-- [GitHub awesome-copilot][awesome-copilot-repo]
-- [Vercel npx skills][vercel-skills]
-- [skills.sh — Agent Skills directory][skills-sh]
-
-<!-- Reference links -->
-
-[agent-skills-spec]: https://agentskills.io/specification
-[clig]: https://clig.dev
-[gnu-cli]: https://www.gnu.org/prep/standards/html_node/Command_002dLine-Interfaces.html
-[posix-utility]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
-[no-color]: https://no-color.org/
-[xdg-basedir]: https://specifications.freedesktop.org/basedir-spec/latest/
-[claude-skills]: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
-[copilot-skills]: https://docs.github.com/en/copilot/concepts/agents/about-agent-skills
-[codex-skills]: https://developers.openai.com/codex/skills
-[kiro-skills]: https://kiro.dev/docs/skills/
-[windsurf-skills]: https://docs.windsurf.com/windsurf/cascade/skills
-[opencode-skills]: https://opencode.ai/docs/skills/
-[ms-agent-skills]: https://learn.microsoft.com/en-us/agent-framework/agents/skills
-[anthropic-repo]: https://github.com/anthropics/skills
-[microsoft-repo]: https://github.com/microsoft/skills
-[awesome-copilot-repo]: https://github.com/github/awesome-copilot
-[vercel-skills]: https://github.com/vercel-labs/skills
-[skills-sh]: https://skills.sh/
+- Format spec: [`docs/format-spec.md`](./format-spec.md)
+- Architecture decisions:
+  [ADR-0001](./adr/0001-multi-kind-compiler-architecture.md) (umbrella),
+  [ADR-0002](./adr/0002-portable-content-format.md) (format),
+  [ADR-0003](./adr/0003-generation-pipeline.md) (pipeline),
+  [ADR-0004](./adr/0004-cli-surface.md) (CLI),
+  [ADR-0005](./adr/0005-skills-sh-ecosystem-interop.md) (interop)
+- Implementation guide: [`docs/architecture.md`](./architecture.md)
+- User guide: [`docs/usage.md`](./usage.md)
+- Agent Skills open standard: <https://agentskills.io>
+- skills.sh ecosystem: <https://skills.sh>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,20 +1,26 @@
 # upskill
 
-`upskill` is a package manager for [Agent Skills][agent-skills] — the shared
-skill format supported by Claude Code, GitHub Copilot, Codex, Cursor, Kiro,
-Windsurf, and OpenCode.
-
-It installs skills from any GitHub or GitLab repository into your project in
-one command. Skills land in `.agents/skills/` and are automatically linked into
-whichever agent config directories already exist in your project. No Node.js.
-No npm. A single static binary.
+`upskill` lets you author and distribute AI-assistance content — **rules**,
+**skills**, and **agents** — across multiple AI coding clients (Claude Code,
+GitHub Copilot, opencode) from a single source of truth. One CLI, one set of
+files, per-client output generated on demand.
 
 ```bash
-upskill search code-review          # find skills
-upskill add owner/repo              # install from a GitHub repo
-upskill list                        # see what's installed
-upskill update                      # re-fetch from source
+upskill add owner/repo               # install everything from a source repo
+upskill update                       # pull latest, regenerate per-client files
+upskill list                         # see what's installed
+upskill new skill code-review        # scaffold a new SSOT skill (in a registry)
 ```
+
+> **Status.** v0.2 is in active development on the `v0.2-redesign` branch.
+> Phases 0–2 (model, parser, generation pipeline) have shipped; Phase 3+
+> (install/update/remove over the pipeline, bundles, lock file migration) is
+> in progress. The latest released binary (`cargo install upskill`) is
+> v0.1.x and exposes the v0.1 skills-installer surface; this guide describes
+> the v0.2 surface that lands in v0.2.0.
+>
+> For the full design, see [`specification.md`](./specification.md). For the
+> on-disk contract, see [`format-spec.md`](./format-spec.md).
 
 ## Installation
 
@@ -26,147 +32,142 @@ Or download a pre-built binary from the [releases page][releases].
 
 ## Quick start
 
+### As a consumer
+
+Inside a project where you want AI clients to pick up rules / skills /
+agents:
+
 ```bash
-# Search the public registry
-upskill search python
+# Install everything from a source repo (auto-detects clients)
+upskill add driftsys/skills
 
-# Install a skill (auto-detects your agents)
-upskill add anthropics/skills --skill python-best-practices
+# Install only specific items
+upskill add driftsys/skills code-review secret-scanner
 
-# See what's installed and which agents are linked
-upskill list
+# Pin to a tag, branch, or commit
+upskill add driftsys/skills@v1.2.0
 ```
 
-Skills are installed to `.agents/skills/` in the current directory. Agent
-symlinks (`.claude/skills`, `.github/skills`, etc.) are created automatically
-when the corresponding agent config directory is detected.
+Generated files land in `.claude/`, `.github/`, and `.agents/` per the
+[generation pipeline](./specification.md#3-generation-pipeline). The
+`.upskill.lock` file in your repo records what was installed and at which
+ref — commit it.
 
----
+### As an author
+
+Inside a source-registry repo (where SSOT items live):
+
+```bash
+# Scaffold a new item
+upskill new skill code-review
+
+# Validate the SSOT before publishing
+upskill lint
+
+# Canonicalise frontmatter (key order, quoting)
+upskill fmt
+```
 
 ## Commands
 
-### `upskill add <source>`
+### Consumer commands
 
-Install skills from a source into the current project (or globally with `-g`).
+#### `upskill add <source> [items...]`
 
-```bash
-upskill add owner/repo                   # GitHub shorthand
-upskill add owner/repo:path/to/skills    # Subfolder only
-upskill add owner/repo@v1.2              # Pin to tag
-upskill add owner/repo@main              # Pin to branch
-upskill add owner/repo@abc123            # Pin to commit SHA
-upskill add gitlab:owner/repo            # GitLab.com
-upskill add https://gitlab.example.com/owner/repo  # Self-hosted GitLab
-upskill add ./path/to/local              # Local directory
-```
-
-**Skill selection:**
+Install content from any source.
 
 ```bash
-upskill add owner/repo --skill my-skill         # Install one skill
-upskill add owner/repo -s foo -s bar            # Install multiple skills
-# (no --skill): interactive prompt in a TTY, default name in CI
+upskill add owner/repo                       # GitHub shorthand
+upskill add owner/repo:path/to/items         # subfolder
+upskill add owner/repo@v1.2                  # pin to tag
+upskill add owner/repo@main                  # pin to branch
+upskill add owner/repo@abc123                # pin to commit SHA
+upskill add gitlab:owner/repo                # GitLab.com
+upskill add https://gitlab.example.com/owner/repo  # self-hosted GitLab
+upskill add ./path/to/local                  # local directory
+upskill add platform-defaults                # bundle from a configured registry
 ```
 
-**Agent flags:**
+`upskill add <source>` installs **everything** the source contains. Append
+item names to filter:
 
 ```bash
-upskill add owner/repo --claude     # Symlink to .claude/skills
-upskill add owner/repo --copilot    # Symlink to .github/skills
-upskill add owner/repo --all        # Symlink to all 7 supported agents
-upskill add owner/repo --copy       # Copy instead of symlinking
-# (no flag): auto-detect from existing agent config directories
+upskill add driftsys/skills code-review secret-scanner
 ```
 
-**Other flags:**
+Default scope is `--project` (writes into `.agents/...` of the current repo),
+falling back to `--global` (`$HOME/.agents/...`) if you're not inside a git
+repo. Pass either flag explicitly to override.
+
+#### `upskill update [name...]`
+
+Pull latest sources and regenerate changed items.
 
 ```bash
-upskill add owner/repo -g           # Global install (~/.agents/skills)
+upskill update                       # update everything
+upskill update code-review           # update one item
+upskill update --dry-run             # preview changes without applying
 ```
 
-### `upskill list`
+`update` always fetches before regenerating; there is no separate `sync`. It
+also re-runs the generation pipeline against the current upskill version, so
+client-format updates land without a separate command.
 
-List installed skills and their agent symlinks.
+#### `upskill remove [name...]`
+
+Remove installed items.
 
 ```bash
-upskill list         # Project skills
-upskill list -g      # Global skills
+upskill remove code-review
+upskill remove --global code-review
 ```
 
-Output format:
+#### `upskill list [--available]`
 
-```
-my-skill    source=github:owner/repo    symlinks=claude,copilot
-other-skill source=local:/path/to/src  symlinks=none
-```
+Show installed content. With `--available`, list items the configured sources
+expose.
 
-### `upskill search <query>`
+#### `upskill info <name>`
 
-Search the public skills registry (skills.sh).
+Show details for an item or bundle: resolved source, version, hash, generated
+output paths.
+
+#### `upskill doctor`
+
+Verify on-disk state matches `.upskill.lock`. Reports drift (manual edits to
+generated files, missing files, hash mismatches).
+
+### Author commands
+
+Run inside a **source-registry** working tree.
+
+#### `upskill new <kind> <name>`
+
+Scaffold a new SSOT item directory.
 
 ```bash
-upskill search rust
-upskill search code-review
-upskill search --limit 20 python
+upskill new rule  no-direct-database-access
+upskill new skill code-review
+upskill new agent security-reviewer
 ```
 
-Output:
+Creates the kind-appropriate directory and entrypoint file (`RULE.md`,
+`SKILL.md`, `AGENT.md`) with starter frontmatter.
 
-```
-rust-mcp-server-generator    7608 installs    upskill add awesome-copilot --skill rust-mcp-server-generator
-rust-analyzer                3200 installs    upskill add anthropics/skills --skill rust-analyzer
-```
+#### `upskill lint [paths...]`
 
-Each result includes the install command to use directly.
-
-**Flags:**
-
-| Flag      | Default | Description                |
-| --------- | ------- | -------------------------- |
-| `--limit` | `10`    | Maximum number of results. |
-
-### `upskill remove <skill>`
-
-Remove an installed skill and clean up agent symlinks.
+Validate SSOT files against the [format spec](./format-spec.md).
 
 ```bash
-upskill remove my-skill         # Prompts for confirmation in a TTY
-upskill remove my-skill --yes   # Skip confirmation
-upskill remove my-skill -g      # Remove from global install
+upskill lint                # lint everything in the working tree
+upskill lint rules/         # lint a subtree
+upskill lint --strict       # CI mode: warnings become errors
 ```
 
-### `upskill check`
+#### `upskill fmt [paths...]`
 
-Show installed skills and their pinned refs.
-
-```bash
-upskill check     # Project lockfile
-upskill check -g  # Global lockfile
-```
-
-Output:
-
-```
-my-skill    github:owner/repo    pinned: latest
-other-skill github:owner/repo    pinned: v1.2
-```
-
-### `upskill update`
-
-Re-install skills from their recorded sources.
-
-```bash
-upskill update                      # Update all skills
-upskill update my-skill             # Update one skill
-upskill update --dry-run            # Preview without applying
-upskill update --force              # Overwrite locally modified skills
-upskill update -g                   # Update global skills
-```
-
-Local modifications are detected via a SHA-256 content hash stored in the
-lockfile. Modified skills are skipped with a warning unless `--force` is used.
-
----
+Canonicalise YAML frontmatter (key order, version quoting, indentation).
+Markdown body formatting is left to dprint — the two tools don't overlap.
 
 ## Recipes
 
@@ -176,116 +177,60 @@ lockfile. Modified skills are skipped with a warning unless `--force` is used.
 # Install without prompts (auto-detects NO_COLOR, non-TTY)
 upskill add owner/repo
 
-# Explicit non-interactive
-GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} upskill add owner/repo
+# Lint in CI (fail on warnings)
+upskill lint --strict
 ```
 
-In a non-TTY environment (CI, pipes), `upskill` automatically:
-
-- Skips interactive prompts and uses defaults.
-- Disables colored output when `NO_COLOR` is set.
-
-### Override the search registry URL
-
-For testing or private deployments:
-
-```bash
-UPSKILL_REGISTRY_URL=https://my-registry.example.com upskill search query
-```
-
-Defaults to `https://skills.sh`.
+In a non-TTY environment, `upskill` skips interactive prompts and disables
+colored output when `NO_COLOR` is set.
 
 ### Private repositories
 
-```bash
-# GitHub — set one of:
-export GITHUB_TOKEN=ghp_...
-export GH_TOKEN=ghp_...
-# or rely on `gh auth token` if the GitHub CLI is authenticated
-
-# GitLab — set one of:
-export GITLAB_TOKEN=glpat_...
-export GL_TOKEN=glpat_...
-# or rely on `glab auth token` if the GitLab CLI is authenticated
-```
-
-### Pin a skill to a specific version
+Token resolution per host:
 
 ```bash
-upskill add owner/repo@v1.2 --skill my-skill
+# GitHub
+export GITHUB_TOKEN=ghp_...      # or GH_TOKEN, or rely on `gh auth token`
+
+# GitLab
+export GITLAB_TOKEN=glpat_...    # or GL_TOKEN, or rely on `glab auth token`
 ```
 
-The pinned ref is recorded in `.upskill-lock.json`. `upskill update` will
-re-fetch from the same ref.
-
-### Install to all agents
+### Pin a source to a specific version
 
 ```bash
-upskill add owner/repo --all
+upskill add owner/repo@v1.2.0
 ```
 
-Creates symlinks in all 7 supported agent directories:
-`.claude/skills`, `.github/skills`, `.codex/skills`, `.cursor/skills`,
-`.kiro/skills`, `.windsurf/skills`, `.opencode/skills`.
+The pinned ref is recorded in `.upskill.lock`. `upskill update` re-fetches
+from the same ref unless you bump it.
 
-### Copy instead of symlinking
+## State files
 
-For environments where symlinks are not supported (e.g. some Windows
-setups, Docker mounts):
+Per [specification §4](./specification.md#4-state-files):
 
-```bash
-upskill add owner/repo --copy
-```
+| File                        | Scope       | Committed? | Purpose                              |
+| --------------------------- | ----------- | ---------- | ------------------------------------ |
+| `.upskill.lock`             | Per-project | Yes        | Deterministic regeneration in CI.    |
+| `~/.upskill/installed.json` | Per-user    | No         | Global install state, source caches. |
 
-Copies skill files directly into each agent directory. Copied skills are
-independent of the source after installation.
+v0.1 users with `.upskill-lock.json` get a one-time migration on first run
+of any v0.2 command — see
+[ADR-0003](./adr/0003-generation-pipeline.md).
 
-### Global install
+## Per-client output paths
 
-```bash
-upskill add owner/repo -g      # Install to ~/.agents/skills
-upskill list -g                # List global skills
-upskill remove my-skill -g     # Remove from global
-```
+Per [ADR-0003](./adr/0003-generation-pipeline.md):
 
-Global skills are not tied to a project directory.
+| Item kind | Claude Code                | GitHub Copilot                                | opencode                       |
+| --------- | -------------------------- | --------------------------------------------- | ------------------------------ |
+| Rule      | `.claude/rules/<name>.md`  | `.github/instructions/<name>.instructions.md` | `.agents/rules/<name>/RULE.md` |
+| Skill     | `.claude/skills/<name>/`   | `.github/skills/<name>/`                      | `.agents/skills/<name>/`       |
+| Agent     | `.claude/agents/<name>.md` | `.github/agents/<name>.agent.md`              | `.opencode/agents/<name>.md`   |
 
----
-
-## Lockfile
-
-Every `add` operation writes `.upskill-lock.json` in the project root (or
-`~/.upskill-lock.json` for global installs). Commit this file to track exact
-skill versions.
-
-Example:
-
-```json
-{
-  "skills": [
-    {
-      "name": "my-skill",
-      "source": "github:owner/repo@v1.2",
-      "ref": "v1.2",
-      "hash": "a3f8c2..."
-    }
-  ]
-}
-```
-
-Fields:
-
-| Field    | Description                                 |
-| -------- | ------------------------------------------- |
-| `name`   | Skill directory name                        |
-| `source` | Full source label including prefix and ref  |
-| `ref`    | Pinned git ref (omitted if tracking latest) |
-| `hash`   | SHA-256 of all files in the skill directory |
-
-The `hash` is used by `upskill update` to detect local modifications before
-overwriting.
-
----
+All output is **copy** (not symlink) — Windows portability without Developer
+Mode. The deliberate divergence from skills.sh is documented in
+[ADR-0005](./adr/0005-skills-sh-ecosystem-interop.md).
 
 ## Exit codes
 
@@ -296,19 +241,4 @@ overwriting.
 | 2    | Usage error (bad args) |
 | 130  | Interrupted (Ctrl+C)   |
 
----
-
-## Supported agents
-
-| Agent    | Skills directory   |
-| -------- | ------------------ |
-| Claude   | `.claude/skills`   |
-| Copilot  | `.github/skills`   |
-| Codex    | `.codex/skills`    |
-| Cursor   | `.cursor/skills`   |
-| Kiro     | `.kiro/skills`     |
-| Windsurf | `.windsurf/skills` |
-| OpenCode | `.opencode/skills` |
-
 [releases]: https://github.com/driftsys/upskill/releases
-[agent-skills]: https://agentskills.io/specification


### PR DESCRIPTION
## Summary

- The mdBook contents (specification, architecture, usage, SUMMARY) predated the v0.2 redesign and described the v0.1 skills installer (symlinks, `.upskill-lock.json`, v0.1 CLI surface). They contradicted ADRs 0002–0005 which specify rules+skills+agents, copy-only output, `.upskill.lock` + `~/.upskill/installed.json`, and a 9-command surface. This PR rewrites them to match.
- AGENTS.md and README.md are refreshed: the stale "Deliberately NOT used" dep list (now relaxed by ADR-0001 §3) and the "name reservation" warning are dropped, the module layout matches current `src/`, and the install-layout split between v0.1 (shipped) and v0.2 (in flight) is documented.
- Two ADRs are renamed for clarity (file + title):
  - `0001-v0.2-architectural-reset` → `0001-multi-kind-compiler-architecture` — the version-in-filename is removed; the title now describes content (this is the umbrella architecture decision) instead of dramatising the act ("reset").
  - `0005-vercel-skills-sh-interop` → `0005-skills-sh-ecosystem-interop` — drops the brand prefix, aligning with the topic-noun pattern of 0002/0003/0004.
- All ADR cross-references updated (0001–0005 inter-references, plus mentions in the rewritten book pages).

This is a docs-only PR; no source changes. `just verify` passes (cargo fmt-check, clippy `-D warnings`, dprint check, markdownlint, build).

## Test plan

- [ ] `just verify` passes locally and in CI.
- [ ] mdBook builds from `docs/` without warnings (CI `pages.yml` deploys from `main`, so book preview lands when this branch merges to `main` via `v0.2-redesign`).
- [ ] All ADR cross-references resolve (`grep -rn "0001-v0.2-architectural-reset\|0005-vercel-skills-sh-interop" --include="*.md" .` returns nothing).
- [ ] SUMMARY.md renders with all five ADRs reachable.

## Notes

The pre-commit hook formatter behaviour caused the changes to land in two commits — the renames + cross-ref updates in the first, the rewrites in the second. They merge into one squash commit on PR merge per repo policy.
