### PR TITLE
feat(cli): hidden --pipeline flag on add routes to v0.2 pipeline

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,14 @@ enum Commands {
         /// Use user-level global installation target
         #[arg(short = 'g', long = "global")]
         global: bool,
+        /// Use the v0.2 SSOT generation pipeline (rules/skills/agents → per-client output).
+        ///
+        /// Replaces the v0.1 fetch-and-symlink flow for this invocation. When set,
+        /// per-agent flags (--claude, --copilot, --all, --copy) and --skill are ignored;
+        /// the pipeline writes to the per-client paths defined in format-spec §7.
+        /// Will become the default in v0.2.0.
+        #[arg(long = "pipeline", hide = true)]
+        pipeline: bool,
     },
     /// List installed skills
     List {
@@ -121,7 +129,14 @@ fn main() {
             all,
             copy,
             global,
-        } => run_add(&source, &skills, claude, copilot, all, copy, global),
+            pipeline,
+        } => {
+            if pipeline {
+                run_pipeline_add(&source, global)
+            } else {
+                run_add(&source, &skills, claude, copilot, all, copy, global)
+            }
+        }
         Commands::List { global } => run_list(global),
         Commands::Remove { skill, yes, global } => run_remove(&skill, yes, global),
         Commands::Check { global } => run_check(global),
@@ -389,6 +404,69 @@ fn run_add(
             eprintln!("error: {}", err);
             EXIT_USAGE
         }
+    }
+}
+
+fn run_pipeline_add(source: &str, global: bool) -> i32 {
+    let parsed = match upskill::source::parse_install_source(source) {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("error: invalid source: {}", err);
+            return EXIT_USAGE;
+        }
+    };
+
+    let target = match pipeline_target(global) {
+        Ok(t) => t,
+        Err(err) => {
+            eprintln!("error: {}", err);
+            return EXIT_ERROR;
+        }
+    };
+
+    let report = match upskill::pipeline::install_from_source(&parsed, &target) {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!("error: {:#}", err);
+            return EXIT_ERROR;
+        }
+    };
+
+    print_pipeline_report(&report, source);
+    EXIT_SUCCESS
+}
+
+fn pipeline_target(global: bool) -> anyhow::Result<std::path::PathBuf> {
+    if global {
+        std::env::var_os("HOME")
+            .map(std::path::PathBuf::from)
+            .ok_or_else(|| anyhow::anyhow!("HOME is not set"))
+    } else {
+        std::env::current_dir().context("failed to get current directory")
+    }
+}
+
+fn print_pipeline_report(report: &upskill::pipeline::InstallReport, source: &str) {
+    use std::collections::BTreeMap;
+    use upskill::pipeline::ItemKind;
+
+    println!("Installed {} files from {}", report.items.len(), source);
+
+    // Group by (kind, name) so each item lists its emitted clients on one line.
+    let mut grouped: BTreeMap<(ItemKind, String), Vec<&'static str>> = BTreeMap::new();
+    for item in &report.items {
+        grouped
+            .entry((item.kind, item.name.clone()))
+            .or_default()
+            .push(item.client.name());
+    }
+    for ((kind, name), clients) in grouped {
+        let kind_label = match kind {
+            ItemKind::Rule => "rule ",
+            ItemKind::Skill => "skill",
+            ItemKind::Agent => "agent",
+        };
+        println!("  {} {:<32} → {}", kind_label, name, clients.join(", "));
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -25,7 +25,7 @@ use crate::model::{Agent, Audience, Rule, Skill};
 use crate::parse::frontmatter;
 use crate::source::{GithubRepo, InstallSource};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ItemKind {
     Rule,
     Skill,

--- a/tests/cli_pipeline_add.rs
+++ b/tests/cli_pipeline_add.rs
@@ -1,0 +1,107 @@
+//! ATDD test for `upskill add --pipeline <local-path>`.
+//!
+//! Drives the CLI surface end-to-end. The `--pipeline` flag (hidden in
+//! `--help`) routes the v0.1 `add` subcommand to `pipeline::install_from_source`
+//! instead of the v0.1 fetch-and-symlink flow, allowing v0.2 install to be
+//! exercised via the binary while v0.1 behaviour stays the default.
+//!
+//! Local-path source only — no network. GitHub-source coverage is in
+//! `tests/pipeline_source.rs` at the library level.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn pipeline_flag_installs_local_ssot_to_cwd() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["add", "--pipeline", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    // Report header includes the source label and item count (12 outputs from
+    // 1 skill + 2 rules + 1 agent × 3 clients).
+    assert!(out.contains("Installed 12"), "stdout missing report: {out}");
+
+    // Spot-check one output per client at the expected per-client paths.
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists()
+    );
+    assert!(
+        target
+            .join(".github/instructions/api-conventions.instructions.md")
+            .exists()
+    );
+    assert!(
+        target
+            .join(".opencode/agents/security-reviewer.md")
+            .exists()
+    );
+}
+
+#[test]
+fn pipeline_flag_invalid_source_returns_usage_error() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "--pipeline", "not a valid source"])
+        .assert()
+        .failure()
+        .code(2); // EXIT_USAGE per CLI spec.
+}
+
+#[test]
+fn pipeline_flag_is_hidden_from_help() {
+    // The flag is intentionally hidden — it's a transitional escape hatch
+    // until the v0.2 surface replaces v0.1 add. Pin the hide(true) attribute
+    // so a future maintainer doesn't surface it accidentally before that
+    // migration lands.
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .args(["add", "--help"])
+        .assert()
+        .success();
+
+    let help = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        !help.contains("--pipeline"),
+        "expected --pipeline hidden from help, got:\n{help}"
+    );
+}


