### PR TITLE
feat(cli): implement upskill update with --dry-run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use upskill::pipeline::{
-    InstallReport, ItemKind, RemoveFilter, RemoveReport, install_with_lockfile, remove,
+    InstallReport, ItemKind, RemoveFilter, RemoveReport, UpdateMode, UpdateReport, UpdateStatus,
+    install_with_lockfile, remove, update,
 };
 use upskill::search;
 use upskill::source::parse_install_source;
@@ -58,13 +59,21 @@ enum Commands {
         #[arg(short = 'g', long = "global")]
         global: bool,
     },
-    /// Pull latest sources and regenerate changed items. (Phase B2.)
+    /// Pull latest sources and regenerate changed items.
+    ///
+    /// Re-fetches the source for every (or just the named) lockfile
+    /// entries and reinstalls those sources. With `--dry-run`, hashes
+    /// the new SSOT and reports what would change without writing.
+    /// `update` always fetches per ADR-0004.
     Update {
         /// Item names to update (omit to update everything).
         names: Vec<String>,
         /// Report what would change without writing.
         #[arg(long = "dry-run")]
         dry_run: bool,
+        /// Operate on `$HOME` instead of the current directory.
+        #[arg(short = 'g', long = "global")]
+        global: bool,
     },
     /// List installed content. (Phase B-and-beyond.)
     List,
@@ -102,7 +111,11 @@ fn main() {
             source,
             global,
         } => run_remove(&names, source.as_deref(), global),
-        Commands::Update { .. } => unimplemented_stub("update", "B2"),
+        Commands::Update {
+            names,
+            dry_run,
+            global,
+        } => run_update(&names, dry_run, global),
         Commands::List => unimplemented_stub("list", "B"),
         Commands::Doctor => unimplemented_stub("doctor", "B3"),
         Commands::Search { query, limit } => run_search(&query, limit),
@@ -248,6 +261,73 @@ fn print_remove_report(report: &RemoveReport) {
             item.name,
             item.deleted_files.len()
         );
