### PR TITLE
feat(lockfile): write schema-2 .upskill-lock.json after pipeline install

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod fetch;
 pub mod generate;
 pub mod install;
 pub mod lockfile;
+pub mod lockfile_v2;
 pub mod model;
 pub mod parse;
 pub mod pipeline;

--- a/src/lockfile_v2.rs
+++ b/src/lockfile_v2.rs
@@ -1,0 +1,332 @@
+//! v0.2 lockfile (`.upskill-lock.json`, `schema: 2`).
+//!
+//! Per [ADR-0003](../../docs/adr/0003-generation-pipeline.md). Records what
+//! the pipeline installed into a consumer project so a future `update` /
+//! `remove` / `doctor` can reason about state. The filename is unchanged
+//! from v0.1; the `schema:` field discriminates.
+//!
+//! Scope of this slice:
+//! - Types + load/save/upsert for `schema: 2` items and (placeholder) bundles.
+//! - Wiring into [`crate::pipeline::install_from_source`] so the lockfile is
+//!   written after a successful install.
+//! - v0.1 → v0.2 in-place migration is a separate slice.
+//! - Bundle entries are part of the schema but not yet populated (Phase 3
+//!   bundle slice).
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use crate::pipeline::{InstallReport, ItemKind};
+
+/// On-disk filename. Same as v0.1 — `schema` discriminates the shape.
+pub const LOCKFILE_NAME: &str = ".upskill-lock.json";
+
+/// The schema version this module produces.
+pub const CURRENT_SCHEMA: u32 = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LockfileV2 {
+    pub schema: u32,
+    #[serde(default)]
+    pub items: Vec<LockedItem>,
+    #[serde(default)]
+    pub bundles: Vec<LockedBundle>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LockedItem {
+    /// `rule` | `skill` | `agent`.
+    pub kind: String,
+    pub name: String,
+    /// Canonical source label (see [`crate::source::InstallSource`]'s
+    /// `Display` impl).
+    pub source: String,
+    /// Resolved git ref when the source pinned one (branch, tag, SHA).
+    /// Absent for local-path sources or unpinned remotes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "ref")]
+    pub git_ref: Option<String>,
+    /// SHA-256 of the SSOT item directory at install time. Used by future
+    /// `update` / `doctor` for drift detection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+}
+
+/// Placeholder for the bundle-install slice. Schema is finalised so the
+/// shape is forward-compatible; no bundle entries are produced today.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LockedBundle {
+    pub name: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "ref")]
+    pub git_ref: Option<String>,
+    /// Item names this bundle resolved to.
+    #[serde(default)]
+    pub items: Vec<String>,
+}
+
+impl Default for LockfileV2 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LockfileV2 {
+    pub fn new() -> Self {
+        Self {
+            schema: CURRENT_SCHEMA,
+            items: Vec::new(),
+            bundles: Vec::new(),
+        }
+    }
+
+    /// Load `<project_root>/.upskill-lock.json`. Returns an empty `schema: 2`
+    /// lockfile when the file does not exist.
+    ///
+    /// Errors:
+    /// - File exists but cannot be parsed as JSON.
+    /// - File parses but its `schema` is not 2 (v0.1 schema-1 migration is a
+    ///   separate slice; this implementation refuses to silently downgrade
+    ///   or upgrade).
+    pub fn load(project_root: &Path) -> Result<Self> {
+        let path = lockfile_path(project_root);
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Self::new()),
+            Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
+        };
+        let parsed: Self =
+            serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+        if parsed.schema != CURRENT_SCHEMA {
+            anyhow::bail!(
+                "{}: schema {} not supported by this implementation (expected {})",
+                path.display(),
+                parsed.schema,
+                CURRENT_SCHEMA
+            );
+        }
+        Ok(parsed)
+    }
+
+    /// Add or replace by `(kind, name)`. Items are kept sorted for
+    /// deterministic on-disk output.
+    pub fn upsert(&mut self, item: LockedItem) {
+        self.items
+            .retain(|existing| !(existing.kind == item.kind && existing.name == item.name));
+        self.items.push(item);
+        self.items.sort();
+    }
+
+    /// Remove by `(kind, name)`.
+    pub fn remove(&mut self, kind: &str, name: &str) {
+        self.items
+            .retain(|existing| !(existing.kind == kind && existing.name == name));
+    }
+
+    /// Persist to `<project_root>/.upskill-lock.json`. Pretty-printed JSON
+    /// with a trailing newline so editors don't fight us.
+    pub fn save(&self, project_root: &Path) -> Result<()> {
+        let path = lockfile_path(project_root);
+        let json = serde_json::to_string_pretty(self).context("serialize lockfile")?;
+        std::fs::write(&path, format!("{json}\n"))
+            .with_context(|| format!("write {}", path.display()))
+    }
+}
+
+fn lockfile_path(project_root: &Path) -> PathBuf {
+    project_root.join(LOCKFILE_NAME)
+}
+
+/// Project an [`InstallReport`] into one [`LockedItem`] per unique `(kind,
+/// name)` (the report has one entry per kind × name × client; the lockfile
+/// records each item once).
+///
+/// `source_label` is taken verbatim from the caller — typically the
+/// `Display` form of the [`InstallSource`] or the original CLI string.
+/// `git_ref` and `hash` are looked up by the caller (the pipeline) per
+/// item; threading them through here keeps the lockfile module free of
+/// filesystem and source concerns.
+pub fn items_from_report(
+    report: &InstallReport,
+    source_label: &str,
+    git_ref: Option<&str>,
+    mut hash_for: impl FnMut(ItemKind, &str) -> Option<String>,
+) -> Vec<LockedItem> {
+    use std::collections::BTreeSet;
+    let mut seen: BTreeSet<(ItemKind, String)> = BTreeSet::new();
+    let mut out = Vec::new();
+    for entry in &report.items {
+        if !seen.insert((entry.kind, entry.name.clone())) {
+            continue;
+        }
+        out.push(LockedItem {
+            kind: kind_label(entry.kind).to_string(),
+            name: entry.name.clone(),
+            source: source_label.to_string(),
+            git_ref: git_ref.map(str::to_string),
+            hash: hash_for(entry.kind, &entry.name),
+        });
+    }
+    out
+}
+
+fn kind_label(kind: ItemKind) -> &'static str {
+    match kind {
+        ItemKind::Rule => "rule",
+        ItemKind::Skill => "skill",
+        ItemKind::Agent => "agent",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generate::Client;
+    use crate::pipeline::InstalledItem;
+    use std::path::PathBuf;
+
+    fn item(kind: &str, name: &str) -> LockedItem {
+        LockedItem {
+            kind: kind.to_string(),
+            name: name.to_string(),
+            source: "github:driftsys/skills".to_string(),
+            git_ref: Some("v1.0.0".to_string()),
+            hash: Some("sha256:deadbeef".to_string()),
+        }
+    }
+
+    #[test]
+    fn new_lockfile_has_current_schema() {
+        let lock = LockfileV2::new();
+        assert_eq!(lock.schema, CURRENT_SCHEMA);
+        assert!(lock.items.is_empty());
+        assert!(lock.bundles.is_empty());
+    }
+
+    #[test]
+    fn upsert_replaces_existing_item_with_same_kind_and_name() {
+        let mut lock = LockfileV2::new();
+        lock.upsert(item("skill", "code-review"));
+        let mut updated = item("skill", "code-review");
+        updated.git_ref = Some("v2.0.0".to_string());
+        lock.upsert(updated);
+        assert_eq!(lock.items.len(), 1);
+        assert_eq!(lock.items[0].git_ref, Some("v2.0.0".to_string()));
+    }
+
+    #[test]
+    fn upsert_keeps_distinct_kinds_separate() {
+        // A rule and a skill with the same name MUST coexist.
+        let mut lock = LockfileV2::new();
+        lock.upsert(item("rule", "shared-name"));
+        lock.upsert(item("skill", "shared-name"));
+        assert_eq!(lock.items.len(), 2);
+    }
+
+    #[test]
+    fn items_are_sorted_for_deterministic_output() {
+        let mut lock = LockfileV2::new();
+        lock.upsert(item("skill", "z"));
+        lock.upsert(item("skill", "a"));
+        let names: Vec<_> = lock.items.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "z"]);
+    }
+
+    #[test]
+    fn remove_filters_by_kind_and_name() {
+        let mut lock = LockfileV2::new();
+        lock.upsert(item("rule", "shared-name"));
+        lock.upsert(item("skill", "shared-name"));
+        lock.remove("rule", "shared-name");
+        assert_eq!(lock.items.len(), 1);
+        assert_eq!(lock.items[0].kind, "skill");
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut lock = LockfileV2::new();
+        lock.upsert(item("skill", "code-review"));
+        lock.save(tmp.path()).expect("save");
+
+        let loaded = LockfileV2::load(tmp.path()).expect("load");
+        assert_eq!(loaded, lock);
+    }
+
+    #[test]
+    fn load_missing_file_returns_empty_v2() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock = LockfileV2::load(tmp.path()).expect("load");
+        assert_eq!(lock, LockfileV2::new());
+    }
+
+    #[test]
+    fn load_rejects_unsupported_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(LOCKFILE_NAME),
+            r#"{"schema": 99, "items": [], "bundles": []}"#,
+        )
+        .unwrap();
+        let err = LockfileV2::load(tmp.path()).expect_err("must reject");
+        assert!(err.to_string().contains("schema 99"));
+    }
+
+    #[test]
+    fn load_rejects_v1_schema_no_silent_downgrade() {
+        // v0.1 lockfiles do not have a `schema` field. Migration is a
+        // separate slice; until then, refuse to load to avoid silent
+        // schema downgrade.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(LOCKFILE_NAME),
+            r#"{"skills": [{"name": "x", "source": "y"}]}"#,
+        )
+        .unwrap();
+        let err = LockfileV2::load(tmp.path()).expect_err("must reject");
+        // serde rejects missing required `schema` field.
+        assert!(err.to_string().contains("parse"));
+    }
+
+    #[test]
+    fn items_from_report_dedupes_per_kind_name() {
+        // Build a report with one skill installed for all three clients —
+        // the lockfile should record it as one item, not three.
+        let report = InstallReport {
+            items: vec![
+                InstalledItem {
+                    kind: ItemKind::Skill,
+                    name: "code-review".into(),
+                    client: Client::Claude,
+                    output_path: PathBuf::from(".claude/skills/code-review/SKILL.md"),
+                    source_hash: Some("sha256:abc".into()),
+                },
+                InstalledItem {
+                    kind: ItemKind::Skill,
+                    name: "code-review".into(),
+                    client: Client::Copilot,
+                    output_path: PathBuf::from(".github/skills/code-review/SKILL.md"),
+                    source_hash: Some("sha256:abc".into()),
+                },
+                InstalledItem {
+                    kind: ItemKind::Skill,
+                    name: "code-review".into(),
+                    client: Client::OpenCode,
+                    output_path: PathBuf::from(".agents/skills/code-review/SKILL.md"),
+                    source_hash: Some("sha256:abc".into()),
+                },
+            ],
+        };
+
+        let items = items_from_report(&report, "local:./src", None, |_, _| {
+            Some("sha256:abc".into())
+        });
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].kind, "skill");
+        assert_eq!(items[0].name, "code-review");
+        assert_eq!(items[0].source, "local:./src");
+        assert_eq!(items[0].hash, Some("sha256:abc".into()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,7 +424,7 @@ fn run_pipeline_add(source: &str, global: bool) -> i32 {
         }
     };
 
-    let report = match upskill::pipeline::install_from_source(&parsed, &target) {
+    let report = match upskill::pipeline::install_with_lockfile(&parsed, &target) {
         Ok(r) => r,
         Err(err) => {
             eprintln!("error: {:#}", err);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -39,6 +39,10 @@ pub struct InstalledItem {
     pub client: Client,
     /// Path relative to the install target root.
     pub output_path: PathBuf,
+    /// SHA-256 of the SSOT item directory at install time. Used by the
+    /// lockfile (#schema-2) for drift detection. Repeated across the per-
+    /// client entries for the same item — they share one SSOT input.
+    pub source_hash: Option<String>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -56,6 +60,43 @@ pub fn install_from_local_path(source: &Path, target: &Path) -> Result<InstallRe
     install_skills(source, target, &mut report)?;
     install_rules(source, target, &mut report)?;
     install_agents(source, target, &mut report)?;
+
+    Ok(report)
+}
+
+/// Install + write lockfile. Consumer-facing entry point.
+///
+/// Calls [`install_from_source`] then merges the resulting [`InstallReport`]
+/// into `<target>/.upskill-lock.json` via [`crate::lockfile_v2`]. Existing
+/// lockfile entries for the same `(kind, name)` are replaced; entries
+/// installed from a different source are left in place.
+///
+/// `git_ref` recorded per item is taken from the source variant when one
+/// is pinned (Github/Gitlab `git_ref`); local-path sources record `None`.
+/// `source` label is the [`InstallSource`] `Display` form.
+pub fn install_with_lockfile(source: &InstallSource, target: &Path) -> Result<InstallReport> {
+    let report = install_from_source(source, target)?;
+
+    let label = source.to_string();
+    let git_ref = match source {
+        InstallSource::Github(r) => r.git_ref.as_deref(),
+        InstallSource::Gitlab(r) => r.git_ref.as_deref(),
+        InstallSource::LocalPath(_) => None,
+    };
+    let hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> = report
+        .items
+        .iter()
+        .map(|it| ((it.kind, it.name.clone()), it.source_hash.clone()))
+        .collect();
+    let new_items = crate::lockfile_v2::items_from_report(&report, &label, git_ref, |k, n| {
+        hashes.get(&(k, n.to_string())).cloned().flatten()
+    });
+
+    let mut lock = crate::lockfile_v2::LockfileV2::load(target)?;
+    for item in new_items {
+        lock.upsert(item);
+    }
+    lock.save(target)?;
 
     Ok(report)
 }
@@ -127,6 +168,7 @@ fn install_skills(source: &Path, target: &Path, report: &mut InstallReport) -> R
         let (skill, body) = frontmatter::parse::<Skill>(&raw)
             .with_context(|| format!("parse {}", entry_path.display()))?;
         let audience = audience_of(skill.metadata.as_ref());
+        let source_hash = crate::lockfile::hash_skill_dir(&dir);
 
         for client in ALL_CLIENTS {
             if !targets(client, audience.as_deref()) {
@@ -141,6 +183,7 @@ fn install_skills(source: &Path, target: &Path, report: &mut InstallReport) -> R
                 name: name.clone(),
                 client,
                 output_path: rel,
+                source_hash: source_hash.clone(),
             });
         }
     }
@@ -158,6 +201,7 @@ fn install_rules(source: &Path, target: &Path, report: &mut InstallReport) -> Re
         let (rule, body) = frontmatter::parse::<Rule>(&raw)
             .with_context(|| format!("parse {}", entry_path.display()))?;
         let audience = audience_of(rule.metadata.as_ref());
+        let source_hash = crate::lockfile::hash_skill_dir(&dir);
 
         for client in ALL_CLIENTS {
             if !targets(client, audience.as_deref()) {
@@ -172,6 +216,7 @@ fn install_rules(source: &Path, target: &Path, report: &mut InstallReport) -> Re
                 name: name.clone(),
                 client,
                 output_path: rel,
+                source_hash: source_hash.clone(),
             });
         }
     }
