### PR TITLE
feat(lockfile): in-place v0.1 → v0.2 lockfile migration on first load

### DIFF
--- a/src/lockfile_v2.rs
+++ b/src/lockfile_v2.rs
@@ -5,11 +5,14 @@
 //! `remove` / `doctor` can reason about state. The filename is unchanged
 //! from v0.1; the `schema:` field discriminates.
 //!
-//! Scope of this slice:
+//! Scope:
 //! - Types + load/save/upsert for `schema: 2` items and (placeholder) bundles.
-//! - Wiring into [`crate::pipeline::install_from_source`] so the lockfile is
-//!   written after a successful install.
-//! - v0.1 → v0.2 in-place migration is a separate slice.
+//! - Wiring into [`crate::pipeline::install_with_lockfile`] so the lockfile
+//!   is written after a successful install.
+//! - In-place v0.1 → v0.2 migration on first load: a v0.1
+//!   `.upskill-lock.json` (no `schema` field, top-level `skills` array) is
+//!   detected, translated to the v0.2 shape with `kind: "skill"` per entry,
+//!   and rewritten in place. Subsequent loads see schema 2 directly.
 //! - Bundle entries are part of the schema but not yet populated (Phase 3
 //!   bundle slice).
 
@@ -85,11 +88,15 @@ impl LockfileV2 {
     /// Load `<project_root>/.upskill-lock.json`. Returns an empty `schema: 2`
     /// lockfile when the file does not exist.
     ///
+    /// Migration: a v0.1-shape file (no `schema` field, top-level `skills`
+    /// array) is detected, translated in memory to schema 2, and rewritten
+    /// in place. Subsequent loads see the v0.2 shape directly. Existing v0.1
+    /// users are not silently broken.
+    ///
     /// Errors:
-    /// - File exists but cannot be parsed as JSON.
-    /// - File parses but its `schema` is not 2 (v0.1 schema-1 migration is a
-    ///   separate slice; this implementation refuses to silently downgrade
-    ///   or upgrade).
+    /// - File exists but is neither v0.2 nor recognisable v0.1 JSON.
+    /// - File parses as v0.2 but its `schema` is greater than the version
+    ///   this implementation supports.
     pub fn load(project_root: &Path) -> Result<Self> {
         let path = lockfile_path(project_root);
         let raw = match std::fs::read_to_string(&path) {
@@ -97,17 +104,36 @@ impl LockfileV2 {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Self::new()),
             Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
         };
-        let parsed: Self =
-            serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
-        if parsed.schema != CURRENT_SCHEMA {
-            anyhow::bail!(
-                "{}: schema {} not supported by this implementation (expected {})",
-                path.display(),
-                parsed.schema,
-                CURRENT_SCHEMA
-            );
+
+        if let Ok(parsed) = serde_json::from_str::<Self>(&raw) {
+            if parsed.schema == CURRENT_SCHEMA {
+                return Ok(parsed);
+            }
+            if parsed.schema > CURRENT_SCHEMA {
+                anyhow::bail!(
+                    "{}: schema {} is newer than this implementation supports \
+                     (max {}); upgrade upskill",
+                    path.display(),
+                    parsed.schema,
+                    CURRENT_SCHEMA
+                );
+            }
+            // schema < CURRENT_SCHEMA but with a `schema` field is unexpected
+            // (v0.1 had no schema field) — fall through to the v0.1 attempt.
         }
-        Ok(parsed)
+
+        if let Ok(v1) = serde_json::from_str::<crate::lockfile::Lockfile>(&raw) {
+            let migrated = migrate_v1(&v1);
+            migrated
+                .save(project_root)
+                .with_context(|| format!("persist v0.1 → v0.2 migration of {}", path.display()))?;
+            return Ok(migrated);
+        }
+
+        anyhow::bail!(
+            "{}: unrecognised lockfile shape (neither v0.2 schema-2 nor v0.1)",
+            path.display()
+        );
     }
 
     /// Add or replace by `(kind, name)`. Items are kept sorted for
@@ -178,6 +204,23 @@ fn kind_label(kind: ItemKind) -> &'static str {
         ItemKind::Skill => "skill",
         ItemKind::Agent => "agent",
     }
+}
+
+/// Translate a v0.1 lockfile (skills-only) into a v0.2 lockfile. Every
+/// v0.1 entry becomes a `kind: "skill"` item; v0.2-only fields (bundles)
+/// stay empty.
+pub fn migrate_v1(v1: &crate::lockfile::Lockfile) -> LockfileV2 {
+    let mut out = LockfileV2::new();
+    for s in &v1.skills {
+        out.upsert(LockedItem {
+            kind: "skill".to_string(),
+            name: s.name.clone(),
+            source: s.source.clone(),
+            git_ref: s.git_ref.clone(),
+            hash: s.hash.clone(),
+        });
+    }
+    out
 }
 
 #[cfg(test)]
