### PR TITLE
feat(fmt): canonicalise YAML frontmatter in SSOT files

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,0 +1,283 @@
+//! `upskill fmt` — canonicalise YAML frontmatter in SSOT files.
+//!
+//! Per [ADR-0004](../../docs/adr/0004-cli-surface.md), `fmt` and `lint`
+//! are sibling author commands. `fmt` operates on YAML frontmatter
+//! only; markdown body content is dprint's job and is preserved
+//! byte-for-byte. Like `lint`, this command refuses to run inside a
+//! consumer project (`.upskill-lock.json` at the path's root).
+//!
+//! What gets canonicalised:
+//!
+//! - Key order — fixed by the [`crate::model`] struct field order
+//!   (`schema → name → description → audience → license → metadata →
+//!   kind-specific → passthroughs → extras`).
+//! - Indentation — `serde_yaml_ng`'s default emit (two-space).
+//! - Unknown top-level keys (the `extra` flatten map) come out
+//!   alphabetically — predictable, even if not the author's order.
+//!
+//! Implementation: parse the frontmatter into the typed model, then
+//! serialise it back with `serde_yaml_ng::to_string`. The body slice
+//! is reattached unchanged.
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Serialize, de::DeserializeOwned};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::lint::{discover, is_consumer_project};
+use crate::model::{Agent, Bundle, Rule, Skill};
+use crate::parse::frontmatter;
+
+/// Outcome of one `upskill fmt` run.
+#[derive(Debug, Default, Clone)]
+pub struct FmtReport {
+    /// Files whose on-disk content differed from the canonical form
+    /// and were rewritten.
+    pub files_changed: Vec<PathBuf>,
+    /// Total entrypoint files inspected.
+    pub files_checked: usize,
+}
+
+/// Canonicalise YAML frontmatter in every SSOT entrypoint discovered
+/// under `paths`. With an empty `paths` slice, defaults to the current
+/// working directory.
+///
+/// Files whose frontmatter was already canonical are left untouched
+/// (no `mtime` thrash). Body content is preserved byte-for-byte.
+pub fn fmt(paths: &[PathBuf]) -> Result<FmtReport> {
+    let owned_cwd: Vec<PathBuf>;
+    let roots: &[PathBuf] = if paths.is_empty() {
+        owned_cwd = vec![std::env::current_dir().context("get current directory")?];
+        &owned_cwd
+    } else {
+        paths
+    };
+
+    for root in roots {
+        if is_consumer_project(root) {
+            return Err(anyhow!(
+                "{}: refusing to format — `.upskill-lock.json` indicates this is a consumer \
+                 project, not a source registry. Run `upskill fmt` inside the SSOT tree instead.",
+                root.display()
+            ));
+        }
+    }
+
+    let mut report = FmtReport::default();
+    for root in roots {
+        for file in discover(root)? {
+            report.files_checked += 1;
+            if format_file(&file)? {
+                report.files_changed.push(file);
+            }
+        }
+    }
+    Ok(report)
+}
+
+/// Format one entrypoint file in place. Returns `true` if the file
+/// changed on disk.
+fn format_file(path: &Path) -> Result<bool> {
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let canonical = canonicalise(&raw, path)?;
+    if canonical == raw {
+        return Ok(false);
+    }
+    fs::write(path, &canonical).with_context(|| format!("write {}", path.display()))?;
+    Ok(true)
+}
+
+/// Produce the canonical form of `raw` for the kind inferred from
+/// `path`'s filename. Pure function — no I/O, no mutation.
+fn canonicalise(raw: &str, path: &Path) -> Result<String> {
+    let kind = file_kind(path)
+        .ok_or_else(|| anyhow!("{}: unknown entrypoint filename", path.display()))?;
+
+    let body = frontmatter::split(raw)
+        .map(|(_, body)| body)
+        .ok_or_else(|| anyhow!("{}: missing YAML frontmatter", path.display()))?;
+
+    let yaml = match kind {
+        EntryKind::Skill => roundtrip::<Skill>(raw)?,
+        EntryKind::Rule => roundtrip::<Rule>(raw)?,
+        EntryKind::Agent => roundtrip::<Agent>(raw)?,
+        EntryKind::Bundle => roundtrip::<Bundle>(raw)?,
+    };
+
+    Ok(format!("---\n{yaml}---\n{body}"))
+}
+
+/// Parse `raw`'s frontmatter into `T`, then serialise `T` back to
+/// YAML. `serde_yaml_ng::to_string` already terminates the output with
+/// a trailing newline — no extra padding needed.
+fn roundtrip<T: DeserializeOwned + Serialize>(raw: &str) -> Result<String> {
+    let (value, _body) =
+        frontmatter::parse::<T>(raw).with_context(|| "parsing frontmatter for fmt")?;
+    serde_yaml_ng::to_string(&value).context("serialise canonical frontmatter")
+}
+
+#[derive(Debug, Clone, Copy)]
+enum EntryKind {
+    Skill,
+    Rule,
+    Agent,
+    Bundle,
+}
+
+fn file_kind(path: &Path) -> Option<EntryKind> {
+    match path.file_name().and_then(|n| n.to_str())? {
+        "SKILL.md" => Some(EntryKind::Skill),
+        "RULE.md" => Some(EntryKind::Rule),
+        "AGENT.md" => Some(EntryKind::Agent),
+        n if n.ends_with(crate::parse::bundle::BUNDLE_SUFFIX) => Some(EntryKind::Bundle),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn canonicalise_reorders_keys() {
+        let raw = concat!(
+            "---\n",
+            "name: scrambled\n",
+            "schema: 1\n",
+            "description: shuffled keys.\n",
+            "license: proprietary\n",
+            "---\n",
+            "## body\n",
+        );
+        let out = canonicalise(raw, Path::new("skills/scrambled/SKILL.md")).unwrap();
+        let yaml = &out[4..out[4..].find("\n---\n").unwrap() + 4];
+        let s = yaml.find("schema:").unwrap();
+        let n = yaml.find("name:").unwrap();
+        let d = yaml.find("description:").unwrap();
+        let l = yaml.find("license:").unwrap();
+        assert!(s < n && n < d && d < l, "wrong order:\n{yaml}");
+    }
+
+    #[test]
+    fn canonicalise_preserves_body_byte_for_byte() {
+        let body = concat!(
+            "\n",
+            "## A heading\n",
+            "\n",
+            "```rust\n",
+            "fn x() {}\n",
+            "```\n",
+            "\n",
+            "<!-- a comment -->\n",
+        );
+        let raw =
+            format!("---\nschema: 1\nname: preserve\ndescription: do not touch body.\n---\n{body}");
+        let out = canonicalise(&raw, Path::new("skills/preserve/SKILL.md")).unwrap();
+        assert!(out.ends_with(body), "body changed:\n{out}");
+    }
+
+    #[test]
+    fn canonicalise_is_idempotent() {
+        let raw = concat!(
+            "---\n",
+            "name: out\n",
+            "schema: 1\n",
+            "description: shuffled.\n",
+            "---\n",
+            "## body\n",
+        );
+        let path = Path::new("skills/out/SKILL.md");
+        let pass1 = canonicalise(raw, path).unwrap();
+        let pass2 = canonicalise(&pass1, path).unwrap();
+        assert_eq!(pass1, pass2, "fmt must be idempotent");
+    }
+
+    #[test]
+    fn fmt_skips_already_canonical_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("skills/clean/SKILL.md");
+        let canonical = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: clean\n",
+            "description: already canonical.\n",
+            "---\n",
+            "## body\n",
+        );
+        write(&item, canonical);
+        let mtime_before = fs::metadata(&item).unwrap().modified().unwrap();
+
+        let report = fmt(&[tmp.path().to_path_buf()]).unwrap();
+        assert!(report.files_changed.is_empty(), "{report:?}");
+
+        let mtime_after = fs::metadata(&item).unwrap().modified().unwrap();
+        assert_eq!(mtime_before, mtime_after, "mtime should not change");
+    }
+
+    #[test]
+    fn fmt_refuses_consumer_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join(".upskill-lock.json"),
+            r#"{"schema":2,"items":[]}"#,
+        )
+        .unwrap();
+        let err = fmt(&[tmp.path().to_path_buf()]).expect_err("must refuse");
+        assert!(format!("{err:#}").contains("consumer project"));
+    }
+
+    #[test]
+    fn fmt_handles_rule_with_scope() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("rules/api/RULE.md");
+        write(
+            &item,
+            concat!(
+                "---\n",
+                "name: api\n",
+                "schema: 1\n",
+                "description: rule with scope.\n",
+                "scope:\n",
+                "  paths:\n",
+                "    - \"src/**/*.ts\"\n",
+                "---\n",
+                "## body\n",
+            ),
+        );
+        let report = fmt(&[tmp.path().to_path_buf()]).unwrap();
+        assert_eq!(report.files_changed, vec![item.clone()]);
+        let after = fs::read_to_string(&item).unwrap();
+        // scope must survive the round-trip.
+        assert!(after.contains("src/**/*.ts"), "scope.paths lost:\n{after}");
+    }
+
+    #[test]
+    fn fmt_handles_bundle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("bundles/baseline.bundle.md");
+        write(
+            &item,
+            concat!(
+                "---\n",
+                "name: baseline\n",
+                "schema: 1\n",
+                "description: a bundle.\n",
+                "items:\n",
+                "  rules: [api]\n",
+                "---\n",
+                "## body\n",
+            ),
+        );
+        let report = fmt(&[tmp.path().to_path_buf()]).unwrap();
+        assert_eq!(report.files_changed.len(), 1);
+        let after = fs::read_to_string(&item).unwrap();
+        assert!(after.contains("- api"), "items.rules lost:\n{after}");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod ancillary;
 pub mod auth;
 pub mod bundle;
 pub mod fetch;