@@ -189,6 +234,7 @@ fn install_agents(source: &Path, target: &Path, report: &mut InstallReport) -> R
         let (agent, body) = frontmatter::parse::<Agent>(&raw)
             .with_context(|| format!("parse {}", entry_path.display()))?;
         let audience = audience_of(agent.metadata.as_ref());
+        let source_hash = crate::lockfile::hash_skill_dir(&dir);
 
         for client in ALL_CLIENTS {
             if !targets(client, audience.as_deref()) {
@@ -203,6 +249,7 @@ fn install_agents(source: &Path, target: &Path, report: &mut InstallReport) -> R
                 name: name.clone(),
                 client,
                 output_path: rel,
+                source_hash: source_hash.clone(),
             });
         }
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::PathBuf;
 
 use thiserror::Error;
@@ -24,6 +25,44 @@ pub enum InstallSource {
     Github(GithubRepo),
     Gitlab(GitlabRepo),
     LocalPath(PathBuf),
+}
+
+/// Stable, round-trippable string label for use in lockfiles, log lines,
+/// and CLI output. Format mirrors what `parse_install_source` accepts:
+///
+/// - `github:<owner>/<name>[@<ref>][:<subfolder>]`
+/// - `gitlab:<owner>/<name>[@<ref>][:<subfolder>]` (host omitted when
+///   `gitlab.com`; otherwise `gitlab+<host>:...`)
+/// - `local:<path>` (absolute when known, otherwise as-given)
+impl fmt::Display for InstallSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InstallSource::Github(r) => write!(f, "github:{}/{}", r.owner, r.name)
+                .and_then(|_| match &r.git_ref {
+                    Some(g) => write!(f, "@{}", g),
+                    None => Ok(()),
+                })
+                .and_then(|_| match &r.subfolder {
+                    Some(s) => write!(f, ":{}", s),
+                    None => Ok(()),
+                }),
+            InstallSource::Gitlab(r) => {
+                if r.host == "gitlab.com" {
+                    write!(f, "gitlab:{}/{}", r.owner, r.name)?;
+                } else {
+                    write!(f, "gitlab+{}:{}/{}", r.host, r.owner, r.name)?;
+                }
+                if let Some(g) = &r.git_ref {
+                    write!(f, "@{}", g)?;
+                }
+                if let Some(s) = &r.subfolder {
+                    write!(f, ":{}", s)?;
+                }
+                Ok(())
+            }
+            InstallSource::LocalPath(p) => write!(f, "local:{}", p.display()),
+        }
+    }
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -1,0 +1,139 @@
+//! ATDD tests for `pipeline::install_with_lockfile`.
+//!
+//! Validates that a successful install writes a v0.2 schema-2 lockfile
+//! (`.upskill-lock.json`) at the consumer-project root with one entry
+//! per `(kind, name)` carrying the source label, optional git ref, and
+//! SSOT content hash.
+
+use std::fs;
+use std::path::Path;
+use upskill::lockfile_v2::{CURRENT_SCHEMA, LockfileV2};
+use upskill::pipeline::install_with_lockfile;
+use upskill::source::InstallSource;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn install_writes_schema_2_lockfile_at_target_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+
+    let lock_path = target.join(".upskill-lock.json");
+    assert!(
+        lock_path.exists(),
+        "lockfile must be written at target root"
+    );
+
+    let raw = fs::read_to_string(&lock_path).unwrap();
+    let parsed: LockfileV2 = serde_json::from_str(&raw).expect("valid schema-2 JSON");
+    assert_eq!(parsed.schema, CURRENT_SCHEMA);
+
+    // 1 skill + 2 rules + 1 agent = 4 unique items (one entry per kind/name,
+    // not per client).
+    assert_eq!(parsed.items.len(), 4, "{:#?}", parsed.items);
+
+    // Every entry has the source label and a SHA-256 hash; local-path
+    // sources record no git_ref.
+    let expected_label = format!("local:{}", source.display());
+    for item in &parsed.items {
+        assert_eq!(item.source, expected_label, "source label per item");
+        assert!(item.git_ref.is_none(), "no ref for local source");
+        let h = item.hash.as_ref().expect("hash present");
+        assert!(
+            h.len() == 64 && h.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash looks like sha-256 hex: {h}"
+        );
+    }
+
+    // Items are sorted by (kind, name) for deterministic on-disk output.
+    let keys: Vec<_> = parsed
+        .items
+        .iter()
+        .map(|i| (i.kind.as_str(), i.name.as_str()))
+        .collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted);
+}
+
+#[test]
+fn re_install_upserts_existing_entries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install 1");
+    let lock1: LockfileV2 =
+        serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
+            .unwrap();
+
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install 2");
+    let lock2: LockfileV2 =
+        serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
+            .unwrap();
+
+    // Re-installing the same source MUST NOT duplicate entries.
+    assert_eq!(lock1.items.len(), lock2.items.len());
+    assert_eq!(lock1, lock2, "lockfile is byte-identical on re-install");
+}
+
+#[test]
+fn install_preserves_unrelated_existing_entries() {
+    use upskill::lockfile_v2::LockedItem;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+
+    // Pre-seed the lockfile with an entry from a different source.
+    let mut seed = LockfileV2::new();
+    seed.upsert(LockedItem {
+        kind: "skill".into(),
+        name: "from-other-source".into(),
+        source: "github:other/repo@v1.0".into(),
+        git_ref: Some("v1.0".into()),
+        hash: Some("a".repeat(64)),
+    });
+    seed.save(&target).unwrap();
+
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+
+    let lock = LockfileV2::load(&target).expect("load");
+    // 4 from the install + 1 pre-seeded = 5.
+    assert_eq!(lock.items.len(), 5);
+    assert!(
+        lock.items.iter().any(|i| i.name == "from-other-source"),
+        "pre-existing entry must survive install"
+    );
+}