@@ -263,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn load_rejects_unsupported_schema() {
+    fn load_rejects_newer_schema() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(
             tmp.path().join(LOCKFILE_NAME),
@@ -275,19 +318,45 @@ mod tests {
     }
 
     #[test]
-    fn load_rejects_v1_schema_no_silent_downgrade() {
-        // v0.1 lockfiles do not have a `schema` field. Migration is a
-        // separate slice; until then, refuse to load to avoid silent
-        // schema downgrade.
+    fn load_migrates_v1_in_place() {
         let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(LOCKFILE_NAME);
+        // v0.1 shape: no `schema` field, top-level `skills` array.
         std::fs::write(
-            tmp.path().join(LOCKFILE_NAME),
-            r#"{"skills": [{"name": "x", "source": "y"}]}"#,
+            &path,
+            r#"{
+                "skills": [
+                    {"name": "code-review", "source": "github:driftsys/skills@v1.0",
+                     "ref": "v1.0", "hash": "abc"}
+                ]
+            }"#,
         )
         .unwrap();
+
+        let loaded = LockfileV2::load(tmp.path()).expect("load with migration");
+        assert_eq!(loaded.schema, CURRENT_SCHEMA);
+        assert_eq!(loaded.items.len(), 1);
+        let it = &loaded.items[0];
+        assert_eq!(it.kind, "skill");
+        assert_eq!(it.name, "code-review");
+        assert_eq!(it.source, "github:driftsys/skills@v1.0");
+        assert_eq!(it.git_ref, Some("v1.0".to_string()));
+        assert_eq!(it.hash, Some("abc".to_string()));
+
+        // Migration was persisted: the file now contains the schema field
+        // and a second load no longer triggers migration.
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(on_disk.contains("\"schema\""));
+        let reloaded = LockfileV2::load(tmp.path()).expect("reload");
+        assert_eq!(reloaded, loaded);
+    }
+
+    #[test]
+    fn load_rejects_unrecognised_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(LOCKFILE_NAME), r#"{"random": "shape"}"#).unwrap();
         let err = LockfileV2::load(tmp.path()).expect_err("must reject");
-        // serde rejects missing required `schema` field.
-        assert!(err.to_string().contains("parse"));
+        assert!(err.to_string().contains("unrecognised"));
     }
 
     #[test]

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -107,6 +107,48 @@ fn re_install_upserts_existing_entries() {
 }
 
 #[test]
+fn install_migrates_v1_lockfile_in_place() {
+    // A user with a pre-v0.2 .upskill-lock.json (no `schema` field, top-level
+    // `skills` array) runs `install_with_lockfile`. The file is migrated to
+    // schema 2 in place, the v0.1 entries survive, and the new install is
+    // merged on top.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+
+    fs::write(
+        target.join(".upskill-lock.json"),
+        r#"{
+            "skills": [
+                {"name": "legacy-skill", "source": "github:legacy/repo@v0.1",
+                 "ref": "v0.1", "hash": "deadbeef"}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+
+    let lock = LockfileV2::load(&target).expect("load");
+    assert_eq!(lock.schema, CURRENT_SCHEMA);
+
+    // 1 legacy entry (migrated as kind "skill") + 4 from this install = 5.
+    assert_eq!(lock.items.len(), 5, "{:#?}", lock.items);
+    assert!(
+        lock.items
+            .iter()
+            .any(|i| i.name == "legacy-skill" && i.source == "github:legacy/repo@v0.1"),
+        "v0.1 entry must survive migration"
+    );
+
+    // On-disk file is now in v0.2 shape (has `schema` field).
+    let raw = fs::read_to_string(target.join(".upskill-lock.json")).unwrap();
+    assert!(raw.contains("\"schema\""));
+}
+
+#[test]
 fn install_preserves_unrelated_existing_entries() {
     use upskill::lockfile_v2::LockedItem;
 


### PR DESCRIPTION
## Summary

Fifth slice of Phase 3, building on #81. A user with a pre-v0.2 `.upskill-lock.json` (no `schema` field, top-level `skills` array) is no longer broken: the file is detected, translated to the v0.2 shape with `kind: "skill"` per entry, and rewritten in place on first load. Subsequent loads see the v0.2 shape directly. Per [ADR-0003 §"State files"](docs/adr/0003-generation-pipeline.md).

`LockfileV2::load` now:

1. Parses as v0.2 — `schema == 2` returns; `schema > 2` errors pointing at an upskill upgrade.
2. Otherwise parses as v0.1 (`crate::lockfile::Lockfile`) — on success calls `migrate_v1`, persists, returns.
3. Otherwise errors with "unrecognised lockfile shape".

```rust
pub fn migrate_v1(v1: &lockfile::Lockfile) -> LockfileV2;
```

Translates each `LockedSkill` to a `LockedItem` with `kind="skill"`; bundles stays empty. Source/ref/hash carried over verbatim.

## Tests

- `src/lockfile_v2.rs` — `load_migrates_v1_in_place`, `load_rejects_unrecognised_shape`, `load_rejects_newer_schema` (rename + tighten of the prior `load_rejects_unsupported_schema`).
- `tests/pipeline_lockfile.rs` — `install_migrates_v1_lockfile_in_place`: pre-seeds a v0.1 file at the consumer-project root, runs `install_with_lockfile`, asserts the legacy entry survives migration, the new install merges on top, and the on-disk file is now in v0.2 shape.

## Out of scope

- `update` / `remove` / `doctor` reading the migrated lockfile.
- Bundle support, ancillary files, GitLab fetch, audience promotion.

## Test plan

- [x] `just verify` clean locally.
- [ ] CI passes.
