### PR TITLE
feat(cli): implement upskill doctor consistency check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use upskill::pipeline::{
-    InstallReport, ItemKind, RemoveFilter, RemoveReport, UpdateMode, UpdateReport, UpdateStatus,
-    install_with_lockfile, remove, update,
+    DoctorReport, InstallReport, ItemKind, OrphanReason, RemoveFilter, RemoveReport, UpdateMode,
+    UpdateReport, UpdateStatus, doctor, install_with_lockfile, remove, update,
 };
 use upskill::search;
 use upskill::source::parse_install_source;
@@ -77,8 +77,20 @@ enum Commands {
     },
     /// List installed content. (Phase B-and-beyond.)
     List,
-    /// Verify installed-state consistency. (Phase B3.)
-    Doctor,
+    /// Verify installed-state consistency.
+    ///
+    /// Three independent buckets per ADR-0004:
+    /// - missing per-client output files (reinstall fixes)
+    /// - SSOT hash drift on `local:` sources (update fixes)
+    /// - lockfile entries with no recoverable source (manual remove)
+    ///
+    /// Doctor never fetches; remote-source drift detection is
+    /// `update --dry-run`. Exit 0 when clean, 1 when any drift is found.
+    Doctor {
+        /// Operate on `$HOME` instead of the current directory.
+        #[arg(short = 'g', long = "global")]
+        global: bool,
+    },
     /// Search the public skills registry.
     Search {
         /// Search query.
@@ -117,7 +129,7 @@ fn main() {
             global,
         } => run_update(&names, dry_run, global),
         Commands::List => unimplemented_stub("list", "B"),
-        Commands::Doctor => unimplemented_stub("doctor", "B3"),
+        Commands::Doctor { global } => run_doctor(global),
         Commands::Search { query, limit } => run_search(&query, limit),
     };
 
@@ -328,6 +340,89 @@ fn short(h: &Option<String>) -> String {
         Some(s) if s.len() >= 8 => s[..8].to_string(),
         Some(s) => s.clone(),
         None => "<no hash>".to_string(),
+    }
+}
+
+fn run_doctor(global: bool) -> i32 {
+    let target = match install_target(global) {
+        Ok(t) => t,
+        Err(err) => {
+            eprintln!("error: {}", err);
+            return EXIT_ERROR;
+        }
+    };
+
+    match doctor(&target) {
+        Ok(report) => {
+            print_doctor_report(&report);
+            if report.is_clean() {
+                EXIT_SUCCESS
+            } else {
+                EXIT_ERROR
+            }
+        }
+        Err(err) => {
+            eprintln!("error: {:#}", err);
+            EXIT_ERROR
+        }
+    }
+}
+
+fn print_doctor_report(report: &DoctorReport) {
+    if report.is_clean() {
+        println!("doctor: clean");
+        return;
+    }
+
+    if !report.missing_outputs.is_empty() {
+        println!(
+            "doctor: missing per-client outputs ({} item(s)) — reinstall to fix",
+            report.missing_outputs.len()
+        );
+        for m in &report.missing_outputs {
+            println!("  {} {}", kind_label(m.kind), m.name);
+            for path in &m.missing_files {
+                println!("    - {}", path.display());
+            }
+        }
+    }
+
+    if !report.stale_hashes.is_empty() {
+        println!(
+            "doctor: SSOT hash drift on local sources ({} item(s)) — `upskill update` to fix",
+            report.stale_hashes.len()
+        );
+        for s in &report.stale_hashes {
+            println!("  {} {} ({})", kind_label(s.kind), s.name, s.source);
+        }
+    }
+
+    if !report.orphan_entries.is_empty() {
+        println!(
+            "doctor: lockfile entries with no recoverable source ({} item(s)) — `upskill remove` to clear",
+            report.orphan_entries.len()
+        );
+        for o in &report.orphan_entries {
+            let reason = match o.reason {
+                OrphanReason::LocalPathGone => "local path gone",
+                OrphanReason::ItemMissingInSource => "item not in source",
+            };
+            println!(
+                "  {} {} ({}) — {}",
+                kind_label(o.kind),
+                o.name,
+                o.source,
+                reason
+            );
+        }
+    }
+}
+
+fn kind_label(kind: ItemKind) -> &'static str {
+    match kind {
+        ItemKind::Rule => "rule ",
+        ItemKind::Skill => "skill",
+        ItemKind::Agent => "agent",
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -234,6 +234,154 @@ fn parse_kind(s: &str) -> Result<ItemKind> {
     }
 }
 
