### PR TITLE
feat(cli): implement upskill remove over schema-2 lockfile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ use clap::{Parser, Subcommand, error::ErrorKind};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use upskill::pipeline::{InstallReport, ItemKind, install_with_lockfile};
+use upskill::pipeline::{
+    InstallReport, ItemKind, RemoveFilter, RemoveReport, install_with_lockfile, remove,
+};
 use upskill::search;
 use upskill::source::parse_install_source;
 
@@ -36,10 +38,25 @@ enum Commands {
         #[arg(short = 'g', long = "global")]
         global: bool,
     },
-    /// Remove installed content. (Phase B1.)
+    /// Remove installed content.
+    ///
+    /// Either name one or more items, or pass `--source <label>` to
+    /// remove every item that came from a single source. Bare
+    /// `upskill remove` is rejected — be explicit per ADR-0004. Ancillary
+    /// files (`CLAUDE.md`, `opencode.json`, `.vscode/settings.json`) are
+    /// not touched.
     Remove {
-        /// Item names to remove (omit to remove all from a single source).
+        /// Item names to remove. Mutually exclusive with `--source`.
         names: Vec<String>,
+        /// Remove every item whose lockfile `source` label matches this
+        /// string. Use the value reported by the install or shown in
+        /// `.upskill-lock.json` (e.g. `local:/path` or
+        /// `github:owner/repo`).
+        #[arg(long = "source")]
+        source: Option<String>,
+        /// Operate on `$HOME` instead of the current directory.
+        #[arg(short = 'g', long = "global")]
+        global: bool,
     },
     /// Pull latest sources and regenerate changed items. (Phase B2.)
     Update {
@@ -80,7 +97,11 @@ fn main() {
 
     let mut exit_code = match cli.command {
         Commands::Add { source, global } => run_add(&source, global),
-        Commands::Remove { .. } => unimplemented_stub("remove", "B1"),
+        Commands::Remove {
+            names,
+            source,
+            global,
+        } => run_remove(&names, source.as_deref(), global),
         Commands::Update { .. } => unimplemented_stub("update", "B2"),
         Commands::List => unimplemented_stub("list", "B"),
         Commands::Doctor => unimplemented_stub("doctor", "B3"),
@@ -170,6 +191,63 @@ fn print_install_report(report: &InstallReport, source: &str) {
             ItemKind::Agent => "agent",
         };
         println!("  {} {:<32} → {}", kind_label, name, clients.join(", "));
+    }
+}
+
+fn run_remove(names: &[String], source: Option<&str>, global: bool) -> i32 {
+    let filter = match (names.is_empty(), source) {
+        (true, Some(s)) => RemoveFilter::BySource(s.to_string()),
+        (false, None) => RemoveFilter::ByNames(names.to_vec()),
+        (true, None) => {
+            eprintln!(
+                "error: nothing to remove — pass one or more item names, or `--source <label>`"
+            );
+            return EXIT_USAGE;
+        }
+        (false, Some(_)) => {
+            eprintln!("error: `--source` and item names are mutually exclusive");
+            return EXIT_USAGE;
+        }
+    };
+
+    let target = match install_target(global) {
+        Ok(t) => t,
+        Err(err) => {
+            eprintln!("error: {}", err);
+            return EXIT_ERROR;
+        }
+    };
+
+    match remove(&target, filter) {
+        Ok(report) => {
+            print_remove_report(&report);
+            EXIT_SUCCESS
+        }
+        Err(err) => {
+            eprintln!("error: {:#}", err);
+            EXIT_ERROR
+        }
+    }
+}
+
+fn print_remove_report(report: &RemoveReport) {
+    if report.items.is_empty() {
+        println!("no matching items in lockfile");
+        return;
+    }
+    println!("Removed {} item(s)", report.items.len());
+    for item in &report.items {
+        let kind_label = match item.kind {
+            ItemKind::Rule => "rule ",
+            ItemKind::Skill => "skill",
+            ItemKind::Agent => "agent",
+        };
+        println!(
+            "  {} {:<32} ({} file(s))",
+            kind_label,
+            item.name,
+            item.deleted_files.len()
+        );
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -126,6 +126,114 @@ pub fn install_with_lockfile(source: &InstallSource, target: &Path) -> Result<In
     Ok(report)
 }
 
+/// What to remove. Per ADR-0004 the user must be explicit — bare
+/// `upskill remove` is not allowed; either name items or pass
+/// `--source <label>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoveFilter {
+    /// Remove every lockfile entry whose `name` matches one of these
+    /// values, regardless of kind. An item name listed here that does not
+    /// match any entry is an error (the caller asked to remove a thing
+    /// that is not installed).
+    ByNames(Vec<String>),
+    /// Remove every lockfile entry whose `source` label matches this
+    /// string verbatim. No-op when the lockfile contains no entry from
+    /// the named source.
+    BySource(String),
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RemoveReport {
+    pub items: Vec<RemovedItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemovedItem {
+    pub kind: ItemKind,
+    pub name: String,
+    /// Files actually deleted from disk (paths relative to `target`).
+    /// May be empty if the lockfile knew about the item but its outputs
+    /// were already gone.
+    pub deleted_files: Vec<PathBuf>,
+}
+
+/// Remove installed content recorded in `<target>/.upskill-lock.json`,
+/// matching `filter`. For each matching entry, deletes every per-client
+/// output file (per [`output_path`]) and drops the entry from the
+/// lockfile. Best-effort `rmdir` of empty per-item parent directories
+/// (e.g., `.claude/skills/<name>/`) so the workspace stays clean.
+///
+/// Ancillary files (`CLAUDE.md`, `opencode.json`,
+/// `.vscode/settings.json`) are deliberately left alone — they are
+/// user-owned after creation per ADR-0003.
+pub fn remove(target: &Path, filter: RemoveFilter) -> Result<RemoveReport> {
+    let mut lock = crate::lockfile_v2::LockfileV2::load(target)?;
+
+    let to_remove: Vec<crate::lockfile_v2::LockedItem> = match &filter {
+        RemoveFilter::ByNames(names) => lock
+            .items
+            .iter()
+            .filter(|i| names.iter().any(|n| n == &i.name))
+            .cloned()
+            .collect(),
+        RemoveFilter::BySource(source) => lock
+            .items
+            .iter()
+            .filter(|i| &i.source == source)
+            .cloned()
+            .collect(),
+    };
+
+    if let RemoveFilter::ByNames(names) = &filter {
+        let matched: std::collections::BTreeSet<&str> =
+            to_remove.iter().map(|i| i.name.as_str()).collect();
+        let unknown: Vec<&str> = names
+            .iter()
+            .filter(|n| !matched.contains(n.as_str()))
+            .map(String::as_str)
+            .collect();
+        if !unknown.is_empty() {
+            anyhow::bail!("not in lockfile: {}", unknown.join(", "));
+        }
+    }
+
+    let mut report = RemoveReport::default();
+    for entry in &to_remove {
+        let kind = parse_kind(&entry.kind)
+            .with_context(|| format!("lockfile entry {}: unknown kind", entry.name))?;
+        let mut deleted_files = Vec::new();
+        for client in ALL_CLIENTS {
+            let rel = output_path(kind, client, &entry.name);
+            let full = target.join(&rel);
+            if full.exists() {
+                fs::remove_file(&full).with_context(|| format!("delete {}", full.display()))?;
+                deleted_files.push(rel);
+                if let Some(parent) = full.parent() {
+                    let _ = fs::remove_dir(parent);
+                }
+            }
+        }
+        lock.remove(&entry.kind, &entry.name);
+        report.items.push(RemovedItem {
+            kind,
+            name: entry.name.clone(),
+            deleted_files,
+        });
+    }
+
+    lock.save(target)?;
+    Ok(report)
+}
+
+fn parse_kind(s: &str) -> Result<ItemKind> {
+    match s {
+        "skill" => Ok(ItemKind::Skill),
+        "rule" => Ok(ItemKind::Rule),
+        "agent" => Ok(ItemKind::Agent),
+        other => anyhow::bail!("unknown kind `{other}`"),
+    }
+}
+
 /// Install items from any supported source into `target`.
 ///
 /// Dispatches on the source variant. All git-backed variants funnel
@@ -352,6 +460,18 @@ fn install_agents(source: &Path, target: &Path, report: &mut InstallReport) -> R
         }
     }
     Ok(())
+}
+
+/// Where the install pipeline writes — and `remove` deletes — the per-
+/// client output for a given `(kind, name)`. Path is relative to the
+/// install target root and matches format-spec §7. Used by both
+/// `install_*` and [`remove`] so the two stay in lockstep.
+pub(crate) fn output_path(kind: ItemKind, client: Client, name: &str) -> PathBuf {
+    match kind {
+        ItemKind::Skill => skill_output_path(client, name),
+        ItemKind::Rule => rule_output_path(client, name),
+        ItemKind::Agent => agent_output_path(client, name),
+    }
 }
 
 /// Per format-spec §7 / ADR-0003. opencode `.agents/skills/<n>/SKILL.md`
