### PR TITLE
feat(ancillary): create CLAUDE.md bridge after pipeline install

### DIFF
--- a/src/ancillary.rs
+++ b/src/ancillary.rs
@@ -1,0 +1,96 @@
+//! Ancillary file management for the v0.2 install pipeline.
+//!
+//! Per [ADR-0003](../../docs/adr/0003-generation-pipeline.md) §"Ancillary
+//! file handling" and format-spec §7.4. The pipeline writes per-client item
+//! output (rules / skills / agents) to the paths in §7; some clients also
+//! need a single one-time hand-shake file at the consumer-project root for
+//! discovery to work. Those files are managed here, separately from the
+//! per-item generation pipeline:
+//!
+//! - **`CLAUDE.md`** — created once with `@AGENTS.md` content if absent.
+//!   Bridges Claude Code (which does not natively read `AGENTS.md`) to the
+//!   project-level instructions Claude users expect to live in `AGENTS.md`.
+//!   Never overwritten — protects user customisations.
+//!
+//! - `.vscode/settings.json` and `opencode.json` — separate slice. Stubs are
+//!   not provided here; this module is intentionally focused on the
+//!   non-mutating CLAUDE.md case until the in-place JSON edit story
+//!   (preserving unknown keys) lands.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Filename written at the consumer-project root.
+const CLAUDE_MD: &str = "CLAUDE.md";
+
+/// Content the bridge file ships with. The single `@AGENTS.md` line is the
+/// Claude Code "load this file" directive; everything Claude Code needs at
+/// the project level is then expected to live in `AGENTS.md`.
+const CLAUDE_MD_BRIDGE: &str = "@AGENTS.md\n";
+
+/// Outcome of a single ancillary write, surfaced for callers that want to
+/// log or report what happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AncillaryAction {
+    /// File did not exist; we created it.
+    Created,
+    /// File already existed; we left it alone.
+    Preserved,
+}
+
+/// Ensure `<target>/CLAUDE.md` exists with the bridge content.
+///
+/// - Absent → created with `CLAUDE_MD_BRIDGE`.
+/// - Present → never modified, regardless of content. A user (or a previous
+///   `upskill` run) may have customised the file; preserving it is part of
+///   the contract per ADR-0003.
+pub fn ensure_claude_bridge(target: &Path) -> Result<AncillaryAction> {
+    let path = target.join(CLAUDE_MD);
+    if path.exists() {
+        return Ok(AncillaryAction::Preserved);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create dir {}", parent.display()))?;
+    }
+    std::fs::write(&path, CLAUDE_MD_BRIDGE).with_context(|| format!("write {}", path.display()))?;
+    Ok(AncillaryAction::Created)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_claude_md_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let action = ensure_claude_bridge(tmp.path()).expect("ensure");
+
+        assert_eq!(action, AncillaryAction::Created);
+        let content = std::fs::read_to_string(tmp.path().join("CLAUDE.md")).unwrap();
+        assert_eq!(content, CLAUDE_MD_BRIDGE);
+    }
+
+    #[test]
+    fn preserves_existing_claude_md_verbatim() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("CLAUDE.md");
+        let user_content = "# My CLAUDE.md\n\nUser customisations here.\n";
+        std::fs::write(&path, user_content).unwrap();
+
+        let action = ensure_claude_bridge(tmp.path()).expect("ensure");
+
+        assert_eq!(action, AncillaryAction::Preserved);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, user_content, "must not overwrite user content");
+    }
+
+    #[test]
+    fn second_call_after_create_is_preserve() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = ensure_claude_bridge(tmp.path()).expect("ensure 1");
+        let second = ensure_claude_bridge(tmp.path()).expect("ensure 2");
+        assert_eq!(first, AncillaryAction::Created);
+        assert_eq!(second, AncillaryAction::Preserved);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! See the repository for progress.
 
 pub mod agent;
+pub mod ancillary;
 pub mod auth;
 pub mod fetch;
 pub mod generate;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -98,6 +98,11 @@ pub fn install_with_lockfile(source: &InstallSource, target: &Path) -> Result<In
     }
     lock.save(target)?;
 
+    // Per ADR-0003 / format-spec §7.4: ensure the Claude Code bridge file
+    // exists at the consumer-project root. Created once with `@AGENTS.md`
+    // content, never overwritten — protects user customisations.
+    crate::ancillary::ensure_claude_bridge(target)?;
+
     Ok(report)
 }
 

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -179,3 +179,42 @@ fn install_preserves_unrelated_existing_entries() {
         "pre-existing entry must survive install"
     );
 }
+
+#[test]
+fn install_creates_claude_bridge_when_absent() {
+    // ADR-0003 / format-spec §7.4: a fresh consumer project gets a CLAUDE.md
+    // bridge file (single line `@AGENTS.md`) so Claude Code picks up
+    // project-level instructions.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+
+    let claude_md = target.join("CLAUDE.md");
+    assert!(claude_md.exists(), "CLAUDE.md must be created");
+    assert_eq!(fs::read_to_string(&claude_md).unwrap(), "@AGENTS.md\n");
+}
+
+#[test]
+fn install_preserves_existing_claude_bridge() {
+    // User customisations must not be clobbered.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+
+    let user_content = "# Project CLAUDE.md\n\n@AGENTS.md\n\nExtra project notes here.\n";
+    fs::write(target.join("CLAUDE.md"), user_content).unwrap();
+
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+
+    assert_eq!(
+        fs::read_to_string(target.join("CLAUDE.md")).unwrap(),
+        user_content,
+        "user CLAUDE.md must be preserved verbatim"
+    );
+}


### PR DESCRIPTION
## Summary

Eighth slice of Phase 3. After `install_with_lockfile`, the pipeline ensures `<target>/CLAUDE.md` exists with `@AGENTS.md` content, bridging Claude Code (which does not natively read `AGENTS.md`) to the project-level instructions. Per [ADR-0003 / format-spec §7.4](docs/adr/0003-generation-pipeline.md).

```rust
pub fn ensure_claude_bridge(target: &Path) -> Result<AncillaryAction>;
```

- Absent → created with `@AGENTS.md\n`.
- Present → never modified. A user (or prior `upskill` run) may have customised the file; preserving it is part of the contract.

Wired into `pipeline::install_with_lockfile` after the lockfile is written.

## Tests

- `src/ancillary.rs` — `creates_claude_md_when_absent`, `preserves_existing_claude_md_verbatim`, `second_call_after_create_is_preserve`.
- `tests/pipeline_lockfile.rs` — `install_creates_claude_bridge_when_absent`, `install_preserves_existing_claude_bridge`.

## Out of scope

- `.vscode/settings.json` mutation (`chat.instructionsFilesLocations`).
- `opencode.json` mutation (`instructions[]` entry on first opencode-rule install).
- Both require in-place JSON edit preserving unknown keys — separate slice.

## Test plan

- [x] `just verify` clean.
- [ ] CI passes.