### PR TITLE
feat(model): promote audience to top-level field per format-spec §3.1

### DIFF
--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -1,6 +1,6 @@
 //! Agent items (§3.4 + §3.1 common fields).
 
-use crate::model::common::{License, Metadata, SchemaVersion};
+use crate::model::common::{Audience, License, Metadata, SchemaVersion};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -34,6 +34,9 @@ pub struct Agent {
     pub name: String,
     pub description: String,
 
+    /// §3.1: top-level audience (promoted from `metadata.audience`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audience: Option<Vec<Audience>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<License>,
 

--- a/src/model/common.rs
+++ b/src/model/common.rs
@@ -64,6 +64,10 @@ pub struct Metadata {
     pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,
+    /// Deprecated: `audience` is now a top-level field per format-spec §3.1.
+    /// Accepted here only as a back-compat fallback; new content SHOULD put
+    /// `audience` at the top level. The pipeline prefers the top-level value
+    /// when both are present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audience: Option<Vec<Audience>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/model/rule.rs
+++ b/src/model/rule.rs
@@ -1,6 +1,6 @@
 //! Rule items (§3.2 + §3.1 common fields).
 
-use crate::model::common::{License, Metadata, SchemaVersion};
+use crate::model::common::{Audience, License, Metadata, SchemaVersion};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -17,6 +17,9 @@ pub struct Rule {
     pub name: String,
     pub description: String,
 
+    /// §3.1: top-level audience (promoted from `metadata.audience`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audience: Option<Vec<Audience>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<License>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/model/skill.rs
+++ b/src/model/skill.rs
@@ -1,6 +1,6 @@
 //! Skill items (§3.3 + §3.1 common fields).
 
-use crate::model::common::{License, Metadata, SchemaVersion};
+use crate::model::common::{Audience, License, Metadata, SchemaVersion};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -10,6 +10,11 @@ pub struct Skill {
     pub name: String,
     pub description: String,
 
+    /// §3.1: top-level audience targeting (promoted from `metadata.audience`
+    /// per format-spec PR #76). When present, generation only emits for
+    /// listed clients. `metadata.audience` is still accepted as a fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audience: Option<Vec<Audience>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<License>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -11,9 +11,9 @@
 //!   (`CLAUDE.md`, `.vscode/settings.json`, `opencode.json`).
 //! - No CLI wiring; this is library API only.
 //!
-//! Audience filter: respects `metadata.audience` per the current model
-//! shape. Promotion of `audience` to a top-level field (per the
-//! format-spec PR #76) is a separate task.
+//! Audience filter: prefers the top-level `audience` field (per
+//! format-spec §3.1) and falls back to `metadata.audience` when the
+//! top-level is absent — accepts both shapes for back-compat.
 
 use anyhow::{Context, Result, anyhow};
 use std::fs;
@@ -167,7 +167,7 @@ fn install_skills(source: &Path, target: &Path, report: &mut InstallReport) -> R
             .with_context(|| format!("read {}", entry_path.display()))?;
         let (skill, body) = frontmatter::parse::<Skill>(&raw)
             .with_context(|| format!("parse {}", entry_path.display()))?;
-        let audience = audience_of(skill.metadata.as_ref());
+        let audience = audience_of(skill.audience.as_ref(), skill.metadata.as_ref());
         let source_hash = crate::lockfile::hash_skill_dir(&dir);
 
         for client in ALL_CLIENTS {
@@ -200,7 +200,7 @@ fn install_rules(source: &Path, target: &Path, report: &mut InstallReport) -> Re
             .with_context(|| format!("read {}", entry_path.display()))?;
         let (rule, body) = frontmatter::parse::<Rule>(&raw)
             .with_context(|| format!("parse {}", entry_path.display()))?;
-        let audience = audience_of(rule.metadata.as_ref());
+        let audience = audience_of(rule.audience.as_ref(), rule.metadata.as_ref());
         let source_hash = crate::lockfile::hash_skill_dir(&dir);
 
         for client in ALL_CLIENTS {
@@ -233,7 +233,7 @@ fn install_agents(source: &Path, target: &Path, report: &mut InstallReport) -> R
             .with_context(|| format!("read {}", entry_path.display()))?;
         let (agent, body) = frontmatter::parse::<Agent>(&raw)
             .with_context(|| format!("parse {}", entry_path.display()))?;
-        let audience = audience_of(agent.metadata.as_ref());
+        let audience = audience_of(agent.audience.as_ref(), agent.metadata.as_ref());
         let source_hash = crate::lockfile::hash_skill_dir(&dir);
 
         for client in ALL_CLIENTS {
@@ -322,7 +322,15 @@ fn iter_item_dirs(kind_root: &Path) -> Result<Vec<(String, PathBuf)>> {
     Ok(out)
 }
 
-fn audience_of(metadata: Option<&crate::model::Metadata>) -> Option<Vec<Audience>> {
+/// Resolve the effective audience for an item. Top-level (§3.1) wins; falls
+/// back to `metadata.audience` for back-compat with v0.1-draft fixtures.
+fn audience_of(
+    top_level: Option<&Vec<Audience>>,
+    metadata: Option<&crate::model::Metadata>,
+) -> Option<Vec<Audience>> {
+    if let Some(list) = top_level {
+        return Some(list.clone());
+    }
     metadata.and_then(|m| m.audience.clone())
 }
 

--- a/tests/pipeline_local.rs
+++ b/tests/pipeline_local.rs
@@ -177,8 +177,58 @@ fn read_target_tree(root: &Path) -> Vec<(String, String)> {
 }
 
 #[test]
+fn install_respects_top_level_audience_filter() {
+    // Audience as a top-level field per format-spec §3.1 — the canonical
+    // shape after PR #76. Pipeline emits only for listed clients.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+
+    let skill_dir = source.join("skills/claude-only-top");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        r#"---
+schema: 1
+name: claude-only-top
+description: Use only when working in Claude Code; this skill targets claude alone for testing top-level audience filtering.
+audience:
+  - claude
+---
+
+## Body
+
+Hello.
+"#,
+    )
+    .unwrap();
+
+    upskill::pipeline::install_from_local_path(&source, &target).expect("install");
+
+    assert!(
+        target
+            .join(".claude/skills/claude-only-top/SKILL.md")
+            .exists()
+    );
+    assert!(
+        !target
+            .join(".github/skills/claude-only-top/SKILL.md")
+            .exists()
+    );
+    assert!(
+        !target
+            .join(".agents/skills/claude-only-top/SKILL.md")
+            .exists()
+    );
+}
+
+#[test]
 fn install_respects_audience_filter() {
-    // Build a tiny custom source with one skill that targets only `claude`.
+    // Back-compat: audience under metadata still works (v0.1-draft shape).
+    // Pipeline reads top-level first, falls back to metadata.audience.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
     let tmp = tempfile::tempdir().unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");


### PR DESCRIPTION
## Summary

Sixth slice of Phase 3. Closes the gap between format-spec PR #76 (which promoted `audience` to a top-level field with spec-defined semantics) and the model layer (which still kept it under `metadata.audience`).

### Model changes (`src/model/`)

- `Skill`, `Rule`, `Agent` each gain `audience: Option<Vec<Audience>>` at the top level.
- `Metadata.audience` is kept as a **deprecated back-compat fallback** so v0.1-draft fixtures (e.g., the security-reviewer agent fixture) still parse and behave correctly.

### Pipeline change (`src/pipeline.rs`)

- `audience_of()` now takes both the top-level value and metadata. Top level wins; metadata is the fallback.
- Module doc updated.

### Tests

- `tests/pipeline_local.rs` — new `install_respects_top_level_audience_filter` pinning the top-level shape; existing `install_respects_audience_filter` retitled to confirm back-compat with `metadata.audience`.

### Out of scope

- Lint warning when both shapes are present in the same item (future `lint` slice).
- Removing the back-compat shim — defer until v0.2.0 release notes explicitly deprecate.

## Test plan

- [x] `just verify` clean.
- [ ] CI passes.