+pub mod fmt;
 pub mod generate;
 pub mod lint;
 pub mod lockfile_v2;

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -121,8 +121,9 @@ pub fn lint(paths: &[PathBuf], strict: bool) -> Result<LintReport> {
 }
 
 /// True when `root/.upskill-lock.json` (or `root` itself, if it is a
-/// file in such a directory) exists.
-fn is_consumer_project(root: &Path) -> bool {
+/// file in such a directory) exists. Shared with `crate::fmt` so both
+/// author commands refuse running inside consumer projects.
+pub(crate) fn is_consumer_project(root: &Path) -> bool {
     let dir = if root.is_dir() {
         root.to_path_buf()
     } else if let Some(parent) = root.parent() {
@@ -158,8 +159,8 @@ impl FileKind {
 /// Walk `root` (file or directory) and return every entrypoint file
 /// the lint should inspect. SSOT items are detected by the
 /// `<kind>s/<name>/<KIND>.md` layout per format-spec §2.1; bundles by
-/// the `*.bundle.md` suffix.
-fn discover(root: &Path) -> Result<Vec<PathBuf>> {
+/// the `*.bundle.md` suffix. Shared with `crate::fmt`.
+pub(crate) fn discover(root: &Path) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
     if root.is_file() {
         if let Some(name) = root.file_name().and_then(|n| n.to_str())

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand, error::ErrorKind};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use upskill::fmt::{FmtReport, fmt};
 use upskill::lint::{LintReport, lint};
 use upskill::pipeline::{
     DoctorReport, InstallReport, ItemKind, ListReport, ListedBundle, ListedItem, OrphanReason,
@@ -124,6 +125,16 @@ enum Commands {
         #[arg(long)]
         strict: bool,
     },
+    /// Canonicalise YAML frontmatter in SSOT files.
+    ///
+    /// Author command — runs only inside a source registry. Body
+    /// markdown is left untouched (dprint's job). Refuses to run inside
+    /// a consumer project (detected by `.upskill-lock.json`). With no
+    /// paths, formats the current directory.
+    Fmt {
+        /// Files or directories to format. Empty = current directory.
+        paths: Vec<PathBuf>,
+    },
 }
 
 fn main() {
@@ -157,6 +168,7 @@ fn main() {
         Commands::Doctor { global } => run_doctor(global),
         Commands::Search { query, limit } => run_search(&query, limit),
         Commands::Lint { paths, strict } => run_lint(&paths, strict),
+        Commands::Fmt { paths } => run_fmt(&paths),
     };
 
     if was_interrupted() {
@@ -549,6 +561,34 @@ fn print_lint_report(report: &LintReport) {
         "{} file(s) checked, {} findings",
         report.files_checked,
         report.findings.len()
+    );
+}
+
+fn run_fmt(paths: &[PathBuf]) -> i32 {
+    match fmt(paths) {
+        Ok(report) => {
+            print_fmt_report(&report);
+            EXIT_SUCCESS
+        }
+        Err(err) => {
+            eprintln!("error: {:#}", err);
+            EXIT_USAGE
+        }
+    }
+}
+
+fn print_fmt_report(report: &FmtReport) {
+    if report.files_changed.is_empty() {
+        println!("{} file(s) checked, all formatted", report.files_checked);
+        return;
+    }
+    for path in &report.files_changed {
+        println!("formatted: {}", path.display());
+    }
+    println!(
+        "{} file(s) checked, {} file(s) changed",
+        report.files_checked,
+        report.files_changed.len()
     );
 }
 

--- a/tests/cli_fmt.rs
+++ b/tests/cli_fmt.rs
@@ -1,0 +1,203 @@
+//! ATDD tests for `upskill fmt`.
+//!
+//! Canonicalises YAML frontmatter in place. Body content is dprint's job;
+//! this command does not touch it. Author command — refuses to run inside
+//! a consumer project (`.upskill-lock.json` at the path's root) per
+//! ADR-0004.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn fmt_reorders_frontmatter_keys_canonically() {
+    let tmp = tempfile::tempdir().unwrap();
+    let item = tmp.path().join("skills/scrambled/SKILL.md");
+    // Canonical order is schema → name → description → audience → license →
+    // metadata. Author wrote them in the wrong order.
+    write(
+        &item,
+        concat!(
+            "---\n",
+            "name: scrambled\n",
+            "license: proprietary\n",
+            "schema: 1\n",
+            "description: A skill written with shuffled keys.\n",
+            "metadata:\n",
+            "  version: \"1.0.0\"\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "Untouched.\n",
+        ),
+    );
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .success();
+
+    let after = fs::read_to_string(&item).unwrap();
+    let yaml_end = after[4..].find("---").expect("frontmatter still ends");
+    let yaml = &after[4..4 + yaml_end];
+    let schema = yaml.find("schema:").unwrap();
+    let name = yaml.find("name:").unwrap();
+    let description = yaml.find("description:").unwrap();
+    let license = yaml.find("license:").unwrap();
+    let metadata = yaml.find("metadata:").unwrap();
+    assert!(
+        schema < name && name < description && description < license && license < metadata,
+        "keys not in canonical order:\n{yaml}"
+    );
+
+    // Body must be byte-for-byte preserved.
+    assert!(after.contains("\n\n## Body\n\nUntouched.\n"), "{after}");
+}
+
+#[test]
+fn fmt_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let item = tmp.path().join("skills/already-canonical/SKILL.md");
+    write(
+        &item,
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: already-canonical\n",
+            "description: Already in canonical key order.\n",
+            "license: proprietary\n",
+            "metadata:\n",
+            "  version: \"1.0.0\"\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+        ),
+    );
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .success();
+    let pass1 = fs::read_to_string(&item).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .success();
+    let pass2 = fs::read_to_string(&item).unwrap();
+
+    assert_eq!(pass1, pass2, "fmt must be idempotent");
+}
+
+#[test]
+fn fmt_does_not_touch_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let item = tmp.path().join("skills/preserve-body/SKILL.md");
+    let body = concat!(
+        "\n",
+        "## A heading\n",
+        "\n",
+        "Some prose with *italic* and **bold**.\n",
+        "\n",
+        "```rust\n",
+        "fn main() {}\n",
+        "```\n",
+        "\n",
+        "<!-- a comment -->\n",
+    );
+    write(
+        &item,
+        &format!(
+            "---\nschema: 1\nname: preserve-body\ndescription: Body must be preserved verbatim.\n---\n{body}"
+        ),
+    );
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .success();
+
+    let after = fs::read_to_string(&item).unwrap();
+    assert!(
+        after.ends_with(body),
+        "body changed:\n{after}\n\nexpected suffix:\n{body}"
+    );
+}
+
+#[test]
+fn fmt_refuses_to_run_inside_consumer_project() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(
+        tmp.path().join(".upskill-lock.json"),
+        r#"{"schema":2,"items":[]}"#,
+    )
+    .unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .failure()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("consumer project") || stderr.contains(".upskill-lock.json"),
+        "expected refusal: {stderr}"
+    );
+}
+
+#[test]
+fn fmt_reports_files_changed_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        &tmp.path().join("skills/needs-fmt/SKILL.md"),
+        concat!(
+            "---\n",
+            "name: needs-fmt\n",
+            "schema: 1\n",
+            "description: Out-of-order frontmatter.\n",
+            "---\n",
+            "## body\n",
+        ),
+    );
+    write(
+        &tmp.path().join("skills/clean/SKILL.md"),
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: clean\n",
+            "description: Already canonical.\n",
+            "---\n",
+            "## body\n",
+        ),
+    );
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("1 file") && out.contains("changed"),
+        "expected change count: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase D, slice D1b. Implements `upskill fmt` per
[ADR-0004](docs/adr/0004-cli-surface.md). Author command — sibling to
`upskill lint`, runs only inside a source-registry tree, refuses to
run inside a consumer project (`.upskill-lock.json` at the path's
root).