### PR DESCRIPTION
## Summary

Fourth slice of Phase 3, building on #78–#80. Pipeline installs now persist a v0.2 lockfile (`.upskill-lock.json`, `schema: 2`) at the consumer-project root so a future `update` / `remove` / `doctor` can reason about installed state.

```rust
pub fn install_with_lockfile(source: &InstallSource, target: &Path) -> Result<InstallReport>;
```

`upskill add --pipeline <source>` now writes `.upskill-lock.json` automatically.

### New module — `src/lockfile_v2.rs`

```rust
pub struct LockfileV2  { schema: u32, items: Vec<LockedItem>, bundles: Vec<LockedBundle> }
pub struct LockedItem  { kind, name, source, ref?, hash? }
pub struct LockedBundle{ name, source, ref?, items[] }   // shape ready, not populated yet
```

- `LockfileV2::load` — schema-checked; missing file → empty `new()`; non-2 schemas rejected (no silent migration; v0.1 → v0.2 is a separate slice).
- `LockfileV2::save` — pretty JSON, trailing newline.
- `LockfileV2::upsert` — replaces by `(kind, name)`, kept sorted for deterministic on-disk output.
- `items_from_report` — dedupes the `InstallReport` (one entry per kind × name × client) into one `LockedItem` per `(kind, name)`.

