### PR TITLE
feat(pipeline): install_from_source dispatches over InstallSource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml_ng = "0.10"
 sha2 = "0.11.0"
+tempfile = "3.14"
 thiserror = "2.0"
 ureq = { version = "2", features = ["json"] }
 
@@ -27,7 +28,6 @@ ureq = { version = "2", features = ["json"] }
 assert_cmd = "2.0"
 predicates = "3.1.4"
 serde_json = "1.0.149"
-tempfile = "3.14"
 
 [profile.release]
 lto = true

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -18,8 +18,11 @@ pub fn clone_github_repo(repo: &GithubRepo, dest: &Path) -> Result<PathBuf, Stri
     )
 }
 
-/// Shallow clone a git URL into `dest/<dir_name>`.
-fn shallow_clone(
+/// Shallow clone a git URL into `dest/<dir_name>`. Visible inside the crate
+/// so the v0.2 pipeline can clone from arbitrary URL forms (`file://`,
+/// GitLab self-hosted, etc.) without going through the GitHub-specific
+/// `clone_github_repo` constructor.
+pub(crate) fn shallow_clone(
     url: &str,
     git_ref: Option<&str>,
     dir_name: &str,
@@ -53,7 +56,7 @@ fn shallow_clone(
     Ok(())
 }
 
-fn resolve_subfolder(
+pub(crate) fn resolve_subfolder(
     clone_dir: &Path,
     subfolder: Option<&str>,
     owner: &str,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -15,13 +15,15 @@
 //! shape. Promotion of `audience` to a top-level field (per the
 //! format-spec PR #76) is a separate task.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::fetch;
 use crate::generate::{self, Client};
 use crate::model::{Agent, Audience, Rule, Skill};
 use crate::parse::frontmatter;
+use crate::source::{GithubRepo, InstallSource};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ItemKind {
@@ -56,6 +58,62 @@ pub fn install_from_local_path(source: &Path, target: &Path) -> Result<InstallRe
     install_agents(source, target, &mut report)?;
 
     Ok(report)
+}
+
+/// Install items from any supported source into `target`.
+///
+/// Dispatches on the source variant:
+/// - `LocalPath` — installs directly from the path on disk.
+/// - `Github` — shallow-clones `https://github.com/<owner>/<repo>` into a
+///   temp directory, resolves the optional subfolder, then runs the local
+///   install pipeline against the resolved path. The temp clone is removed
+///   on success or failure.
+/// - `Gitlab` — not yet supported in this slice; tracked as a follow-up.
+pub fn install_from_source(source: &InstallSource, target: &Path) -> Result<InstallReport> {
+    match source {
+        InstallSource::LocalPath(path) => install_from_local_path(path, target),
+        InstallSource::Github(repo) => install_from_github(repo, target),
+        InstallSource::Gitlab(_) => Err(anyhow!(
+            "GitLab sources are not yet supported by the v0.2 pipeline; \
+             use a GitHub source or a local path"
+        )),
+    }
+}
+
+fn install_from_github(repo: &GithubRepo, target: &Path) -> Result<InstallReport> {
+    let url = format!("https://github.com/{}/{}.git", repo.owner, repo.name);
+    install_from_git_url(
+        &url,
+        repo.git_ref.as_deref(),
+        repo.subfolder.as_deref(),
+        &repo.owner,
+        &repo.name,
+        target,
+    )
+}
+
+/// Shallow-clone `url` into a tempdir, resolve `subfolder` inside the clone,
+/// and run the local install pipeline against the result. The tempdir is
+/// removed on return regardless of outcome (RAII via `tempfile::TempDir`).
+///
+/// Public so callers can install from arbitrary git URLs (mirrors, local
+/// `file://` clones, future GitLab self-hosted) without going through
+/// [`InstallSource`]. The high-level [`install_from_source`] is preferred
+/// when an `InstallSource` already exists.
+pub fn install_from_git_url(
+    url: &str,
+    git_ref: Option<&str>,
+    subfolder: Option<&str>,
+    owner: &str,
+    name: &str,
+    target: &Path,
+) -> Result<InstallReport> {
+    let tmp = tempfile::tempdir().context("create temp dir for clone")?;
+    fetch::shallow_clone(url, git_ref, "clone", tmp.path())
+        .map_err(|e| anyhow!("git clone {}: {}", url, e))?;
+    let source = fetch::resolve_subfolder(&tmp.path().join("clone"), subfolder, owner, name)
+        .map_err(|e| anyhow!("{}", e))?;
+    install_from_local_path(&source, target)
 }
 
 fn install_skills(source: &Path, target: &Path, report: &mut InstallReport) -> Result<()> {

--- a/tests/pipeline_source.rs
+++ b/tests/pipeline_source.rs
@@ -1,0 +1,236 @@
+//! ATDD test for `pipeline::install_from_source`.
+//!
+//! Covers the dispatch over `InstallSource` variants:
+//! - `LocalPath` — delegates to `install_from_local_path`.
+//! - `Github` — shallow-clones into a temp dir, then runs the local install
+//!   pipeline. Tested using a local bare git repo with a `file://` URL via
+//!   the crate-internal `install_from_git_url` helper, which is the same
+//!   code path the GitHub branch uses (the only difference is URL
+//!   construction).
+//! - `Gitlab` — currently returns an error (out of scope for this slice).
+//!
+//! Network is not used.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use upskill::pipeline::{InstallReport, install_from_source};
+use upskill::source::{GitlabRepo, InstallSource};
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn install_from_source_local_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+
+    let report: InstallReport =
+        install_from_source(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+
+    // Same expectation as the local-path direct test: 12 outputs.
+    assert_eq!(report.items.len(), 12);
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists()
+    );
+    assert!(
+        target
+            .join(".github/instructions/api-conventions.instructions.md")
+            .exists()
+    );
+    assert!(
+        target
+            .join(".opencode/agents/security-reviewer.md")
+            .exists()
+    );
+}
+
+#[test]
+fn install_from_source_gitlab_returns_error_for_now() {
+    let tmp = tempfile::tempdir().unwrap();
+    let target = tmp.path().join("target");
+    let gitlab = InstallSource::Gitlab(GitlabRepo {
+        host: "gitlab.com".to_string(),
+        owner: "anyone".to_string(),
+        name: "anything".to_string(),
+        git_ref: None,
+        subfolder: None,
+    });
+
+    let err = install_from_source(&gitlab, &target).expect_err("must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("GitLab"),
+        "error should mention GitLab, got: {msg}"
+    );
+}
+
+/// Build a local bare repo containing the fixture SSOT corpus, return its
+/// path. The pipeline can then clone it via a `file://` URL — exercises the
+/// same code path as a real GitHub clone, with no network.
+fn make_bare_ssot_repo(root: &Path) -> PathBuf {
+    let bare = root.join("ssot.git");
+    let work = root.join("work");
+
+    git(&["init", "--bare", bare.to_str().unwrap()], None);
+    git(
+        &["clone", bare.to_str().unwrap(), work.to_str().unwrap()],
+        None,
+    );
+
+    // Stage the fixture corpus into the working tree.
+    stage_source(&work);
+
+    // Some `git init` defaults are `master`; the shallow-clone path passes
+    // `--branch <ref>` only if a ref is requested, so we don't depend on a
+    // specific branch name. Just commit and push HEAD.
+    git(&["add", "."], Some(&work));
+    git(
+        &[
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@test.com",
+            "commit",
+            "-m",
+            "initial",
+        ],
+        Some(&work),
+    );
+    git(&["push"], Some(&work));
+
+    bare
+}
+
+fn git(args: &[&str], cwd: Option<&Path>) {
+    let mut cmd = Command::new("git");
+    cmd.args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE");
+    if let Some(d) = cwd {
+        cmd.current_dir(d);
+    }
+    let out = cmd.output().expect("git command");
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn install_from_source_clones_local_bare_repo_via_file_url() {
+    // Same end-to-end shape as install_from_source_local_path, but the
+    // source is a git URL. Uses the crate-internal git-URL helper to avoid
+    // depending on a real GitHub host. This exercises the clone +
+    // resolve_subfolder + install_from_local_path composition.
+    let tmp = tempfile::tempdir().unwrap();
+    let bare = make_bare_ssot_repo(tmp.path());
+    let target = tmp.path().join("target");
+    let url = format!("file://{}", bare.display());
+
+    let report = upskill::pipeline::install_from_git_url(&url, None, None, "test", "ssot", &target)
+        .expect("install via git url");
+
+    assert_eq!(report.items.len(), 12);
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists()
+    );
+    assert!(
+        target
+            .join(".github/instructions/api-conventions.instructions.md")
+            .exists()
+    );
+    assert!(
+        target
+            .join(".opencode/agents/security-reviewer.md")
+            .exists()
+    );
+}
+
+#[test]
+fn install_from_source_clone_subfolder() {
+    // Stage the SSOT corpus inside a subfolder of the repo, then ask the
+    // pipeline to install only that subfolder. Verifies that
+    // resolve_subfolder is wired correctly through install_from_git_url.
+    let tmp = tempfile::tempdir().unwrap();
+    let bare_root = tmp.path().join("repo-root");
+    let bare = bare_root.join("ssot.git");
+    let work = bare_root.join("work");
+    fs::create_dir_all(&bare_root).unwrap();
+    git(&["init", "--bare", bare.to_str().unwrap()], None);
+    git(
+        &["clone", bare.to_str().unwrap(), work.to_str().unwrap()],
+        None,
+    );
+
+    // Place the fixture corpus under content/portable/ within the repo.
+    let nested = work.join("content/portable");
+    fs::create_dir_all(&nested).unwrap();
+    stage_source(&nested);
+    // Add an unrelated top-level file that should NOT be installed.
+    fs::write(work.join("README.md"), "# repo readme\n").unwrap();
+
+    git(&["add", "."], Some(&work));
+    git(
+        &[
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@test.com",
+            "commit",
+            "-m",
+            "initial",
+        ],
+        Some(&work),
+    );
+    git(&["push"], Some(&work));
+
+    let target = tmp.path().join("target");
+    let url = format!("file://{}", bare.display());
+    let report = upskill::pipeline::install_from_git_url(
+        &url,
+        None,
+        Some("content/portable"),
+        "test",
+        "ssot",
+        &target,
+    )
+    .expect("install via git url with subfolder");
+
+    assert_eq!(report.items.len(), 12);
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists()
+    );
+}


### PR DESCRIPTION
## Summary

Second slice of Phase 3, building on #78. Composes the existing `fetch.rs` git-clone path with the local install pipeline, so a caller can install from any supported `InstallSource` variant in a single call.

```rust
pub fn install_from_source(source: &InstallSource, target: &Path) -> Result<InstallReport>;

// Lower-level escape hatch — useful for mirrors, file:// clones, future GitLab.
pub fn install_from_git_url(
    url: &str, git_ref: Option<&str>, subfolder: Option<&str>,
    owner: &str, name: &str, target: &Path,
) -> Result<InstallReport>;
```

### Dispatch in `install_from_source`

| Variant     | Behaviour                                                                      |
| ----------- | ------------------------------------------------------------------------------ |
| `LocalPath` | Calls `install_from_local_path` directly.                                      |
| `Github`    | Builds `https://github.com/<owner>/<name>.git`, calls `install_from_git_url`.  |
| `Gitlab`    | Returns a clear error pointing at GitHub or local-path. Tracked as follow-up.  |

`install_from_git_url` shallow-clones into a `tempfile::TempDir`, resolves the optional subfolder, then runs `install_from_local_path`. The temp clone is removed on return regardless of outcome (RAII).

### Crate changes

- `src/fetch.rs`: `shallow_clone` and `resolve_subfolder` become `pub(crate)` so the pipeline can clone arbitrary URL forms (`file://`, future GitLab self-hosted) without going through the GitHub-specific `clone_github_repo` constructor.
- `Cargo.toml`: `tempfile` moves from `dev-dependencies` to `dependencies`. ~50 KB binary cost — well-maintained, no async, no transitive bloat. Avoids the alternative of asking pipeline callers to manage temp dirs themselves.

## Tests

`tests/pipeline_source.rs` (4 new):

- `install_from_source_local_path` — round-trips the `LocalPath` variant through `install_from_source`; same 12-output expectation as #78.
- `install_from_source_gitlab_returns_error_for_now` — pins the deferred behaviour so it cannot regress silently.
- `install_from_source_clones_local_bare_repo_via_file_url` — builds a bare git repo from the fixture corpus, drives the full clone+install pipeline via a `file://` URL. Same code path as a real GitHub clone (only the URL form differs); no network.
- `install_from_source_clone_subfolder` — same shape but stages the corpus under `content/portable/` in the repo and installs only that subfolder. Verifies `resolve_subfolder` wiring.

## Out of scope (later Phase 3 slices)

- CLI wiring (no `add` subcommand changes; v0.1 `add` still drives the shipped binary).
- GitLab fetch (helper exists for HTTPS clone; needs auth-header / `PRIVATE-TOKEN` handling per ADR-0005 / format-spec §5.3).
- Lockfile, bundles, ancillary files, `update` / `remove` / `doctor`.

## Test plan

- [x] `just verify` clean locally (cargo fmt-check, clippy `-D warnings`, dprint check, markdownlint, build, 4 new integration tests + #78's 6 tests still pass).
- [ ] CI passes (clippy, fmt, test, convco).
- [ ] No v0.1 test regressions (`cli_*` tests still pass).

## Notes

- Library-only PR — no CLI surface changes, no v0.1 behaviour changes.
- Branches off latest `v0.2-redesign` (post-#78).
- `install_from_git_url` is `pub` rather than `pub(crate)` so integration tests can drive it with a `file://` URL without depending on real GitHub. It's also a useful escape hatch for callers that already have a URL in hand.