```text
upskill fmt [paths...]
```

With no paths, formats the current directory.

## What gets canonicalised

- **Key order** — fixed by the model struct field order:
  `schema → name → description → audience → license → metadata →
  kind-specific → passthroughs → extras`. The plan called this out as
  the canonical sequence; the model already encodes it.
- **Indentation** — `serde_yaml_ng`'s default emit (two-space).
- **Unknown top-level keys** — the `extra` flatten map iterates
  alphabetically, so they come out in a predictable order even if not
  the author's.
- **Body** — byte-for-byte preserved. Markdown-body formatting is
  dprint's job; the two tools deliberately don't overlap.

Files whose frontmatter already round-trips equal to itself are left
untouched (no `mtime` thrash).

## Library surface

```rust
pub fn fmt(paths: &[PathBuf]) -> Result<FmtReport>;

pub struct FmtReport {
    pub files_changed: Vec<PathBuf>,
    pub files_checked: usize,
}
```

## Sharing with `lint`

`lint::discover` and `lint::is_consumer_project` are promoted to
`pub(crate)` and re-used here. The two-line visibility bump avoids
duplicating the SSOT walk and the consumer-project guard.

## Out of scope

- `--check` / `--write` flag split. The plan calls for a single
  in-place mode; CI can use `git diff --exit-code` after `upskill fmt`.
- Markdown body formatting (dprint owns that).
- Forcing version-string quoting beyond what `serde_yaml_ng` already
  emits. `"1.0.0"` round-trips as a quoted string in practice;
  scenarios where the YAML emitter would lose quotes need a separate
  rule and aren't blocking v0.2.0.

## Tests

- `src/fmt.rs` — 7 unit tests covering reorder, body preservation,
  idempotence, mtime stability for canonical files, consumer-project
  refusal, rule-scope round-trip, bundle round-trip.
- `tests/cli_fmt.rs` — 5 integration tests driving the CLI end-to-end.

## Test plan

- [x] `just verify` clean.
- [ ] CI passes.