### PR DESCRIPTION
## Summary

Third slice of Phase 3, building on #78 and #79. First v0.2 behaviour reachable from the binary, opt-in via a hidden flag so v0.1 `add` (and its 13 `cli_*.rs` tests) stay unchanged.

```bash
upskill add --pipeline <source>
```

Routes the v0.1 `Add` subcommand to `pipeline::install_from_source` from #79 instead of the v0.1 fetch-and-symlink flow. Source format parsing reuses the existing `source::parse_install_source`, so all the v0.1 source forms (`owner/repo`, `owner/repo@ref`, `owner/repo:path`, full URLs, local paths) work unchanged. Target is cwd by default, `$HOME` with `-g` / `--global`.

The flag is intentionally `hide(true)` in `--help` — a transitional escape hatch until the v0.2 surface (per [ADR-0004](docs/adr/0004-cli-surface.md)) replaces v0.1 `add` wholesale. Surfacing it now would publish a verb the docs don't yet describe.

When `--pipeline` is set, the v0.1-only flags (`--claude`, `--copilot`, `--all`, `--copy`, `--skill`) are silently ignored. Tightening that into a clap conflict is a follow-up.

### stdout report

```
Installed 12 files from ./local/path
  rule  api-conventions          → claude, copilot, opencode
  rule  license-awareness        → claude, copilot, opencode
  skill create-api-endpoint      → claude, copilot, opencode
  agent security-reviewer        → claude, copilot, opencode
```

Grouped by `(kind, name)` via `BTreeMap` for deterministic output.

## Tests

`tests/cli_pipeline_add.rs` (3 new):

- `pipeline_flag_installs_local_ssot_to_cwd` — drives the binary against a temp SSOT source, asserts the report header and per-client output paths land in cwd.
- `pipeline_flag_invalid_source_returns_usage_error` — pins exit code 2 for malformed sources.
- `pipeline_flag_is_hidden_from_help` — pins `hide(true)` so a future maintainer doesn't surface the flag accidentally before the v0.2 `add` migration.

## Crate changes

- `src/main.rs` — new `--pipeline` flag on `Add`; new `run_pipeline_add`, `pipeline_target`, `print_pipeline_report`.
- `src/pipeline.rs` — `ItemKind` gains `PartialOrd` + `Ord` so it can key the `BTreeMap` used by `print_pipeline_report`.

## Out of scope (later Phase 3 slices)

- Replace v0.1 `add` wholesale with the pipeline flow + rewrite `cli_*.rs` tests + drop `--pipeline` flag.
- Lockfile (`.upskill-lock.json` schema 2 read/write).
- Bundle support, ancillary files, `update` / `remove` / `doctor`.

## Test plan

- [x] `just verify` clean locally (cargo fmt-check, clippy `-D warnings`, dprint check, markdownlint, build).
- [x] All tests pass: 3 new CLI tests + 4 from #79 + 6 from #78 + 13 v0.1 `cli_*.rs` tests + library unit tests.
- [ ] CI passes (clippy, fmt, test, convco).

## Notes

- Branches off latest `v0.2-redesign` (post-#79).
- v0.1 `add` behaviour is byte-identical without the flag — same shipped binary surface.