Transitional name; renames to `lockfile.rs` once v0.1 is sunset.

### `Display` for `InstallSource` — `src/source.rs`

Round-trippable source labels for the lockfile and log lines. Format mirrors `parse_install_source`:

| Variant      | Display form                                                  |
| ------------ | ------------------------------------------------------------- |
| Github       | `github:<owner>/<name>[@<ref>][:<sub>]`                       |
| Gitlab.com   | `gitlab:<owner>/<name>[@<ref>][:<sub>]`                       |
| Gitlab self  | `gitlab+<host>:<owner>/<name>[@<ref>][:<sub>]`                |
| LocalPath    | `local:<path>`                                                |

### Pipeline change — `src/pipeline.rs`

- `InstalledItem` gains `source_hash: Option<String>`. Computed once per item via `lockfile::hash_skill_dir` during the per-kind walks (skill/rule/agent) and shared across the per-client report entries. Hashing the SSOT (not the generated output) is intentional — drift detection should catch user edits to source content, not generator-version differences.
- `install_with_lockfile` is a thin wrapper that calls `install_from_source`, then `upserts` each `(kind, name)` into the lockfile and saves. Pre-existing entries from a different source survive.

### CLI wiring — `src/main.rs`

`run_pipeline_add` now calls `install_with_lockfile` instead of `install_from_source`. No flag changes.

