### PR TITLE
feat(pipeline): install local SSOT to per-client output on disk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod install;
 pub mod lockfile;
 pub mod model;
 pub mod parse;
+pub mod pipeline;
 pub mod search;
 pub mod source;
 pub mod ui;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,286 @@
+//! v0.2 install pipeline: local SSOT path → per-client output on disk.
+//!
+//! Walks a source directory laid out per format-spec §2.1, parses each
+//! item's frontmatter into the model (§3), renders per-client output via
+//! `crate::generate`, and writes the result to the per-client paths
+//! defined in format-spec §7 / ADR-0003.
+//!
+//! Scope (Phase 3 first slice):
+//! - Local path source only (no git fetch).
+//! - No lockfile, no bundle resolution, no ancillary file management
+//!   (`CLAUDE.md`, `.vscode/settings.json`, `opencode.json`).
+//! - No CLI wiring; this is library API only.
+//!
+//! Audience filter: respects `metadata.audience` per the current model
+//! shape. Promotion of `audience` to a top-level field (per the
+//! format-spec PR #76) is a separate task.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::generate::{self, Client};
+use crate::model::{Agent, Audience, Rule, Skill};
+use crate::parse::frontmatter;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ItemKind {
+    Rule,
+    Skill,
+    Agent,
+}
+
+#[derive(Debug, Clone)]
+pub struct InstalledItem {
+    pub kind: ItemKind,
+    pub name: String,
+    pub client: Client,
+    /// Path relative to the install target root.
+    pub output_path: PathBuf,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct InstallReport {
+    pub items: Vec<InstalledItem>,
+}
+
+const ALL_CLIENTS: [Client; 3] = [Client::Claude, Client::Copilot, Client::OpenCode];
+
+/// Install every item under `source` into `target`, generating per-client
+/// output for each client unless filtered by `metadata.audience`.
+pub fn install_from_local_path(source: &Path, target: &Path) -> Result<InstallReport> {
+    let mut report = InstallReport::default();
+
+    install_skills(source, target, &mut report)?;
+    install_rules(source, target, &mut report)?;
+    install_agents(source, target, &mut report)?;
+
+    Ok(report)
+}
+
+fn install_skills(source: &Path, target: &Path, report: &mut InstallReport) -> Result<()> {
+    for (name, dir) in iter_item_dirs(&source.join("skills"))? {
+        let entry_path = dir.join("SKILL.md");
+        if !entry_path.exists() {
+            continue;
+        }
+        let raw = fs::read_to_string(&entry_path)
+            .with_context(|| format!("read {}", entry_path.display()))?;
+        let (skill, body) = frontmatter::parse::<Skill>(&raw)
+            .with_context(|| format!("parse {}", entry_path.display()))?;
+        let audience = audience_of(skill.metadata.as_ref());
+
+        for client in ALL_CLIENTS {
+            if !targets(client, audience.as_deref()) {
+                continue;
+            }
+            let rendered = generate::render_skill(&skill, body, client)
+                .with_context(|| format!("render skill {} for {:?}", name, client))?;
+            let rel = skill_output_path(client, &name);
+            write_output(target, &rel, &rendered)?;
+            report.items.push(InstalledItem {
+                kind: ItemKind::Skill,
+                name: name.clone(),
+                client,
+                output_path: rel,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn install_rules(source: &Path, target: &Path, report: &mut InstallReport) -> Result<()> {
+    for (name, dir) in iter_item_dirs(&source.join("rules"))? {
+        let entry_path = dir.join("RULE.md");
+        if !entry_path.exists() {
+            continue;
+        }
+        let raw = fs::read_to_string(&entry_path)
+            .with_context(|| format!("read {}", entry_path.display()))?;
+        let (rule, body) = frontmatter::parse::<Rule>(&raw)
+            .with_context(|| format!("parse {}", entry_path.display()))?;
+        let audience = audience_of(rule.metadata.as_ref());
+
+        for client in ALL_CLIENTS {
+            if !targets(client, audience.as_deref()) {
+                continue;
+            }
+            let rendered = generate::render_rule(&rule, body, client)
+                .with_context(|| format!("render rule {} for {:?}", name, client))?;
+            let rel = rule_output_path(client, &name);
+            write_output(target, &rel, &rendered)?;
+            report.items.push(InstalledItem {
+                kind: ItemKind::Rule,
+                name: name.clone(),
+                client,
+                output_path: rel,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn install_agents(source: &Path, target: &Path, report: &mut InstallReport) -> Result<()> {
+    for (name, dir) in iter_item_dirs(&source.join("agents"))? {
+        let entry_path = dir.join("AGENT.md");
+        if !entry_path.exists() {
+            continue;
+        }
+        let raw = fs::read_to_string(&entry_path)
+            .with_context(|| format!("read {}", entry_path.display()))?;
+        let (agent, body) = frontmatter::parse::<Agent>(&raw)
+            .with_context(|| format!("parse {}", entry_path.display()))?;
+        let audience = audience_of(agent.metadata.as_ref());
+
+        for client in ALL_CLIENTS {
+            if !targets(client, audience.as_deref()) {
+                continue;
+            }
+            let rendered = generate::render_agent(&agent, body, client)
+                .with_context(|| format!("render agent {} for {:?}", name, client))?;
+            let rel = agent_output_path(client, &name);
+            write_output(target, &rel, &rendered)?;
+            report.items.push(InstalledItem {
+                kind: ItemKind::Agent,
+                name: name.clone(),
+                client,
+                output_path: rel,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Per format-spec §7 / ADR-0003. opencode `.agents/skills/<n>/SKILL.md`
+/// is the canonical-store path; opencode walks it natively.
+fn skill_output_path(client: Client, name: &str) -> PathBuf {
+    match client {
+        Client::Claude => PathBuf::from(format!(".claude/skills/{name}/SKILL.md")),
+        Client::Copilot => PathBuf::from(format!(".github/skills/{name}/SKILL.md")),
+        Client::OpenCode => PathBuf::from(format!(".agents/skills/{name}/SKILL.md")),
+    }
+}
+
+/// Per format-spec §7 / ADR-0003. Copilot uses
+/// `<name>.instructions.md`; opencode uses a per-rule directory under
+/// `.agents/rules/`.
+fn rule_output_path(client: Client, name: &str) -> PathBuf {
+    match client {
+        Client::Claude => PathBuf::from(format!(".claude/rules/{name}.md")),
+        Client::Copilot => PathBuf::from(format!(".github/instructions/{name}.instructions.md")),
+        Client::OpenCode => PathBuf::from(format!(".agents/rules/{name}/RULE.md")),
+    }
+}
+
+/// Per format-spec §7 / ADR-0003. Copilot uses `<name>.agent.md`.
+fn agent_output_path(client: Client, name: &str) -> PathBuf {
+    match client {
+        Client::Claude => PathBuf::from(format!(".claude/agents/{name}.md")),
+        Client::Copilot => PathBuf::from(format!(".github/agents/{name}.agent.md")),
+        Client::OpenCode => PathBuf::from(format!(".opencode/agents/{name}.md")),
+    }
+}
+
+fn write_output(target: &Path, rel: &Path, content: &str) -> Result<()> {
+    let full = target.join(rel);
+    if let Some(parent) = full.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
+    }
+    fs::write(&full, content).with_context(|| format!("write {}", full.display()))?;
+    Ok(())
+}
+
+/// Iterate `(name, dir)` for every immediate subdirectory of `kind_root`.
+/// Returns an empty iterator when the kind root does not exist (treating
+/// "no items of this kind" as a non-error).
+fn iter_item_dirs(kind_root: &Path) -> Result<Vec<(String, PathBuf)>> {
+    if !kind_root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in
+        fs::read_dir(kind_root).with_context(|| format!("read_dir {}", kind_root.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = entry
+            .file_name()
+            .to_str()
+            .map(str::to_owned)
+            .with_context(|| format!("non-UTF8 name in {}", kind_root.display()))?;
+        out.push((name, path));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+fn audience_of(metadata: Option<&crate::model::Metadata>) -> Option<Vec<Audience>> {
+    metadata.and_then(|m| m.audience.clone())
+}
+
+fn targets(client: Client, audience: Option<&[Audience]>) -> bool {
+    match audience {
+        None => true,
+        Some(list) => list.iter().any(|a| audience_matches(client, *a)),
+    }
+}
+
+fn audience_matches(client: Client, a: Audience) -> bool {
+    matches!(
+        (client, a),
+        (Client::Claude, Audience::Claude)
+            | (Client::Copilot, Audience::Copilot)
+            | (Client::OpenCode, Audience::OpenCode)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_paths_match_spec() {
+        assert_eq!(
+            skill_output_path(Client::Claude, "x"),
+            PathBuf::from(".claude/skills/x/SKILL.md")
+        );
+        assert_eq!(
+            skill_output_path(Client::OpenCode, "x"),
+            PathBuf::from(".agents/skills/x/SKILL.md")
+        );
+        assert_eq!(
+            rule_output_path(Client::Copilot, "x"),
+            PathBuf::from(".github/instructions/x.instructions.md")
+        );
+        assert_eq!(
+            rule_output_path(Client::OpenCode, "x"),
+            PathBuf::from(".agents/rules/x/RULE.md")
+        );
+        assert_eq!(
+            agent_output_path(Client::Copilot, "x"),
+            PathBuf::from(".github/agents/x.agent.md")
+        );
+        assert_eq!(
+            agent_output_path(Client::OpenCode, "x"),
+            PathBuf::from(".opencode/agents/x.md")
+        );
+    }
+
+    #[test]
+    fn audience_none_targets_all_clients() {
+        for c in ALL_CLIENTS {
+            assert!(targets(c, None));
+        }
+    }
+
+    #[test]
+    fn audience_subset_filters_other_clients() {
+        let only_claude = vec![Audience::Claude];
+        assert!(targets(Client::Claude, Some(&only_claude)));
+        assert!(!targets(Client::Copilot, Some(&only_claude)));
+        assert!(!targets(Client::OpenCode, Some(&only_claude)));
+    }
+}

--- a/tests/pipeline_local.rs
+++ b/tests/pipeline_local.rs
@@ -1,0 +1,220 @@
+//! ATDD test for `pipeline::install_from_local_path`.
+//!
+//! Given a local SSOT source directory laid out per format-spec §2.1
+//! (`skills/<name>/SKILL.md`, `rules/<name>/RULE.md`, `agents/<name>/AGENT.md`),
+//! `install_from_local_path(source, target)` writes per-client generated
+//! output files under `target` at the paths defined in format-spec §7 and
+//! ADR-0003.
+//!
+//! Content equality is verified against the existing golden fixtures in
+//! `tests/fixtures/expected/` (the same fixtures used by `generate_*` tests).
+
+use std::fs;
+use std::path::Path;
+use upskill::pipeline::{InstallReport, install_from_local_path};
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+/// Stage the entire fixture corpus into a temp source directory.
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_expected(client: &str, fixture_name: &str) -> String {
+    let path = format!("{FIXTURES}/expected/{client}/{fixture_name}");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn assert_file_eq(actual_path: &Path, expected: &str, label: &str) {
+    let actual = fs::read_to_string(actual_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", actual_path.display()));
+    if actual == expected {
+        return;
+    }
+    eprintln!("=== {label}: actual ===\n{actual}");
+    eprintln!("=== {label}: expected ===\n{expected}");
+    panic!("{label} mismatch (see stderr above)");
+}
+
+#[test]
+fn install_writes_per_client_output_for_all_kinds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+
+    let report: InstallReport = install_from_local_path(&source, &target).expect("install");
+
+    // Skill — written to .claude/skills/<n>/SKILL.md, .github/skills/<n>/SKILL.md,
+    // .agents/skills/<n>/SKILL.md (opencode canonical-store).
+    assert_file_eq(
+        &target.join(".claude/skills/create-api-endpoint/SKILL.md"),
+        &read_expected("claude", "create-api-endpoint.SKILL.md"),
+        "claude skill",
+    );
+    assert_file_eq(
+        &target.join(".github/skills/create-api-endpoint/SKILL.md"),
+        &read_expected("copilot", "create-api-endpoint.SKILL.md"),
+        "copilot skill",
+    );
+    assert_file_eq(
+        &target.join(".agents/skills/create-api-endpoint/SKILL.md"),
+        &read_expected("opencode", "create-api-endpoint.SKILL.md"),
+        "opencode skill",
+    );
+
+    // Rule (api-conventions, scoped) — Claude .claude/rules/<n>.md,
+    // Copilot .github/instructions/<n>.instructions.md, opencode
+    // .agents/rules/<n>/RULE.md.
+    assert_file_eq(
+        &target.join(".claude/rules/api-conventions.md"),
+        &read_expected("claude", "api-conventions.RULE.md"),
+        "claude rule (scoped)",
+    );
+    assert_file_eq(
+        &target.join(".github/instructions/api-conventions.instructions.md"),
+        &read_expected("copilot", "api-conventions.RULE.md"),
+        "copilot rule (scoped)",
+    );
+    assert_file_eq(
+        &target.join(".agents/rules/api-conventions/RULE.md"),
+        &read_expected("opencode", "api-conventions.RULE.md"),
+        "opencode rule (scoped)",
+    );
+
+    // Rule (license-awareness, unscoped).
+    assert_file_eq(
+        &target.join(".claude/rules/license-awareness.md"),
+        &read_expected("claude", "license-awareness.RULE.md"),
+        "claude rule (unscoped)",
+    );
+    assert_file_eq(
+        &target.join(".github/instructions/license-awareness.instructions.md"),
+        &read_expected("copilot", "license-awareness.RULE.md"),
+        "copilot rule (unscoped)",
+    );
+    assert_file_eq(
+        &target.join(".agents/rules/license-awareness/RULE.md"),
+        &read_expected("opencode", "license-awareness.RULE.md"),
+        "opencode rule (unscoped)",
+    );
+
+    // Agent — Claude .claude/agents/<n>.md, Copilot .github/agents/<n>.agent.md,
+    // opencode .opencode/agents/<n>.md.
+    assert_file_eq(
+        &target.join(".claude/agents/security-reviewer.md"),
+        &read_expected("claude", "security-reviewer.AGENT.md"),
+        "claude agent",
+    );
+    assert_file_eq(
+        &target.join(".github/agents/security-reviewer.agent.md"),
+        &read_expected("copilot", "security-reviewer.AGENT.md"),
+        "copilot agent",
+    );
+    assert_file_eq(
+        &target.join(".opencode/agents/security-reviewer.md"),
+        &read_expected("opencode", "security-reviewer.AGENT.md"),
+        "opencode agent",
+    );
+
+    // Report enumerates everything written.
+    // 1 skill * 3 clients + 2 rules * 3 clients + 1 agent * 3 clients = 12.
+    assert_eq!(report.items.len(), 12, "report item count");
+}
+
+#[test]
+fn install_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+
+    install_from_local_path(&source, &target).expect("install 1");
+    let snapshot = read_target_tree(&target);
+
+    install_from_local_path(&source, &target).expect("install 2");
+    let snapshot2 = read_target_tree(&target);
+
+    assert_eq!(snapshot, snapshot2, "second install must be byte-identical");
+}
+
+fn read_target_tree(root: &Path) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    fn walk(dir: &Path, root: &Path, out: &mut Vec<(String, String)>) {
+        for entry in fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let p = entry.path();
+            if p.is_dir() {
+                walk(&p, root, out);
+            } else {
+                let rel = p.strip_prefix(root).unwrap().to_string_lossy().into_owned();
+                let content = fs::read_to_string(&p).unwrap();
+                out.push((rel, content));
+            }
+        }
+    }
+    walk(root, root, &mut out);
+    out.sort();
+    out
+}
+
+#[test]
+fn install_respects_audience_filter() {
+    // Build a tiny custom source with one skill that targets only `claude`.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+
+    let skill_dir = source.join("skills/claude-only");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        r#"---
+schema: 1
+name: claude-only
+description: Use only when working in Claude Code; this skill targets claude alone for testing audience filtering.
+metadata:
+  audience:
+    - claude
+---
+
+## Body
+
+Hello.
+"#,
+    )
+    .unwrap();
+
+    install_from_local_path(&source, &target).expect("install");
+
+    assert!(
+        target.join(".claude/skills/claude-only/SKILL.md").exists(),
+        "claude output present"
+    );
+    assert!(
+        !target.join(".github/skills/claude-only/SKILL.md").exists(),
+        "copilot output absent (filtered by audience)"
+    );
+    assert!(
+        !target.join(".agents/skills/claude-only/SKILL.md").exists(),
+        "opencode output absent (filtered by audience)"
+    );
+}


### PR DESCRIPTION
## Summary

First slice of Phase 3 (per [ADR-0001 build order](docs/adr/0001-multi-kind-compiler-architecture.md)). Adds a library API that walks a local SSOT source tree, parses each item via the existing `parse/`+`model/` stack, renders per-client output via `generate/`, and writes the result to disk at the per-client paths defined in [format-spec §7](docs/format-spec.md#7-generation-client-specific-output) / [ADR-0003](docs/adr/0003-generation-pipeline.md).

```rust
pub fn install_from_local_path(source: &Path, target: &Path) -> Result<InstallReport>;
```

| Kind  | Claude Code                | GitHub Copilot                                | opencode                       |
| ----- | -------------------------- | --------------------------------------------- | ------------------------------ |
| Skill | `.claude/skills/<n>/SKILL.md` | `.github/skills/<n>/SKILL.md`               | `.agents/skills/<n>/SKILL.md`  |
| Rule  | `.claude/rules/<n>.md`     | `.github/instructions/<n>.instructions.md`    | `.agents/rules/<n>/RULE.md`    |
| Agent | `.claude/agents/<n>.md`    | `.github/agents/<n>.agent.md`                 | `.opencode/agents/<n>.md`      |

Audience filter respected per the current model shape (`metadata.audience`). Promoting `audience` to a top-level field per the [PR #76 spec change](https://github.com/driftsys/upskill/pull/76) is a separate task (model layer).

## Tests

`tests/pipeline_local.rs`:
- **`install_writes_per_client_output_for_all_kinds`** — golden fixtures from `tests/fixtures/expected/` (the same corpus the existing `generate_*` tests use) validate that every kind × every client lands at the right path with byte-identical content. 12 outputs from 1 skill + 2 rules + 1 agent.
- **`install_is_idempotent`** — running twice produces a byte-identical tree.
- **`install_respects_audience_filter`** — a skill with `audience: [claude]` produces only the Claude Code output.

Plus three `pipeline`-internal unit tests covering the output-path mapping and the audience filter logic.

## Out of scope (later Phase 3 slices)

- CLI wiring (no `add` subcommand changes; v0.1 `add` still drives the shipped binary).
- Source fetching (git clone, GitLab, source-format parsing reuse).
- Lockfile (`.upskill-lock.json` schema 2 read/write, drift detection, in-place migration from v0.1).
- Bundle parsing and transitive `requires` resolution.
- Ancillary file management (`CLAUDE.md`, `.vscode/settings.json`, `opencode.json`).
- `update` / `remove` / `doctor` commands.

## Test plan

- [x] `just verify` clean locally (cargo fmt-check, clippy `-D warnings`, dprint check, markdownlint, build, 3 new integration tests + 3 new unit tests pass).
- [ ] CI passes (clippy, fmt, test, convco).
- [ ] No v0.1 test regressions (`cli_*` tests still pass).

## Notes

- Library-only PR — no CLI surface changes, no v0.1 behaviour changes. The shipped binary (`v0.1.x`, on `main`) is unaffected.
- Branches off latest `v0.2-redesign` (post-#77).
- Filing an epic/story to track the rest of Phase 3 is a follow-up; this PR is the smallest valuable unit and stands alone.