@@ -663,5 +783,47 @@ mod tests {
         assert_eq!(percent_encode_userinfo("@"), "%40");
         assert_eq!(percent_encode_userinfo("/"), "%2F");
         assert_eq!(percent_encode_userinfo("%"), "%25");
+    }
+
+    #[test]
+    fn parse_kind_round_trips_lockfile_strings() {
+        // The labels written by `lockfile_v2::items_from_report` MUST round-
+        // trip through `parse_kind` so `remove` can dispatch on them.
+        for k in [ItemKind::Rule, ItemKind::Skill, ItemKind::Agent] {
+            let label = match k {
+                ItemKind::Rule => "rule",
+                ItemKind::Skill => "skill",
+                ItemKind::Agent => "agent",
+            };
+            assert_eq!(parse_kind(label).unwrap(), k);
+        }
+    }
+
+    #[test]
+    fn parse_kind_rejects_unknown_string() {
+        let err = parse_kind("bundle").expect_err("must reject");
+        assert!(err.to_string().contains("bundle"));
+    }
+
+    #[test]
+    fn output_path_dispatches_to_per_kind_helper() {
+        // The dispatcher must produce the same path as the per-kind
+        // function for the same `(kind, client, name)` tuple, otherwise
+        // `install` would write to one place and `remove` would look in
+        // another.
+        for client in ALL_CLIENTS {
+            assert_eq!(
+                output_path(ItemKind::Skill, client, "x"),
+                skill_output_path(client, "x")
+            );
+            assert_eq!(
+                output_path(ItemKind::Rule, client, "x"),
+                rule_output_path(client, "x")
+            );
+            assert_eq!(
+                output_path(ItemKind::Agent, client, "x"),
+                agent_output_path(client, "x")
+            );
+        }
     }
 }

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -93,7 +93,6 @@ fn unimplemented_commands_emit_phase_message() {
     // the user at the phase that ships each command.
     let tmp = tempfile::tempdir().unwrap();
     for (cmd, phase) in [
-        ("remove", "Phase B1"),
         ("update", "Phase B2"),
         ("list", "Phase B"),
         ("doctor", "Phase B3"),

--- a/tests/cli_remove.rs
+++ b/tests/cli_remove.rs
@@ -1,0 +1,220 @@
+//! ATDD tests for `upskill remove`.
+//!
+//! Drives `add` then `remove` end-to-end via the CLI: verifies the
+//! per-client output files come back gone and the lockfile drops the
+//! entries. Ancillary files (`CLAUDE.md`, `opencode.json`,
+//! `.vscode/settings.json`) must remain — they are user-owned after
+//! creation per ADR-0003.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn install(target: &Path, source: &Path) {
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn remove_by_name_deletes_all_per_client_outputs_and_lockfile_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    // Sanity check: install put the skill files in place.
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists()
+    );
+    assert!(
+        target
+            .join(".github/skills/create-api-endpoint/SKILL.md")
+            .exists()
+    );
+    assert!(
+        target
+            .join(".agents/skills/create-api-endpoint/SKILL.md")
+            .exists()
+    );
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["remove", "create-api-endpoint"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("Removed 1 item"),
+        "remove report missing: {stdout}"
+    );
+
+    for path in [
+        ".claude/skills/create-api-endpoint/SKILL.md",
+        ".github/skills/create-api-endpoint/SKILL.md",
+        ".agents/skills/create-api-endpoint/SKILL.md",
+    ] {
+        assert!(
+            !target.join(path).exists(),
+            "still on disk after remove: {path}"
+        );
+    }
+
+    let lock = fs::read_to_string(target.join(".upskill-lock.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&lock).unwrap();
+    let names: Vec<&str> = parsed["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        !names.contains(&"create-api-endpoint"),
+        "lockfile still has the entry: {names:?}"
+    );
+}
+
+#[test]
+fn remove_by_source_drops_every_entry_from_that_source() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let source_label = format!("local:{}", source.display());
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["remove", "--source", &source_label])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    // Fixture corpus = 1 skill + 2 rules + 1 agent = 4 items.
+    assert!(
+        stdout.contains("Removed 4 item"),
+        "remove report wrong: {stdout}"
+    );
+
+    let lock = fs::read_to_string(target.join(".upskill-lock.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&lock).unwrap();
+    assert!(
+        parsed["items"].as_array().unwrap().is_empty(),
+        "lockfile not emptied: {parsed}"
+    );
+}
+
+#[test]
+fn remove_preserves_ancillary_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let source_label = format!("local:{}", source.display());
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["remove", "--source", &source_label])
+        .assert()
+        .success();
+
+    // ADR-0003: ancillary files are user-owned after creation. `remove`
+    // must not delete them even when every item from a source goes away.
+    assert!(
+        target.join("CLAUDE.md").exists(),
+        "CLAUDE.md must survive remove"
+    );
+    assert!(
+        target.join("opencode.json").exists(),
+        "opencode.json must survive remove"
+    );
+    assert!(
+        target.join(".vscode/settings.json").exists(),
+        ".vscode/settings.json must survive remove"
+    );
+}
+
+#[test]
+fn remove_bare_invocation_is_usage_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["remove"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn remove_names_and_source_together_is_usage_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["remove", "foo", "--source", "github:o/r"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn remove_unknown_name_is_general_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["remove", "this-was-never-installed"])
+        .assert()
+        .failure()
+        .code(1);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("this-was-never-installed"),
+        "stderr should name the missing item: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

First Phase B slice. `upskill remove` reads `.upskill-lock.json`, deletes per-client output files for matching entries, drops the entries from the lockfile, and best-effort `rmdir`s empty per-item parent directories. Ancillary files (`CLAUDE.md`, `opencode.json`, `.vscode/settings.json`) are preserved — user-owned per ADR-0003.

## Library API (`src/pipeline.rs`)

```rust
pub enum RemoveFilter {
    ByNames(Vec<String>),
    BySource(String),
}
pub fn remove(target: &Path, filter: RemoveFilter) -> Result<RemoveReport>;
pub(crate) fn output_path(kind: ItemKind, client: Client, name: &str) -> PathBuf;
```

`output_path` is the new single source of truth for per-client paths, shared by `install_*` + `remove` so the two cannot drift. Per-kind helpers (`skill_output_path`, `rule_output_path`, `agent_output_path`) stay private but route through the dispatcher.

## CLI surface (per ADR-0004)

| Invocation | Outcome |
|---|---|
| `upskill remove <name>...` | by-name removal |
| `upskill remove --source <label>` | by-source removal |
| `upskill remove` (bare) | exit 2, "be explicit" message |
| names + `--source` together | exit 2, mutually exclusive |
| unknown name | exit 1, stderr names the missing item |
| `--global` | operate on `$HOME` instead of cwd |

## Tests

- `tests/cli_remove.rs` (new) — 6 ATDD tests: by-name, by-source, ancillary preservation, bare-invocation usage error, mutual-exclusion usage error, unknown-name general error.
- `src/pipeline.rs` — 3 new unit tests for `parse_kind` round-trip and the `output_path` dispatcher.
- `tests/cli_add.rs` — drop `remove` from the unimplemented-stub list.

## Out of scope

- `--global` flag tested only via the existing `cli_exit_codes` HOME-unset case (already covered for `add --global`).
- Bundle removal — bundles aren't installed yet; `LockfileV2.bundles` placeholder unchanged.

## Test plan

- [x] `just verify` clean (106 unit + 30+ integration).
- [ ] CI passes.