+    }
+}
+
+fn run_update(names: &[String], dry_run: bool, global: bool) -> i32 {
+    let target = match install_target(global) {
+        Ok(t) => t,
+        Err(err) => {
+            eprintln!("error: {}", err);
+            return EXIT_ERROR;
+        }
+    };
+    let mode = if dry_run {
+        UpdateMode::DryRun
+    } else {
+        UpdateMode::Apply
+    };
+
+    match update(&target, names, mode) {
+        Ok(report) => {
+            print_update_report(&report, dry_run);
+            EXIT_SUCCESS
+        }
+        Err(err) => {
+            eprintln!("error: {:#}", err);
+            EXIT_ERROR
+        }
+    }
+}
+
+fn print_update_report(report: &UpdateReport, dry_run: bool) {
+    if report.items.is_empty() {
+        println!("nothing to update — lockfile is empty");
+        return;
+    }
+    let header = if dry_run {
+        "Dry-run: would update"
+    } else {
+        "Updated"
+    };
+    let changes = report
+        .items
+        .iter()
+        .filter(|i| !matches!(i.status, UpdateStatus::UpToDate))
+        .count();
+    println!("{header} {} of {} item(s)", changes, report.items.len());
+    for item in &report.items {
+        let kind_label = match item.kind {
+            ItemKind::Rule => "rule ",
+            ItemKind::Skill => "skill",
+            ItemKind::Agent => "agent",
+        };
+        let status = match &item.status {
+            UpdateStatus::UpToDate => "up to date".to_string(),
+            UpdateStatus::Updated { new_hash, .. } => format!("updated → {}", short(new_hash)),
+            UpdateStatus::WouldChange { new_hash, .. } => {
+                format!("would change → {}", short(new_hash))
+            }
+        };
+        println!("  {} {:<32} {}", kind_label, item.name, status);
+    }
+}
+
+fn short(h: &Option<String>) -> String {
+    match h {
+        Some(s) if s.len() >= 8 => s[..8].to_string(),
+        Some(s) => s.clone(),
+        None => "<no hash>".to_string(),
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -234,6 +234,185 @@ fn parse_kind(s: &str) -> Result<ItemKind> {
     }
 }
 
+/// Whether `update` writes or just reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateMode {
+    Apply,
+    DryRun,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateStatus {
+    /// SSOT hash matches the lockfile — nothing to do.
+    UpToDate,
+    /// `Apply` mode: the lockfile hash changed (or was previously unset
+    /// and now resolved). Outputs were rewritten.
+    Updated {
+        old_hash: Option<String>,
+        new_hash: Option<String>,
+    },
+    /// `DryRun` mode: SSOT hash differs from the lockfile entry; an
+    /// `update` (without `--dry-run`) would rewrite outputs.
+    WouldChange {
+        old_hash: Option<String>,
+        new_hash: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdatedItem {
+    pub kind: ItemKind,
+    pub name: String,
+    pub source: String,
+    pub status: UpdateStatus,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UpdateReport {
+    pub items: Vec<UpdatedItem>,
+}
+
+/// Re-fetch every source recorded in `<target>/.upskill-lock.json` and
+/// either reinstall (`Apply`) or report what would change (`DryRun`).
+///
+/// `names` selects which lockfile entries to update; empty means "all".
+/// When names are given, the entries' source labels are used to fetch
+/// — so `update foo` may also re-render other items installed from the
+/// same source (the pipeline always reinstalls a source as a unit).
+/// Names that match no lockfile entry are an error.
+///
+/// `update` always fetches per ADR-0004 — there is no `--offline`.
+pub fn update(target: &Path, names: &[String], mode: UpdateMode) -> Result<UpdateReport> {
+    let lock = crate::lockfile_v2::LockfileV2::load(target)?;
+
+    let entries: Vec<crate::lockfile_v2::LockedItem> = if names.is_empty() {
+        lock.items.clone()
+    } else {
+        let matched: Vec<crate::lockfile_v2::LockedItem> = lock
+            .items
+            .iter()
+            .filter(|i| names.iter().any(|n| n == &i.name))
+            .cloned()
+            .collect();
+        let matched_names: std::collections::BTreeSet<&str> =
+            matched.iter().map(|i| i.name.as_str()).collect();
+        let unknown: Vec<&str> = names
+            .iter()
+            .filter(|n| !matched_names.contains(n.as_str()))
+            .map(String::as_str)
+            .collect();
+        if !unknown.is_empty() {
+            anyhow::bail!("not in lockfile: {}", unknown.join(", "));
+        }
+        matched
+    };
+
+    // Group by source: installing or hashing once per source covers every
+    // matching entry sharing it.
+    let mut by_source: std::collections::BTreeMap<String, Vec<crate::lockfile_v2::LockedItem>> =
+        std::collections::BTreeMap::new();
+    for entry in entries {
+        by_source
+            .entry(entry.source.clone())
+            .or_default()
+            .push(entry);
+    }
+
+    let mut report = UpdateReport::default();
+    for (source_label, source_entries) in by_source {
+        let source = crate::source::parse_install_source_label(&source_label)
+            .with_context(|| format!("parse lockfile source label `{source_label}`"))?;
+
+        match mode {
+            UpdateMode::Apply => {
+                let install_report = install_with_lockfile(&source, target)?;
+                let mut new_hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> =
+                    std::collections::BTreeMap::new();
+                for it in &install_report.items {
+                    new_hashes.insert((it.kind, it.name.clone()), it.source_hash.clone());
+                }
+                for entry in &source_entries {
+                    let kind = parse_kind(&entry.kind)?;
+                    let new_hash = new_hashes
+                        .get(&(kind, entry.name.clone()))
+                        .cloned()
+                        .flatten();
+                    let status = if new_hash == entry.hash {
+                        UpdateStatus::UpToDate
+                    } else {
+                        UpdateStatus::Updated {
+                            old_hash: entry.hash.clone(),
+                            new_hash,
+                        }
+                    };
+                    report.items.push(UpdatedItem {
+                        kind,
+                        name: entry.name.clone(),
+                        source: source_label.clone(),
+                        status,
+                    });
+                }
+            }
+            UpdateMode::DryRun => {
+                let (root, _guard) = fetch_ssot(&source)?;
+                let new_hashes = hash_source_items(&root);
+                for entry in &source_entries {
+                    let kind = parse_kind(&entry.kind)?;
+                    let new_hash = new_hashes
+                        .get(&(kind, entry.name.clone()))
+                        .cloned()
+                        .flatten();
+                    let status = if new_hash == entry.hash {
+                        UpdateStatus::UpToDate
+                    } else {
+                        UpdateStatus::WouldChange {
+                            old_hash: entry.hash.clone(),
+                            new_hash,
+                        }
+                    };
+                    report.items.push(UpdatedItem {
+                        kind,
+                        name: entry.name.clone(),
+                        source: source_label.clone(),
+                        status,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Hash every item directory under a SSOT root, keyed by `(kind, name)`.
+/// Used by `update --dry-run` to compute would-be hashes without
+/// installing. Mirrors the per-kind walk of `install_from_local_path`.
+fn hash_source_items(
+    source_root: &Path,
+) -> std::collections::BTreeMap<(ItemKind, String), Option<String>> {
+    let mut out = std::collections::BTreeMap::new();
+    for kind in [ItemKind::Skill, ItemKind::Rule, ItemKind::Agent] {
+        let kind_dir = source_root.join(match kind {
+            ItemKind::Skill => "skills",
+            ItemKind::Rule => "rules",
+            ItemKind::Agent => "agents",
+        });
+        let Ok(entries) = fs::read_dir(&kind_dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                out.insert((kind, name.to_string()), hash_item_dir(&path));
+            }
+        }
+    }
+    out
+}
+
 /// Install items from any supported source into `target`.
 ///
 /// Dispatches on the source variant. All git-backed variants funnel
@@ -261,12 +440,8 @@ pub fn install_from_source(source: &InstallSource, target: &Path) -> Result<Inst
 }
 
 fn install_from_github(repo: &GithubRepo, target: &Path) -> Result<InstallReport> {
-    let url = match crate::auth::resolve_github_token().token() {
-        Some(token) => inject_basic_auth(&github_clone_url(repo), "x-access-token", token)?,
-        None => github_clone_url(repo),
-    };
     install_from_git_url(
-        &url,
+        &github_authenticated_url(repo)?,
         repo.git_ref.as_deref(),
         repo.subfolder.as_deref(),
         &repo.owner,
@@ -276,12 +451,8 @@ fn install_from_github(repo: &GithubRepo, target: &Path) -> Result<InstallReport
 }
 
 fn install_from_gitlab(repo: &GitlabRepo, target: &Path) -> Result<InstallReport> {
-    let url = match crate::auth::resolve_gitlab_token().token() {
-        Some(token) => inject_basic_auth(&gitlab_clone_url(repo), "oauth2", token)?,
-        None => gitlab_clone_url(repo),
-    };
     install_from_git_url(
-        &url,
+        &gitlab_authenticated_url(repo)?,
         repo.git_ref.as_deref(),
         repo.subfolder.as_deref(),
         &repo.owner,
@@ -296,6 +467,67 @@ fn github_clone_url(repo: &GithubRepo) -> String {
 
 fn gitlab_clone_url(repo: &GitlabRepo) -> String {
     format!("https://{}/{}/{}.git", repo.host, repo.owner, repo.name)
+}
+
+fn github_authenticated_url(repo: &GithubRepo) -> Result<String> {
+    Ok(match crate::auth::resolve_github_token().token() {
+        Some(token) => inject_basic_auth(&github_clone_url(repo), "x-access-token", token)?,
+        None => github_clone_url(repo),
+    })
+}
+
+fn gitlab_authenticated_url(repo: &GitlabRepo) -> Result<String> {
+    Ok(match crate::auth::resolve_gitlab_token().token() {
+        Some(token) => inject_basic_auth(&gitlab_clone_url(repo), "oauth2", token)?,
+        None => gitlab_clone_url(repo),
+    })
+}
+
+/// Resolve the SSOT root for a source, fetching when remote.
+///
+/// Returns `(path, guard)`:
+/// - `path` is the on-disk SSOT root that callers walk for `skills/`,
+///   `rules/`, `agents/` subdirectories.
+/// - `guard` is `Some(TempDir)` for git sources (drop cleans up the
+///   clone) and `None` for local-path sources.
+///
+/// Used by `update` (especially `--dry-run`) where we want the SSOT on
+/// disk without committing to an install. For `install_*` the same
+/// fetch happens internally inside `install_from_git_url` — we keep
+/// that path independent so install can stay one tempdir-scoped pass.
+pub fn fetch_ssot(source: &InstallSource) -> Result<(PathBuf, Option<tempfile::TempDir>)> {
+    match source {
+        InstallSource::LocalPath(p) => Ok((p.clone(), None)),
+        InstallSource::Github(repo) => clone_to_tempdir(
+            &github_authenticated_url(repo)?,
+            repo.git_ref.as_deref(),
+            repo.subfolder.as_deref(),
+            &repo.owner,
+            &repo.name,
+        ),
+        InstallSource::Gitlab(repo) => clone_to_tempdir(
+            &gitlab_authenticated_url(repo)?,
+            repo.git_ref.as_deref(),
+            repo.subfolder.as_deref(),
+            &repo.owner,
+            &repo.name,
+        ),
+    }
+}
+
+fn clone_to_tempdir(
+    url: &str,
+    git_ref: Option<&str>,
+    subfolder: Option<&str>,
+    owner: &str,
+    name: &str,
+) -> Result<(PathBuf, Option<tempfile::TempDir>)> {
+    let tmp = tempfile::tempdir().context("create temp dir for clone")?;
+    fetch::shallow_clone(url, git_ref, "clone", tmp.path())
+        .map_err(|e| anyhow!("git clone {}: {}", url, e))?;
+    let source = fetch::resolve_subfolder(&tmp.path().join("clone"), subfolder, owner, name)
+        .map_err(|e| anyhow!("{}", e))?;
+    Ok((source, Some(tmp)))
 }
 
 /// Inject HTTP Basic credentials into an `https://` URL so `git clone`

--- a/src/source.rs
+++ b/src/source.rs
@@ -95,6 +95,38 @@ pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseEr
     parse_github_source(source).map(InstallSource::Github)
 }
 
+/// Parse a lockfile source label produced by the [`Display`] impl back
+/// into an [`InstallSource`]. The inverse of `Display::fmt` and the
+/// counterpart to [`parse_install_source`], which accepts user-facing
+/// shorthand instead of the canonical labels.
+///
+/// Recognised labels:
+/// - `github:<owner>/<name>[@<ref>][:<subfolder>]`
+/// - `gitlab:<owner>/<name>[@<ref>][:<subfolder>]` — host is `gitlab.com`
+/// - `gitlab+<host>:<owner>/<name>[@<ref>][:<subfolder>]` — self-hosted
+/// - `local:<path>` — absolute on round-trip; passed through verbatim
+pub fn parse_install_source_label(label: &str) -> Result<InstallSource, SourceParseError> {
+    if let Some(rest) = label.strip_prefix("local:") {
+        return Ok(InstallSource::LocalPath(PathBuf::from(rest)));
+    }
+    if let Some(rest) = label.strip_prefix("github:") {
+        return parse_github_source(rest).map(InstallSource::Github);
+    }
+    if let Some(rest) = label.strip_prefix("gitlab+") {
+        let (host, after) = rest
+            .split_once(':')
+            .ok_or(SourceParseError::InvalidFormat)?;
+        if host.is_empty() {
+            return Err(SourceParseError::EmptySegment);
+        }
+        return parse_gitlab_source(after, host).map(InstallSource::Gitlab);
+    }
+    if let Some(rest) = label.strip_prefix("gitlab:") {
+        return parse_gitlab_source(rest, "gitlab.com").map(InstallSource::Gitlab);
+    }
+    Err(SourceParseError::InvalidFormat)
+}
+
 fn parse_url_source(url_without_scheme: &str) -> Result<InstallSource, SourceParseError> {
     // Split host from path: "gitlab.com/owner/repo@ref:sub" or "github.com/owner/repo"
     let (host_part, path_part) = url_without_scheme
@@ -429,5 +461,78 @@ mod tests {
         assert_eq!(repo.host, "git.company.com:8443");
         assert_eq!(repo.owner, "team");
         assert_eq!(repo.name, "skills");
+    }
+
+    // Lockfile source label round-trip — every shape Display can produce
+    // must round-trip through parse_install_source_label so `update` can
+    // reconstruct the source from a lockfile entry.
+
+    fn assert_label_roundtrip(s: &InstallSource) {
+        let label = s.to_string();
+        let parsed = parse_install_source_label(&label)
+            .unwrap_or_else(|e| panic!("round-trip failed for `{label}`: {e:?}"));
+        assert_eq!(&parsed, s, "round-trip mismatch for `{label}`");
+    }
+
+    #[test]
+    fn label_roundtrip_local_path() {
+        assert_label_roundtrip(&InstallSource::LocalPath(PathBuf::from("/abs/path")));
+        assert_label_roundtrip(&InstallSource::LocalPath(PathBuf::from(
+            "/path with spaces/x",
+        )));
+    }
+
+    #[test]
+    fn label_roundtrip_github_minimal() {
+        assert_label_roundtrip(&InstallSource::Github(GithubRepo {
+            owner: "driftsys".into(),
+            name: "skills".into(),
+            git_ref: None,
+            subfolder: None,
+        }));
+    }
+
+    #[test]
+    fn label_roundtrip_github_full() {
+        assert_label_roundtrip(&InstallSource::Github(GithubRepo {
+            owner: "driftsys".into(),
+            name: "skills".into(),
+            git_ref: Some("v1.2.3".into()),
+            subfolder: Some("rules/lint".into()),
+        }));
+    }
+
+    #[test]
+    fn label_roundtrip_gitlab_dot_com() {
+        assert_label_roundtrip(&InstallSource::Gitlab(GitlabRepo {
+            host: "gitlab.com".into(),
+            owner: "team".into(),
+            name: "skills".into(),
+            git_ref: Some("main".into()),
+            subfolder: None,
+        }));
+    }
+
+    #[test]
+    fn label_roundtrip_gitlab_self_hosted() {
+        assert_label_roundtrip(&InstallSource::Gitlab(GitlabRepo {
+            host: "gitlab.example.com".into(),
+            owner: "team".into(),
+            name: "rules".into(),
+            git_ref: None,
+            subfolder: Some("a/b".into()),
+        }));
+    }
+
+    #[test]
+    fn label_rejects_bare_string() {
+        let err = parse_install_source_label("driftsys/skills").expect_err("must reject");
+        assert_eq!(err, SourceParseError::InvalidFormat);
+    }
+
+    #[test]
+    fn label_rejects_gitlab_plus_without_host() {
+        let err = parse_install_source_label("gitlab+:team/x").expect_err("must reject");
+        assert_eq!(err, SourceParseError::EmptySegment);
     }
 }

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -92,11 +92,7 @@ fn unimplemented_commands_emit_phase_message() {
     // implementations land progressively. Verify the stub message points
     // the user at the phase that ships each command.
     let tmp = tempfile::tempdir().unwrap();
-    for (cmd, phase) in [
-        ("update", "Phase B2"),
-        ("list", "Phase B"),
-        ("doctor", "Phase B3"),
-    ] {
+    for (cmd, phase) in [("list", "Phase B"), ("doctor", "Phase B3")] {
         let assert = Command::cargo_bin("upskill")
             .unwrap()
             .current_dir(tmp.path())

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -1,0 +1,207 @@
+//! ATDD tests for `upskill update`.
+//!
+//! Drives `add` then `update` end-to-end via the CLI. The local-path
+//! source path lets us mutate the SSOT in place between `add` and
+//! `update` to exercise the change-detection branch (lockfile hash vs
+//! recomputed hash) without hitting the network.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn install(target: &Path, source: &Path) {
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+/// Mutate one fixture skill so its content hash will change on the next
+/// install. Appends a sentinel line to the SKILL body.
+fn mutate_skill(source: &Path) {
+    let path = source.join("skills/create-api-endpoint/SKILL.md");
+    let original = fs::read_to_string(&path).unwrap();
+    fs::write(path, format!("{original}\n<!-- mutated by test -->\n")).unwrap();
+}
+
+fn lockfile_hash_for(target: &Path, name: &str) -> Option<String> {
+    let raw = fs::read_to_string(target.join(".upskill-lock.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    parsed["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["name"].as_str() == Some(name))
+        .and_then(|i| i["hash"].as_str().map(str::to_string))
+}
+
+#[test]
+fn update_no_change_reports_up_to_date() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("Updated 0 of 4 item(s)"),
+        "expected no changes, got:\n{out}"
+    );
+    assert!(
+        out.contains("up to date"),
+        "expected up-to-date status, got:\n{out}"
+    );
+}
+
+#[test]
+fn update_after_ssot_mutation_rewrites_outputs_and_lockfile_hash() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let original_hash = lockfile_hash_for(&target, "create-api-endpoint").unwrap();
+    mutate_skill(&source);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "create-api-endpoint"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("Updated 1 of"),
+        "expected 1 change, got:\n{out}"
+    );
+
+    let new_hash = lockfile_hash_for(&target, "create-api-endpoint").unwrap();
+    assert_ne!(
+        original_hash, new_hash,
+        "lockfile hash should change after SSOT mutation"
+    );
+
+    // The rendered Claude SKILL output should now contain the mutation marker.
+    let claude_out =
+        fs::read_to_string(target.join(".claude/skills/create-api-endpoint/SKILL.md")).unwrap();
+    assert!(
+        claude_out.contains("mutated by test"),
+        "regenerated output missing mutation marker"
+    );
+}
+
+#[test]
+fn update_dry_run_reports_change_without_writing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let original_hash = lockfile_hash_for(&target, "create-api-endpoint").unwrap();
+    mutate_skill(&source);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "--dry-run"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(out.contains("Dry-run"), "expected dry-run header: {out}");
+    assert!(
+        out.contains("would change"),
+        "expected `would change` status: {out}"
+    );
+
+    // Lockfile must not have been touched.
+    let after_hash = lockfile_hash_for(&target, "create-api-endpoint").unwrap();
+    assert_eq!(
+        original_hash, after_hash,
+        "dry-run must not modify the lockfile"
+    );
+
+    // And the rendered output stays at the pre-mutation content.
+    let claude_out =
+        fs::read_to_string(target.join(".claude/skills/create-api-endpoint/SKILL.md")).unwrap();
+    assert!(
+        !claude_out.contains("mutated by test"),
+        "dry-run must not regenerate per-client output"
+    );
+}
+
+#[test]
+fn update_unknown_name_is_general_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "this-was-never-installed"])
+        .assert()
+        .failure()
+        .code(1);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("this-was-never-installed"),
+        "stderr should name the missing item: {stderr}"
+    );
+}
+
+#[test]
+fn update_empty_lockfile_is_no_op() {
+    let tmp = tempfile::tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["update"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("nothing to update"),
+        "expected empty-lockfile message: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Second Phase B slice. `upskill update` re-fetches the source for every (or just the named) lockfile entries and reinstalls those sources via the existing pipeline. With `--dry-run`, hashes the new SSOT and reports what would change without writing. `update` always fetches per ADR-0004; no `--offline`.

## Library API (`src/pipeline.rs`)

```rust
pub enum UpdateMode { Apply, DryRun }
pub enum UpdateStatus {
    UpToDate,
    Updated     { old_hash: Option<String>, new_hash: Option<String> },
    WouldChange { old_hash: Option<String>, new_hash: Option<String> },
}
pub fn update(target: &Path, names: &[String], mode: UpdateMode) -> Result<UpdateReport>;
pub fn fetch_ssot(source: &InstallSource) -> Result<(PathBuf, Option<TempDir>)>;
```

`fetch_ssot` is the new shared SSOT-resolver: returns the on-disk SSOT root + a tempdir guard that cleans up the clone on drop. Used by `update --dry-run` to walk the would-be source without committing to an install.

Cleanup refactor in the same diff: extracted `github_authenticated_url` / `gitlab_authenticated_url` helpers used by both `install_from_*` and `fetch_ssot`, so token injection lives in exactly one place.

## Lockfile-source label parser (`src/source.rs`)

```rust
pub fn parse_install_source_label(label: &str) -> Result<InstallSource, SourceParseError>;
```

The inverse of `Display`. The lockfile stores the source as the canonical label (`github:owner/repo`, `gitlab+host:...`, `local:/path`, etc.), not the user-shorthand form `parse_install_source` accepts.

## CLI

| Invocation | Outcome |
|---|---|
| `upskill update` | refresh every lockfile entry |
| `upskill update foo bar` | refresh only the named items (their sources still re-fetched as units) |
| `upskill update --dry-run [...]` | report would-be changes; no writes |
| `--global` | operate on `$HOME` instead of cwd |
| unknown name | exit 1, stderr names the missing item |
| empty lockfile | success with "nothing to update" message |

## Tests

- `tests/cli_update.rs` (new) — 5 ATDD tests covering: no-change "up to date", apply path with SSOT mutation rewrites outputs + lockfile hash, dry-run reports change without writing, unknown-name error, empty-lockfile no-op.
- `src/source.rs` — 7 new round-trip tests covering every shape `Display` produces (local / github minimal+full / gitlab.com / self-hosted gitlab), plus "bare string" rejection and the `gitlab+:` empty-host case.
- `tests/cli_add.rs` — drop `update` from the unimplemented-stub list.

## Out of scope

- Bundle updates — bundles aren't installed yet; the lockfile's bundle slot is unchanged.
- Source-label parser does not currently round-trip local paths back through any normalisation (we pass the raw bytes after `local:`). Should be fine because installs already store absolute paths.

## Test plan

- [x] `just verify` clean (113 unit + 38 integration).
- [ ] CI passes.
