### PR TITLE
feat(bundle): resolve and install bundles end-to-end

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,0 +1,309 @@
+//! Bundle resolution: walk the `requires` graph, union items, detect
+//! conflicts and cycles. Per format-spec §3.7.
+//!
+//! Inputs come from [`crate::parse::bundle`] (`load`/`discover`); the
+//! install layer in [`crate::pipeline`] consumes the [`Resolved`] output
+//! to decide which item directories to render.
+
+use anyhow::Result;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::model::Bundle;
+use crate::pipeline::ItemKind;
+
+/// What a bundle (and everything it transitively requires) installs.
+///
+/// `bundles` is the post-order topological walk — every required bundle
+/// appears before the bundle that requires it. The entry bundle is the
+/// last element. Resolvers preserve this order so callers that record
+/// per-bundle state see dependencies first.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Resolved {
+    pub bundles: Vec<Bundle>,
+    pub items: ResolvedItems,
+}
+
+/// Union of every item across the reached bundles, deduplicated by
+/// `(kind, name)` and sorted for deterministic install order.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ResolvedItems {
+    pub rules: Vec<String>,
+    pub skills: Vec<String>,
+    pub agents: Vec<String>,
+}
+
+impl ResolvedItems {
+    /// Total count across all kinds. Useful for install reports.
+    pub fn total(&self) -> usize {
+        self.rules.len() + self.skills.len() + self.agents.len()
+    }
+
+    /// Lookup by `(kind, name)`. Used by the filtered-install path so
+    /// the SSOT walk can skip directories that aren't in the resolution.
+    pub fn contains(&self, kind: ItemKind, name: &str) -> bool {
+        let bucket = match kind {
+            ItemKind::Rule => &self.rules,
+            ItemKind::Skill => &self.skills,
+            ItemKind::Agent => &self.agents,
+        };
+        bucket.iter().any(|n| n == name)
+    }
+}
+
+/// Resolve `entry` transitively against `available` (every bundle the
+/// caller discovered in the same source registry).
+///
+/// Errors:
+/// - **missing requirement** — a `requires` name has no matching bundle
+///   in `available`.
+/// - **cycle** — `entry` (transitively) requires a bundle that
+///   (transitively) requires `entry`.
+/// - **item conflict** — two reached bundles list the same `(kind,
+///   name)` tuple. Same name in different kinds is allowed.
+///
+/// Version constraints in `Requires.version` are accepted but **not
+/// enforced** at this layer (kept as opaque strings). Constraint
+/// matching is a follow-up; today the resolver picks the first matching
+/// bundle by `name` regardless of version.
+pub fn resolve(entry: &Bundle, available: &[Bundle]) -> Result<Resolved> {
+    let by_name: BTreeMap<&str, &Bundle> = available.iter().map(|b| (b.name.as_str(), b)).collect();
+
+    let mut visited: BTreeSet<String> = BTreeSet::new();
+    let mut on_stack: BTreeSet<String> = BTreeSet::new();
+    let mut order: Vec<Bundle> = Vec::new();
+
+    visit(entry, &by_name, &mut visited, &mut on_stack, &mut order)?;
+
+    let items = union_items(&order)?;
+    Ok(Resolved {
+        bundles: order,
+        items,
+    })
+}
+
+fn visit(
+    bundle: &Bundle,
+    by_name: &BTreeMap<&str, &Bundle>,
+    visited: &mut BTreeSet<String>,
+    on_stack: &mut BTreeSet<String>,
+    order: &mut Vec<Bundle>,
+) -> Result<()> {
+    if visited.contains(&bundle.name) {
+        return Ok(());
+    }
+    if on_stack.contains(&bundle.name) {
+        // Should be unreachable because the caller checks visited first;
+        // included for completeness.
+        anyhow::bail!("bundle dependency cycle including `{}`", bundle.name);
+    }
+    on_stack.insert(bundle.name.clone());
+
+    for req in &bundle.requires {
+        if on_stack.contains(&req.name) {
+            anyhow::bail!(
+                "bundle dependency cycle: `{}` requires `{}` which is already on the resolution stack",
+                bundle.name,
+                req.name
+            );
+        }
+        let dep = by_name.get(req.name.as_str()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "bundle `{}` requires `{}` which was not found in the source registry",
+                bundle.name,
+                req.name
+            )
+        })?;
+        visit(dep, by_name, visited, on_stack, order)?;
+    }
+
+    on_stack.remove(&bundle.name);
+    visited.insert(bundle.name.clone());
+    order.push(bundle.clone());
+    Ok(())
+}
+
+fn union_items(bundles: &[Bundle]) -> Result<ResolvedItems> {
+    let mut seen: BTreeMap<(ItemKind, String), String> = BTreeMap::new();
+    for bundle in bundles {
+        for name in &bundle.items.rules {
+            insert_or_conflict(&mut seen, ItemKind::Rule, name, &bundle.name)?;
+        }
+        for name in &bundle.items.skills {
+            insert_or_conflict(&mut seen, ItemKind::Skill, name, &bundle.name)?;
+        }
+        for name in &bundle.items.agents {
+            insert_or_conflict(&mut seen, ItemKind::Agent, name, &bundle.name)?;
+        }
+    }
+
+    let mut rules = Vec::new();
+    let mut skills = Vec::new();
+    let mut agents = Vec::new();
+    for ((kind, name), _origin) in seen {
+        match kind {
+            ItemKind::Rule => rules.push(name),
+            ItemKind::Skill => skills.push(name),
+            ItemKind::Agent => agents.push(name),
+        }
+    }
+    Ok(ResolvedItems {
+        rules,
+        skills,
+        agents,
+    })
+}
+
+fn insert_or_conflict(
+    seen: &mut BTreeMap<(ItemKind, String), String>,
+    kind: ItemKind,
+    name: &str,
+    origin: &str,
+) -> Result<()> {
+    let key = (kind, name.to_string());
+    if let Some(prior) = seen.get(&key) {
+        anyhow::bail!(
+            "item conflict: {:?} `{}` is named by both bundles `{}` and `{}`",
+            kind,
+            name,
+            prior,
+            origin
+        );
+    }
+    seen.insert(key, origin.to_string());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{BundleItems, Requires, SchemaVersion};
+
+    fn bundle(name: &str, items: BundleItems, requires: Vec<&str>) -> Bundle {
+        Bundle {
+            schema: SchemaVersion::new(1).unwrap(),
+            name: name.to_string(),
+            description: format!("test bundle {name}"),
+            license: None,
+            items,
+            requires: requires
+                .into_iter()
+                .map(|n| Requires {
+                    name: n.to_string(),
+                    version: None,
+                })
+                .collect(),
+            metadata: None,
+            extra: Default::default(),
+        }
+    }
+
+    fn items(rules: &[&str], skills: &[&str], agents: &[&str]) -> BundleItems {
+        BundleItems {
+            rules: rules.iter().map(|s| s.to_string()).collect(),
+            skills: skills.iter().map(|s| s.to_string()).collect(),
+            agents: agents.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn resolve_single_bundle_with_no_requires() {
+        let entry = bundle("solo", items(&["r1"], &["s1"], &["a1"]), vec![]);
+        let resolved = resolve(&entry, &[entry.clone()]).unwrap();
+
+        assert_eq!(resolved.bundles.len(), 1);
+        assert_eq!(resolved.bundles[0].name, "solo");
+        assert_eq!(resolved.items.total(), 3);
+        assert!(resolved.items.contains(ItemKind::Rule, "r1"));
+        assert!(resolved.items.contains(ItemKind::Skill, "s1"));
+        assert!(resolved.items.contains(ItemKind::Agent, "a1"));
+    }
+
+    #[test]
+    fn resolve_walks_requires_in_dependency_order() {
+        // entry → mid → leaf (mid requires leaf, entry requires mid)
+        let leaf = bundle("leaf", items(&["leaf-rule"], &[], &[]), vec![]);
+        let mid = bundle("mid", items(&[], &["mid-skill"], &[]), vec!["leaf"]);
+        let entry = bundle("entry", items(&[], &[], &["entry-agent"]), vec!["mid"]);
+        let available = vec![leaf.clone(), mid.clone(), entry.clone()];
+
+        let resolved = resolve(&entry, &available).unwrap();
+
+        let order: Vec<&str> = resolved.bundles.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(
+            order,
+            vec!["leaf", "mid", "entry"],
+            "post-order topological"
+        );
+        assert_eq!(resolved.items.total(), 3);
+    }
+
+    #[test]
+    fn resolve_unions_items_across_bundles() {
+        let a = bundle("a", items(&["a-rule"], &["common-skill"], &[]), vec![]);
+        let b = bundle("b", items(&["b-rule"], &[], &["b-agent"]), vec!["a"]);
+        let resolved = resolve(&b, &[a, b.clone()]).unwrap();
+        assert_eq!(resolved.items.rules.len(), 2);
+        assert_eq!(resolved.items.skills, vec!["common-skill"]);
+        assert_eq!(resolved.items.agents, vec!["b-agent"]);
+    }
+
+    #[test]
+    fn resolve_dedupe_path_diamond_does_not_error() {
+        // diamond: entry → A, entry → B, A → leaf, B → leaf.
+        // `leaf` is reached twice; the resolver should visit it once.
+        let leaf = bundle("leaf", items(&["leaf-rule"], &[], &[]), vec![]);
+        let a = bundle("a", items(&["a-rule"], &[], &[]), vec!["leaf"]);
+        let b = bundle("b", items(&["b-rule"], &[], &[]), vec!["leaf"]);
+        let entry = bundle("entry", items(&[], &[], &[]), vec!["a", "b"]);
+        let available = vec![leaf, a, b, entry.clone()];
+
+        let resolved = resolve(&entry, &available).unwrap();
+        assert_eq!(
+            resolved.bundles.len(),
+            4,
+            "leaf reached twice, visited once"
+        );
+        // Items unioned without duplicates because each bundle's items
+        // are disjoint.
+        assert_eq!(resolved.items.rules.len(), 3);
+    }
+
+    #[test]
+    fn resolve_errors_on_item_conflict() {
+        // Both bundles list rule "x" — even though they're related by
+        // requires, the spec calls this a conflict.
+        let a = bundle("a", items(&["x"], &[], &[]), vec![]);
+        let b = bundle("b", items(&["x"], &[], &[]), vec!["a"]);
+        let err = resolve(&b, &[a, b.clone()]).expect_err("conflict");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("item conflict"), "{msg}");
+        assert!(msg.contains("`x`"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_allows_same_name_in_different_kinds() {
+        let a = bundle("a", items(&["shared"], &[], &[]), vec![]);
+        let b = bundle("b", items(&[], &["shared"], &[]), vec!["a"]);
+        let resolved = resolve(&b, &[a, b.clone()]).unwrap();
+        assert_eq!(resolved.items.rules, vec!["shared"]);
+        assert_eq!(resolved.items.skills, vec!["shared"]);
+    }
+
+    #[test]
+    fn resolve_errors_on_cycle() {
+        let a = bundle("a", items(&[], &[], &[]), vec!["b"]);
+        let b = bundle("b", items(&[], &[], &[]), vec!["a"]);
+        let err = resolve(&a, &[a.clone(), b]).expect_err("cycle");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("cycle"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_errors_on_missing_requirement() {
+        let a = bundle("a", items(&[], &[], &[]), vec!["does-not-exist"]);
+        let err = resolve(&a, &[a.clone()]).expect_err("missing");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("does-not-exist"), "{msg}");
+        assert!(msg.contains("not found"), "{msg}");
+    }
+}

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -64,7 +64,10 @@ pub(crate) fn resolve_subfolder(
 ) -> Result<PathBuf, String> {
     if let Some(sub) = subfolder {
         let sub_path = clone_dir.join(sub);
-        if !sub_path.is_dir() {
+        // Subfolders are usually directories (item-root paths) but bundle
+        // sources point at a `<name>.bundle.md` file directly. Accept
+        // both — the install layer dispatches on file vs dir.
+        if !sub_path.exists() {
             return Err(format!(
                 "subfolder '{}' not found in {}/{}",
                 sub, owner, name

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod ancillary;
 pub mod auth;
+pub mod bundle;
 pub mod fetch;
 pub mod generate;
 pub mod lockfile_v2;

--- a/src/lockfile_v2.rs
+++ b/src/lockfile_v2.rs
@@ -56,8 +56,11 @@ pub struct LockedItem {
     pub hash: Option<String>,
 }
 
-/// Placeholder for the bundle-install slice. Schema is finalised so the
-/// shape is forward-compatible; no bundle entries are produced today.
+/// Bundle entry recorded when an install resolves a `.bundle.md` file
+/// (the entry bundle and every transitive `requires`). The lockfile's
+/// per-item `items` array still carries each rule/skill/agent
+/// independently — this entry is metadata that pairs each bundle name
+/// to the items it resolved to.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LockedBundle {
     pub name: String,
@@ -65,7 +68,10 @@ pub struct LockedBundle {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "ref")]
     pub git_ref: Option<String>,
-    /// Item names this bundle resolved to.
+    /// Item names declared by THIS bundle (not the transitive closure).
+    /// Resolution flattens the closure into `items`; the per-bundle
+    /// breakdown lives here so a future `remove <bundle>` can subtract
+    /// only that bundle's contribution.
     #[serde(default)]
     pub items: Vec<String>,
 }
@@ -149,6 +155,14 @@ impl LockfileV2 {
     pub fn remove(&mut self, kind: &str, name: &str) {
         self.items
             .retain(|existing| !(existing.kind == kind && existing.name == name));
+    }
+
+    /// Add or replace a bundle entry by `name`. Bundles are kept sorted
+    /// for deterministic on-disk output.
+    pub fn upsert_bundle(&mut self, bundle: LockedBundle) {
+        self.bundles.retain(|existing| existing.name != bundle.name);
+        self.bundles.push(bundle);
+        self.bundles.sort();
     }
 
     /// Persist to `<project_root>/.upskill-lock.json`. Pretty-printed JSON
@@ -383,6 +397,7 @@ mod tests {
         // Build a report with one skill installed for all three clients —
         // the lockfile should record it as one item, not three.
         let report = InstallReport {
+            bundles: Vec::new(),
             items: vec![
                 InstalledItem {
                     kind: ItemKind::Skill,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -55,20 +55,118 @@ pub struct InstalledItem {
 #[derive(Debug, Default, Clone)]
 pub struct InstallReport {
     pub items: Vec<InstalledItem>,
+    /// When the install resolved a bundle (entry `source` was a
+    /// `.bundle.md` file), every reached bundle in dependency order. The
+    /// last entry is the bundle the user named. Empty for non-bundle
+    /// installs.
+    pub bundles: Vec<crate::model::Bundle>,
 }
 
 const ALL_CLIENTS: [Client; 3] = [Client::Claude, Client::Copilot, Client::OpenCode];
 
 /// Install every item under `source` into `target`, generating per-client
 /// output for each client unless filtered by `metadata.audience`.
+///
+/// Bundle dispatch: when `source` is a `*.bundle.md` file (not a
+/// directory), discovers sibling bundles in the registry root walked up
+/// from the file, resolves transitively (per [`crate::bundle::resolve`]),
+/// and installs only the resolved items. The reached bundles are
+/// surfaced via [`InstallReport::bundles`] so the lockfile slice can
+/// record them.
 pub fn install_from_local_path(source: &Path, target: &Path) -> Result<InstallReport> {
+    if is_bundle_file(source) {
+        return install_bundle_file(source, target);
+    }
     let mut report = InstallReport::default();
-
-    install_skills(source, target, &mut report)?;
-    install_rules(source, target, &mut report)?;
-    install_agents(source, target, &mut report)?;
-
+    install_skills(source, target, &mut report, None)?;
+    install_rules(source, target, &mut report, None)?;
+    install_agents(source, target, &mut report, None)?;
     Ok(report)
+}
+
+fn install_bundle_file(bundle_path: &Path, target: &Path) -> Result<InstallReport> {
+    let registry_root = find_registry_root(bundle_path).with_context(|| {
+        format!(
+            "find SSOT registry root containing skills/, rules/, agents/, or bundles/ \
+             above {}",
+            bundle_path.display()
+        )
+    })?;
+
+    let entry = crate::parse::bundle::load(bundle_path)
+        .with_context(|| format!("load entry bundle {}", bundle_path.display()))?;
+
+    let available: Vec<crate::model::Bundle> = crate::parse::bundle::discover(&registry_root)
+        .with_context(|| {
+            format!(
+                "discover sibling bundles under registry root {}",
+                registry_root.display()
+            )
+        })?
+        .into_iter()
+        .map(|(_, b)| b)
+        .collect();
+
+    let resolved = crate::bundle::resolve(&entry, &available)?;
+
+    let mut report = InstallReport {
+        bundles: resolved.bundles.clone(),
+        ..InstallReport::default()
+    };
+    install_skills(&registry_root, target, &mut report, Some(&resolved.items))?;
+    install_rules(&registry_root, target, &mut report, Some(&resolved.items))?;
+    install_agents(&registry_root, target, &mut report, Some(&resolved.items))?;
+    Ok(report)
+}
+
+fn is_bundle_file(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with(crate::parse::bundle::BUNDLE_SUFFIX))
+}
+
+/// Walk up from `bundle_path`'s parent until a directory is found that
+/// contains at least one of `skills/`, `rules/`, `agents/`, `bundles/`.
+/// Falls back to the bundle's parent directory if no such ancestor
+/// exists, so a flat layout (bundle and items in the same dir) still
+/// works.
+fn find_registry_root(bundle_path: &Path) -> Result<PathBuf> {
+    let parent = bundle_path
+        .parent()
+        .ok_or_else(|| anyhow!("bundle path {} has no parent", bundle_path.display()))?;
+    let mut cursor = parent;
+    loop {
+        if has_ssot_layout(cursor) {
+            return Ok(cursor.to_path_buf());
+        }
+        match cursor.parent() {
+            Some(p) => cursor = p,
+            None => break,
+        }
+    }
+    Ok(parent.to_path_buf())
+}
+
+fn has_ssot_layout(dir: &Path) -> bool {
+    ["skills", "rules", "agents", "bundles"]
+        .iter()
+        .any(|child| dir.join(child).is_dir())
+}
+
+/// Flat list of every item name a single bundle declares (in
+/// rule/skill/agent order). Used by `install_with_lockfile` to populate
+/// `LockedBundle.items` — the per-bundle view, not the transitive
+/// closure.
+fn bundle_item_names(bundle: &crate::model::Bundle) -> Vec<String> {
+    let mut out = Vec::with_capacity(
+        bundle.items.rules.len() + bundle.items.skills.len() + bundle.items.agents.len(),
+    );
+    out.extend(bundle.items.rules.iter().cloned());
+    out.extend(bundle.items.skills.iter().cloned());
+    out.extend(bundle.items.agents.iter().cloned());
+    out
 }
 
 /// Install + write lockfile. Consumer-facing entry point.
@@ -102,6 +200,14 @@ pub fn install_with_lockfile(source: &InstallSource, target: &Path) -> Result<In
     let mut lock = crate::lockfile_v2::LockfileV2::load(target)?;
     for item in new_items {
         lock.upsert(item);
+    }
+    for bundle in &report.bundles {
+        lock.upsert_bundle(crate::lockfile_v2::LockedBundle {
+            name: bundle.name.clone(),
+            source: label.clone(),
+            git_ref: git_ref.map(str::to_string),
+            items: bundle_item_names(bundle),
+        });
     }
     lock.save(target)?;
 
@@ -739,8 +845,18 @@ pub fn install_from_git_url(
     install_from_local_path(&source, target)
 }
 
-fn install_skills(source: &Path, target: &Path, report: &mut InstallReport) -> Result<()> {
+fn install_skills(
+    source: &Path,
+    target: &Path,
+    report: &mut InstallReport,
+    filter: Option<&crate::bundle::ResolvedItems>,
+) -> Result<()> {
     for (name, dir) in iter_item_dirs(&source.join("skills"))? {
+        if let Some(items) = filter
+            && !items.contains(ItemKind::Skill, &name)
+        {
+            continue;
+        }
         let entry_path = dir.join("SKILL.md");
         if !entry_path.exists() {
             continue;
@@ -772,8 +888,18 @@ fn install_skills(source: &Path, target: &Path, report: &mut InstallReport) -> R
     Ok(())
 }
 
-fn install_rules(source: &Path, target: &Path, report: &mut InstallReport) -> Result<()> {
+fn install_rules(
+    source: &Path,
+    target: &Path,
+    report: &mut InstallReport,
+    filter: Option<&crate::bundle::ResolvedItems>,
+) -> Result<()> {
     for (name, dir) in iter_item_dirs(&source.join("rules"))? {
+        if let Some(items) = filter
+            && !items.contains(ItemKind::Rule, &name)
+        {
+            continue;
+        }
         let entry_path = dir.join("RULE.md");
         if !entry_path.exists() {
             continue;
@@ -805,8 +931,18 @@ fn install_rules(source: &Path, target: &Path, report: &mut InstallReport) -> Re
     Ok(())
 }
 
-fn install_agents(source: &Path, target: &Path, report: &mut InstallReport) -> Result<()> {
+fn install_agents(
+    source: &Path,
+    target: &Path,
+    report: &mut InstallReport,
+    filter: Option<&crate::bundle::ResolvedItems>,
+) -> Result<()> {
     for (name, dir) in iter_item_dirs(&source.join("agents"))? {
+        if let Some(items) = filter
+            && !items.contains(ItemKind::Agent, &name)
+        {
+            continue;
+        }
         let entry_path = dir.join("AGENT.md");
         if !entry_path.exists() {
             continue;

--- a/tests/cli_bundle_install.rs
+++ b/tests/cli_bundle_install.rs
@@ -1,0 +1,195 @@
+//! ATDD tests for `upskill add <bundle-file>` (bundle install path).
+//!
+//! `install_with_lockfile` detects when its source resolves to a
+//! `.bundle.md` file, walks up to the registry root, discovers sibling
+//! bundles, resolves transitively, and installs only the items the
+//! resolution names. The lockfile records the entry bundle and every
+//! transitive dependency.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+/// Stage `tests/fixtures/{rules,skills,agents,bundles}` into a fresh
+/// registry root so each test starts with a clean copy.
+fn stage_registry(root: &Path) {
+    for kind in ["skills", "rules", "agents", "bundles"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = root.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn bundle_install_writes_only_referenced_items() {
+    // `platform-baseline.bundle.md` references every fixture item, so a
+    // bundle install renders the same files as a directory install.
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    let bundle = registry.join("bundles/platform-baseline.bundle.md");
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["add", bundle.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists(),
+        "skill installed"
+    );
+    assert!(
+        target
+            .join(".github/instructions/api-conventions.instructions.md")
+            .exists(),
+        "rule installed"
+    );
+    assert!(
+        target
+            .join(".opencode/agents/security-reviewer.md")
+            .exists(),
+        "agent installed"
+    );
+}
+
+#[test]
+fn bundle_install_records_bundle_in_lockfile() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    let bundle = registry.join("bundles/platform-baseline.bundle.md");
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["add", bundle.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let raw = fs::read_to_string(target.join(".upskill-lock.json")).unwrap();
+    let lock: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+    let bundles = lock["bundles"].as_array().expect("bundles array");
+    assert_eq!(bundles.len(), 1, "one bundle resolved");
+    assert_eq!(bundles[0]["name"], "platform-baseline");
+    let items = bundles[0]["items"].as_array().expect("bundle items array");
+    assert_eq!(items.len(), 4, "1 skill + 2 rules + 1 agent");
+
+    // Item entries land in the regular per-item array too.
+    let names: Vec<&str> = lock["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"create-api-endpoint"));
+    assert!(names.contains(&"api-conventions"));
+    assert!(names.contains(&"license-awareness"));
+    assert!(names.contains(&"security-reviewer"));
+}
+
+#[test]
+fn bundle_install_resolves_transitive_requires() {
+    // `platform-extras` requires `platform-baseline`. Installing extras
+    // should record both bundles in the lockfile and install items from
+    // both bundles' union.
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    // `extras` has rule `license-awareness`; baseline has the rest.
+    // Mark them disjoint so the union is exact (no conflict).
+    // Adjust the extras fixture in-place: drop overlap with baseline.
+    let extras_path = registry.join("bundles/platform-extras.bundle.md");
+    let extras = fs::read_to_string(&extras_path).unwrap();
+    // The fixture lists `license-awareness` which overlaps with baseline.
+    // Replace with a non-overlapping rule so the resolver succeeds.
+    fs::write(
+        &extras_path,
+        extras.replace(
+            "items:\n  rules:\n    - license-awareness",
+            "items:\n  rules: []",
+        ),
+    )
+    .unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["add", extras_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let raw = fs::read_to_string(target.join(".upskill-lock.json")).unwrap();
+    let lock: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let bundles = lock["bundles"].as_array().expect("bundles array");
+    let names: Vec<&str> = bundles
+        .iter()
+        .map(|b| b["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"platform-extras") && names.contains(&"platform-baseline"),
+        "transitive bundles recorded: {names:?}"
+    );
+
+    // Items from baseline must be installed too — extras alone has no rules.
+    assert!(
+        target
+            .join(".github/instructions/api-conventions.instructions.md")
+            .exists(),
+        "baseline rule installed via transitive resolution"
+    );
+}
+
+#[test]
+fn bundle_install_errors_on_item_conflict() {
+    // The fixture's `extras` lists `license-awareness` which baseline
+    // also lists — that's a (kind=rule, name=license-awareness) conflict
+    // when extras requires baseline. Resolution must fail.
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    let extras = registry.join("bundles/platform-extras.bundle.md");
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["add", extras.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("item conflict") && stderr.contains("license-awareness"),
+        "expected item-conflict error: {stderr}"
+    );
+}

--- a/tests/pipeline_local.rs
+++ b/tests/pipeline_local.rs
@@ -229,9 +229,6 @@ fn install_respects_audience_filter() {
     let tmp = tempfile::tempdir().unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
-    let tmp = tempfile::tempdir().unwrap();
-    let source = tmp.path().join("source");
-    let target = tmp.path().join("target");
 
     let skill_dir = source.join("skills/claude-only");
     fs::create_dir_all(&skill_dir).unwrap();


### PR DESCRIPTION
## Summary

Second Phase C slice. `upskill add <bundle.md>` now walks the `requires` graph, unions items across reached bundles, and installs just those items. Per format-spec §3.7.

## New module (`src/bundle.rs`)

```rust
pub struct Resolved {
    pub bundles: Vec<Bundle>,    // post-order topological walk
    pub items:   ResolvedItems,  // (kind, name) union
}
pub struct ResolvedItems { rules, skills, agents: Vec<String> }
pub fn resolve(entry: &Bundle, available: &[Bundle]) -> Result<Resolved>;
```

DFS resolver with three-color marking — errors on:

- **missing requirement** (`requires` name not found in the registry)
- **cycle** (gray-stack hit during recursion)
- **item conflict** (same `(kind, name)` named by two reached bundles)

Diamond paths (A → B → leaf, A → C → leaf) are NOT errors — `leaf` is visited once. Same name in different kinds (`rule x` and `skill x`) is allowed.

## Pipeline wiring (`src/pipeline.rs`)

- `InstallReport.bundles: Vec<Bundle>` — empty for non-bundle installs; populated with the dependency-ordered closure when bundle resolved.
- `install_from_local_path` detects `*.bundle.md` files and dispatches to a new `install_bundle_file` path that:
  1. Walks up from the file to find the registry root (first ancestor with `skills/`, `rules/`, `agents/`, or `bundles/` as children; falls back to the bundle's parent dir for flat layouts).
  2. Discovers all bundles via `parse::bundle::discover`.
  3. Resolves transitively.
  4. Calls the same `install_skills` / `install_rules` / `install_agents` loops with an `Option<&ResolvedItems>` filter.
- `install_with_lockfile` upserts every reached bundle into `LockfileV2.bundles` with the per-bundle item list (the transitive closure flattens into `LockfileV2.items` as usual).
- `LockfileV2::upsert_bundle` added; `LockedBundle` doc updated to reflect that `items` is the per-bundle declaration, not the closure.
- `fetch::resolve_subfolder` relaxed: accepts files (the bundle path) in addition to directories. The install layer dispatches.

## Tests

- `src/bundle.rs` — 8 unit tests cover every branch (single bundle, dependency order, union, diamond, conflict, allowed cross-kind name reuse, cycle, missing requirement) without filesystem coupling.
- `tests/cli_bundle_install.rs` (new) — 4 ATDD tests:
  - `bundle_install_writes_only_referenced_items`
  - `bundle_install_records_bundle_in_lockfile`
  - `bundle_install_resolves_transitive_requires`
  - `bundle_install_errors_on_item_conflict`

## Out of scope

- Version-constraint enforcement (`Requires.version` is parsed and stored but not interpreted; the resolver matches by name and uses the first available bundle). Tracked as future work.
- `--bundle` lookup by name on the CLI (today the user passes the file path directly). Could be added on top of the source format.

## Test plan

- [x] `just verify` clean (135 unit + 51 integration).
- [ ] CI passes.
