### PR TITLE
docs: align book + AGENTS with .upskill-lock.json (post-#75 / #76 cleanup)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,8 @@ src/
 │
 ├── agent.rs             v0.1 agent detection / symlink targets (retired in Phase 3)
 ├── install.rs           v0.1 install flow (replaced in Phase 3)
-└── lockfile.rs          v0.1 .upskill-lock.json (replaced in Phase 3 with
-                         .upskill.lock + ~/.upskill/installed.json)
+└── lockfile.rs          v0.1 .upskill-lock.json schema (Phase 3 keeps
+                         the filename, bumps schema, adds ~/.upskill/installed.json)
 ```
 
 Core docs (published as mdBook at <https://driftsys.github.io/upskill/>):
@@ -111,9 +111,10 @@ or `~/.agents/skills/` (global) with per-agent symlinks. State in
 `.upskill-lock.json`. `AGENT_DEFS` in `src/agent.rs` is the source of truth.
 
 **v0.2 (this branch, Phase 3 in flight).** Per-item generated output, copy
-only (no symlinks). State split between `.upskill.lock` (per-project,
-committed) and `~/.upskill/installed.json` (per-user). v0.1 lockfiles are
-read once on first invocation for migration. Per-client output paths and
+only (no symlinks). State split between `.upskill-lock.json` (per-project,
+committed, schema-versioned) and `~/.upskill/installed.json` (per-user).
+The lockfile filename is unchanged from v0.1; v0.2 bumps a `schema:` field
+and rewrites in place on first invocation. Per-client output paths and
 ancillary files (`CLAUDE.md`, `.vscode/settings.json`, `opencode.json`) are
 specified in
 [ADR-0003](docs/adr/0003-generation-pipeline.md) and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,18 +97,18 @@ src/
 
 ### 2.1 v0.2 module status
 
-| Module      | Status                                                                                                                                              |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model/`    | Done (Phase 0). Full schema for rules, skills, agents.                                                                                              |
-| `parse/`    | Done (Phase 0). YAML frontmatter parsing with `serde_yaml_ng`.                                                                                      |
-| `generate/` | Done (Phase 1–2). All three kinds × all three clients.                                                                                              |
-| `source`    | Reused from v0.1. Source format unchanged (parity with `npx skills`).                                                                               |
-| `fetch`     | Reused from v0.1. Git clone via shell-out.                                                                                                          |
-| `auth`      | Reused from v0.1. Token resolution unchanged.                                                                                                       |
-| `install`   | v0.1 logic. Phase 3 replaces with SSOT-pipeline install over `generate/`.                                                                           |
-| `lockfile`  | v0.1 schema. Phase 3 replaces with `.upskill.lock` (per-project) and `~/.upskill/installed.json` (per-user); v0.1 lockfile read once for migration. |
-| `agent`     | v0.1 symlink/copy targets. Phase 3 retires in favour of per-client output paths from the format spec.                                               |
-| `search`    | v0.1 skills.sh API. Carries forward unchanged.                                                                                                      |
+| Module      | Status                                                                                                                                                   |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model/`    | Done (Phase 0). Full schema for rules, skills, agents.                                                                                                   |
+| `parse/`    | Done (Phase 0). YAML frontmatter parsing with `serde_yaml_ng`.                                                                                           |
+| `generate/` | Done (Phase 1–2). All three kinds × all three clients.                                                                                                   |
+| `source`    | Reused from v0.1. Source format unchanged (parity with `npx skills`).                                                                                    |
+| `fetch`     | Reused from v0.1. Git clone via shell-out.                                                                                                               |
+| `auth`      | Reused from v0.1. Token resolution unchanged.                                                                                                            |
+| `install`   | v0.1 logic. Phase 3 replaces with SSOT-pipeline install over `generate/`.                                                                                |
+| `lockfile`  | v0.1 schema. Phase 3 replaces with `.upskill-lock.json` (per-project) and `~/.upskill/installed.json` (per-user); v0.1 lockfile read once for migration. |
+| `agent`     | v0.1 symlink/copy targets. Phase 3 retires in favour of per-client output paths from the format spec.                                                    |
+| `search`    | v0.1 skills.sh API. Carries forward unchanged.                                                                                                           |
 
 ## 3. Generation pipeline internals
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -199,7 +199,7 @@ Three files outside the per-item path tree are managed idempotently:
 Per [ADR-0003](./adr/0003-generation-pipeline.md). State is split between
 two files, both schema-versioned (`schema: 1`).
 
-### 4.1 `.upskill.lock` (per-project, committed)
+### 4.1 `.upskill-lock.json` (per-project, committed)
 
 Lives at the consumer-project root. Records what was installed, from where,
 at what resolved git ref, with what content hashes. Plays the same role as
@@ -236,10 +236,13 @@ state for the global location, and source-registry caches. Not committed.
 
 ### 4.3 v0.1 lockfile migration
 
-v0.1's per-project `.upskill-lock.json` is read once by a translator that
-produces equivalent entries in the new files. Existing v0.1 users are not
-silently broken. The translator runs on first invocation of any v0.2 command
-in a directory containing a v0.1 lockfile.
+The lockfile filename does not change between v0.1 and v0.2 — both versions
+use `.upskill-lock.json`. Per
+[ADR-0003](./adr/0003-generation-pipeline.md), v0.2 stamps a top-level
+`schema: 2` field; v0.1 lockfiles (no `schema` field) are read once on first
+invocation of a v0.2 command and rewritten in place with the v0.2 entry shape.
+Any user-global state moves into `~/.upskill/installed.json`. Existing v0.1
+users are not silently broken.
 
 ## 5. Source format and authentication
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,7 +50,7 @@ upskill add driftsys/skills@v1.2.0
 
 Generated files land in `.claude/`, `.github/`, and `.agents/` per the
 [generation pipeline](./specification.md#3-generation-pipeline). The
-`.upskill.lock` file in your repo records what was installed and at which
+`.upskill-lock.json` file in your repo records what was installed and at which
 ref — commit it.
 
 ### As an author
@@ -134,7 +134,7 @@ output paths.
 
 #### `upskill doctor`
 
-Verify on-disk state matches `.upskill.lock`. Reports drift (manual edits to
+Verify on-disk state matches `.upskill-lock.json`. Reports drift (manual edits to
 generated files, missing files, hash mismatches).
 
 ### Author commands
@@ -202,7 +202,7 @@ export GITLAB_TOKEN=glpat_...    # or GL_TOKEN, or rely on `glab auth token`
 upskill add owner/repo@v1.2.0
 ```
 
-The pinned ref is recorded in `.upskill.lock`. `upskill update` re-fetches
+The pinned ref is recorded in `.upskill-lock.json`. `upskill update` re-fetches
 from the same ref unless you bump it.
 
 ## State files
@@ -211,11 +211,12 @@ Per [specification §4](./specification.md#4-state-files):
 
 | File                        | Scope       | Committed? | Purpose                              |
 | --------------------------- | ----------- | ---------- | ------------------------------------ |
-| `.upskill.lock`             | Per-project | Yes        | Deterministic regeneration in CI.    |
+| `.upskill-lock.json`        | Per-project | Yes        | Deterministic regeneration in CI.    |
 | `~/.upskill/installed.json` | Per-user    | No         | Global install state, source caches. |
 
-v0.1 users with `.upskill-lock.json` get a one-time migration on first run
-of any v0.2 command — see
+v0.1 users keep the same `.upskill-lock.json` filename. v0.2 stamps a
+`schema: 2` field on first run and rewrites the file in place with the new
+entry shape — see
 [ADR-0003](./adr/0003-generation-pipeline.md).
 
 ## Per-client output paths


### PR DESCRIPTION
## Summary

Follow-up to #76. The format-spec PR aligned `format-spec.md`, `ADR-0003`, and `ADR-0004` to `.upskill-lock.json` (matching `src/lockfile.rs`). #75 had already merged a v0.2 doc rewrite that used the earlier `.upskill.lock` name. This PR completes the alignment in the four files left over.

- `docs/specification.md` — §4.1 heading and §4.3 migration paragraph.
- `docs/usage.md` — intro, state-files table, recipe paragraph, and `doctor` section.
- `docs/architecture.md` — module-status row for `lockfile.rs`.
- `AGENTS.md` — module-layout comment and v0.2 install-layout paragraph.

The migration prose is also updated to match ADR-0003: the filename does not change between v0.1 and v0.2; v0.2 stamps `schema: 2` and rewrites the file in place on first invocation, rather than producing a separate file via a translator. This also fixes the "replaced with itself" tautology that the mechanical replacement would have left in the AGENTS.md module-layout comment.

## Test plan

- [x] `just verify` clean locally.
- [ ] CI passes (clippy, fmt, test, convco).
- [ ] No `.upskill.lock` references remain: `grep -rn '\.upskill\.lock\b' docs/ src/ AGENTS.md README.md` returns nothing.