+fn kind_subdir(kind: ItemKind) -> &'static str {
+    match kind {
+        ItemKind::Skill => "skills",
+        ItemKind::Rule => "rules",
+        ItemKind::Agent => "agents",
+    }
+}
+
+/// One per-client output file the lockfile said should exist but doesn't.
+#[derive(Debug, Clone)]
+pub struct MissingOutput {
+    pub kind: ItemKind,
+    pub name: String,
+    /// Paths relative to the install target.
+    pub missing_files: Vec<PathBuf>,
+}
+
+/// SSOT content hash differs from what the lockfile recorded at install
+/// time. Only computed for `local:` sources still on disk —
+/// remote-source drift is the job of `update --dry-run`, which fetches.
+#[derive(Debug, Clone)]
+pub struct StaleHash {
+    pub kind: ItemKind,
+    pub name: String,
+    pub source: String,
+    pub stored_hash: Option<String>,
+    pub current_hash: Option<String>,
+}
+
+/// Lockfile entry whose source can no longer be reached: the local
+/// path is gone or the named item has been removed from the SSOT
+/// directory. The user has to `remove` it explicitly to clear the
+/// lockfile, since `update` would just fail trying to fetch.
+#[derive(Debug, Clone)]
+pub struct OrphanEntry {
+    pub kind: ItemKind,
+    pub name: String,
+    pub source: String,
+    pub reason: OrphanReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrphanReason {
+    /// `local:<path>` source no longer resolves to a directory on disk.
+    LocalPathGone,
+    /// Source still exists but no longer contains the item with this
+    /// `(kind, name)` (e.g., it was renamed or removed in the SSOT).
+    ItemMissingInSource,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DoctorReport {
+    pub missing_outputs: Vec<MissingOutput>,
+    pub stale_hashes: Vec<StaleHash>,
+    pub orphan_entries: Vec<OrphanEntry>,
+}
+
+impl DoctorReport {
+    /// True when nothing is wrong — every per-client output is on disk,
+    /// every locally-sourced item still hashes the same, and every
+    /// lockfile entry has a recoverable source.
+    pub fn is_clean(&self) -> bool {
+        self.missing_outputs.is_empty()
+            && self.stale_hashes.is_empty()
+            && self.orphan_entries.is_empty()
+    }
+}
+
+/// Verify installed-state consistency against `.upskill-lock.json`.
+/// Three independent buckets per ADR-0004:
+/// - **missing outputs** — file paths the lockfile says should exist
+///   but don't. Reinstall (`upskill add <source>`) fixes it.
+/// - **stale hashes** — for `local:` sources still on disk, the SSOT
+///   item directory hashes to a value that does not match the lockfile.
+///   `upskill update` (or `--dry-run`) fixes it.
+/// - **orphan entries** — the lockfile points at a `local:` source that
+///   is gone, or at an item that no longer exists in its source. The
+///   user has to `upskill remove` to clear it.
+///
+/// Doctor never fetches. Remote-source drift is detected by
+/// `update --dry-run`, which does fetch.
+pub fn doctor(target: &Path) -> Result<DoctorReport> {
+    let lock = crate::lockfile_v2::LockfileV2::load(target)?;
+    let mut report = DoctorReport::default();
+
+    for entry in &lock.items {
+        let kind = parse_kind(&entry.kind).with_context(|| {
+            format!(
+                "lockfile entry {}: unknown kind `{}`",
+                entry.name, entry.kind
+            )
+        })?;
+
+        let mut missing = Vec::new();
+        for client in ALL_CLIENTS {
+            let rel = output_path(kind, client, &entry.name);
+            if !target.join(&rel).exists() {
+                missing.push(rel);
+            }
+        }
+        if !missing.is_empty() {
+            report.missing_outputs.push(MissingOutput {
+                kind,
+                name: entry.name.clone(),
+                missing_files: missing,
+            });
+        }
+
+        if let Some(local_path) = entry.source.strip_prefix("local:") {
+            let ssot_root = Path::new(local_path);
+            if !ssot_root.is_dir() {
+                report.orphan_entries.push(OrphanEntry {
+                    kind,
+                    name: entry.name.clone(),
+                    source: entry.source.clone(),
+                    reason: OrphanReason::LocalPathGone,
+                });
+                continue;
+            }
+            let item_dir = ssot_root.join(kind_subdir(kind)).join(&entry.name);
+            if !item_dir.is_dir() {
+                report.orphan_entries.push(OrphanEntry {
+                    kind,
+                    name: entry.name.clone(),
+                    source: entry.source.clone(),
+                    reason: OrphanReason::ItemMissingInSource,
+                });
+                continue;
+            }
+            let current = hash_item_dir(&item_dir);
+            if current != entry.hash {
+                report.stale_hashes.push(StaleHash {
+                    kind,
+                    name: entry.name.clone(),
+                    source: entry.source.clone(),
+                    stored_hash: entry.hash.clone(),
+                    current_hash: current,
+                });
+            }
+        }
+        // Non-local sources: doctor only validates per-client outputs.
+        // Hash comparison would require a network fetch — out of scope
+        // here, see `update --dry-run`.
+    }
+
+    Ok(report)
+}
+
 /// Whether `update` writes or just reports.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateMode {
@@ -392,11 +540,7 @@ fn hash_source_items(
 ) -> std::collections::BTreeMap<(ItemKind, String), Option<String>> {
     let mut out = std::collections::BTreeMap::new();
     for kind in [ItemKind::Skill, ItemKind::Rule, ItemKind::Agent] {
-        let kind_dir = source_root.join(match kind {
-            ItemKind::Skill => "skills",
-            ItemKind::Rule => "rules",
-            ItemKind::Agent => "agents",
-        });
+        let kind_dir = source_root.join(kind_subdir(kind));
         let Ok(entries) = fs::read_dir(&kind_dir) else {
             continue;
         };
@@ -1035,6 +1179,52 @@ mod tests {
     fn parse_kind_rejects_unknown_string() {
         let err = parse_kind("bundle").expect_err("must reject");
         assert!(err.to_string().contains("bundle"));
+    }
+
+    #[test]
+    fn doctor_report_is_clean_when_all_buckets_empty() {
+        let report = DoctorReport::default();
+        assert!(report.is_clean());
+    }
+
+    #[test]
+    fn doctor_report_not_clean_with_any_drift() {
+        let mut report = DoctorReport::default();
+        report.missing_outputs.push(MissingOutput {
+            kind: ItemKind::Skill,
+            name: "x".into(),
+            missing_files: vec![PathBuf::from("a")],
+        });
+        assert!(!report.is_clean());
+
+        let mut report = DoctorReport::default();
+        report.stale_hashes.push(StaleHash {
+            kind: ItemKind::Skill,
+            name: "x".into(),
+            source: "local:/p".into(),
+            stored_hash: None,
+            current_hash: Some("abc".into()),
+        });
+        assert!(!report.is_clean());
+
+        let mut report = DoctorReport::default();
+        report.orphan_entries.push(OrphanEntry {
+            kind: ItemKind::Skill,
+            name: "x".into(),
+            source: "local:/p".into(),
+            reason: OrphanReason::LocalPathGone,
+        });
+        assert!(!report.is_clean());
+    }
+
+    #[test]
+    fn kind_subdir_matches_install_pipeline_layout() {
+        // Format-spec §2.1: SSOT root has skills/, rules/, agents/.
+        // The doctor walks the same layout install_skills/_rules/_agents
+        // walk; pinning the subdir names here catches accidental rename.
+        assert_eq!(kind_subdir(ItemKind::Skill), "skills");
+        assert_eq!(kind_subdir(ItemKind::Rule), "rules");
+        assert_eq!(kind_subdir(ItemKind::Agent), "agents");
     }
 
     #[test]

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -92,7 +92,7 @@ fn unimplemented_commands_emit_phase_message() {
     // implementations land progressively. Verify the stub message points
     // the user at the phase that ships each command.
     let tmp = tempfile::tempdir().unwrap();
-    for (cmd, phase) in [("list", "Phase B"), ("doctor", "Phase B3")] {
+    for (cmd, phase) in [("list", "Phase B")] {
         let assert = Command::cargo_bin("upskill")
             .unwrap()
             .current_dir(tmp.path())

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -1,0 +1,200 @@
+//! ATDD tests for `upskill doctor`.
+//!
+//! Verifies the three drift buckets per ADR-0004:
+//! - missing per-client output files (reinstall fixes)
+//! - SSOT hash drift on `local:` sources (update fixes)
+//! - lockfile entries with no recoverable source (manual remove)
+//!
+//! Doctor never fetches; remote-source drift detection is `update --dry-run`.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn install(target: &Path, source: &Path) {
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn doctor_clean_install_exits_zero() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["doctor"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(out.contains("doctor: clean"), "expected clean: {out}");
+}
+
+#[test]
+fn doctor_empty_lockfile_exits_zero() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["doctor"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn doctor_detects_missing_output_files() {
+    // Install, then delete one rendered output behind upskill's back —
+    // the bucket-1 path. Doctor must exit 1 and name the missing file.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let stolen = target.join(".claude/skills/create-api-endpoint/SKILL.md");
+    fs::remove_file(&stolen).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .code(1);
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("missing per-client outputs") && out.contains("create-api-endpoint"),
+        "expected missing-output report: {out}"
+    );
+    assert!(
+        out.contains(".claude/skills/create-api-endpoint/SKILL.md"),
+        "expected the missing path listed: {out}"
+    );
+}
+
+#[test]
+fn doctor_detects_ssot_hash_drift() {
+    // Install from a local source, mutate the SSOT in place — the
+    // bucket-2 path. Doctor must exit 1 and surface the stale-hash bucket.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    let skill_md = source.join("skills/create-api-endpoint/SKILL.md");
+    let original = fs::read_to_string(&skill_md).unwrap();
+    fs::write(&skill_md, format!("{original}\n<!-- mutation -->\n")).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .code(1);
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("SSOT hash drift") && out.contains("create-api-endpoint"),
+        "expected stale-hash bucket: {out}"
+    );
+    assert!(
+        out.contains("upskill update"),
+        "should suggest the fix command: {out}"
+    );
+}
+
+#[test]
+fn doctor_detects_orphan_when_local_path_gone() {
+    // Install from a local source, remove the source dir — the bucket-3
+    // path. Doctor must exit 1 and surface every entry as orphan.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    fs::remove_dir_all(&source).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .code(1);
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("no recoverable source"),
+        "expected orphan bucket: {out}"
+    );
+    assert!(out.contains("local path gone"), "should explain why: {out}");
+    assert!(
+        out.contains("upskill remove"),
+        "should suggest the fix command: {out}"
+    );
+}
+
+#[test]
+fn doctor_detects_orphan_when_item_removed_from_source() {
+    // Install from a local source, remove just one item dir from the
+    // SSOT (leaving the source root). Doctor must report that one item
+    // as orphan with "item not in source", and other items stay clean.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    install(&target, &source);
+
+    fs::remove_dir_all(source.join("skills/create-api-endpoint")).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .code(1);
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("create-api-endpoint") && out.contains("item not in source"),
+        "expected orphan with reason: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Third Phase B slice. `upskill doctor` reads `.upskill-lock.json` and classifies drift into three independent buckets per ADR-0004:

- **missing per-client output files** (reinstall fixes) — checks every expected `output_path(kind, client, name)` exists for each lockfile entry.
- **SSOT hash drift on `local:` sources** (update fixes) — re-hashes the SSOT item directory and compares to `LockedItem.hash`.
- **lockfile entries with no recoverable source** (manual remove) — `local:` path is gone (`OrphanReason::LocalPathGone`) or the named item disappeared from the source (`OrphanReason::ItemMissingInSource`).

Doctor never fetches. Remote-source drift detection is the job of `update --dry-run`, which does fetch.

## Library API (`src/pipeline.rs`)

```rust
pub struct DoctorReport {
    pub missing_outputs: Vec<MissingOutput>,
    pub stale_hashes:    Vec<StaleHash>,
    pub orphan_entries:  Vec<OrphanEntry>,
}
impl DoctorReport { pub fn is_clean(&self) -> bool; }

pub enum OrphanReason { LocalPathGone, ItemMissingInSource }

pub fn doctor(target: &Path) -> Result<DoctorReport>;
```

Pulled out `kind_subdir(ItemKind)` so the SSOT-walk uses one mapping shared by `doctor` and `update`'s `hash_source_items`.

## CLI

| Invocation | Outcome |
|---|---|
| `upskill doctor` | exit 0 when clean, 1 when any drift |
| `--global` | operate on `$HOME` instead of cwd |

Output groups by bucket and suggests the fix command per bucket (reinstall / `upskill update` / `upskill remove`).

## Tests

- `tests/cli_doctor.rs` (new) — 6 ATDD tests: clean install, empty lockfile, missing-output detection, SSOT hash drift, orphan via local-path-gone, orphan via item-missing-in-source.
- `src/pipeline.rs` — 3 new unit tests for `DoctorReport::is_clean` and the `kind_subdir` mapping.
- `tests/cli_add.rs` — drop `doctor` from the unimplemented-stub list.

## Out of scope

- Remote-source hash drift (network fetch in `doctor`) — by design; that path goes through `update --dry-run`.
- Lockfile entries with `unknown kind` are surfaced as a hard error (lockfile likely written by a future schema). Could be softened to a fourth bucket if it bites in practice.

## Test plan

- [x] `just verify` clean (116 unit + 44 integration).
- [ ] CI passes.