## Tests

`tests/pipeline_lockfile.rs` (3 new ATDD):
- `install_writes_schema_2_lockfile_at_target_root` — lockfile present, `schema: 2`, one entry per `(kind, name)` carrying source label and SHA-256 hex hash, items sorted by `(kind, name)`.
- `re_install_upserts_existing_entries` — running install twice produces a byte-identical lockfile (no duplicates).
- `install_preserves_unrelated_existing_entries` — pre-seeded entries from another source survive a fresh install.

`src/lockfile_v2.rs` (8 unit tests): schema field, upsert behaviour across `(kind, name)`, sort order, remove, save/load roundtrip, missing file → empty, schema rejection (unsupported + v0.1-shape), report→items dedup.

All #78/#79/#80 tests still pass — `InstalledItem` extension is additive (existing assertions only check counts and paths).

## Out of scope (later Phase 3 slices)

- v0.1 → v0.2 in-place schema migration (separate slice).
- Bundle entries are part of the schema but not yet populated.
- `update` / `remove` / `doctor` reading the lockfile.
- Lockfile reading at non-default scope (`-g`/`--global`).

## Test plan

- [x] `just verify` clean locally.
- [x] All tests pass: 3 new ATDD + 8 new unit + #78/#79/#80 tests + 13 v0.1 `cli_*.rs` tests.
- [ ] CI passes (clippy, fmt, test, convco).

## Notes

- Branches off latest `v0.2-redesign` (post-#80).
- v0.1 `add` behaviour and v0.1 lockfile (`src/lockfile.rs`) byte-identical without `--pipeline`. The two modules coexist until the v0.1 sunset.
