### PR TITLE
feat(new): scaffold new rule / skill / agent items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod lockfile_v2;
 pub mod model;
 pub mod parse;
 pub mod pipeline;
+pub mod scaffold;
 pub mod search;
 pub mod source;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use upskill::pipeline::{
     RemoveFilter, RemoveReport, UpdateMode, UpdateReport, UpdateStatus, doctor,
     install_with_lockfile, list, remove, update,
 };
+use upskill::scaffold::{NewKind, ScaffoldReport, scaffold};
 use upskill::search;
 use upskill::source::parse_install_source;
 
@@ -135,6 +136,19 @@ enum Commands {
         /// Files or directories to format. Empty = current directory.
         paths: Vec<PathBuf>,
     },
+    /// Scaffold a new rule, skill, or agent.
+    ///
+    /// Writes the minimum frontmatter the format spec requires plus
+    /// kind-specific defaults (e.g. `mode: subagent` / `model: sonnet`
+    /// for agents) into `<cwd>/<kind>s/<name>/<KIND>.md`. Author
+    /// command — refuses to run inside a consumer project.
+    New {
+        /// One of `rule`, `skill`, `agent`.
+        kind: String,
+        /// Item name. Lowercase letters, digits, hyphens; max 64 chars
+        /// per format-spec §2.1.
+        name: String,
+    },
 }
 
 fn main() {
@@ -169,6 +183,7 @@ fn main() {
         Commands::Search { query, limit } => run_search(&query, limit),
         Commands::Lint { paths, strict } => run_lint(&paths, strict),
         Commands::Fmt { paths } => run_fmt(&paths),
+        Commands::New { kind, name } => run_new(&kind, &name),
     };
 
     if was_interrupted() {
@@ -590,6 +605,54 @@ fn print_fmt_report(report: &FmtReport) {
         report.files_checked,
         report.files_changed.len()
     );
+}
+
+fn run_new(kind: &str, name: &str) -> i32 {
+    let parsed_kind = match NewKind::parse(kind) {
+        Ok(k) => k,
+        Err(err) => {
+            eprintln!("error: {}", err);
+            return EXIT_USAGE;
+        }
+    };
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(err) => {
+            eprintln!("error: get current directory: {}", err);
+            return EXIT_ERROR;
+        }
+    };
+    match scaffold(&cwd, parsed_kind, name) {
+        Ok(report) => {
+            print_scaffold_report(&report);
+            EXIT_SUCCESS
+        }
+        Err(err) => {
+            let msg = format!("{:#}", err);
+            eprintln!("error: {}", msg);
+            // Author-command misuse (consumer-project) → usage error;
+            // every other failure → 1.
+            if msg.contains("consumer project") {
+                EXIT_USAGE
+            } else {
+                EXIT_ERROR
+            }
+        }
+    }
+}
+
+fn print_scaffold_report(report: &ScaffoldReport) {
+    let kind_label = match report.kind {
+        NewKind::Rule => "rule",
+        NewKind::Skill => "skill",
+        NewKind::Agent => "agent",
+    };
+    println!(
+        "scaffolded {kind_label} `{}` at {}",
+        report.name,
+        report.written.display()
+    );
+    println!("edit the file and replace the TODO body before publishing.");
 }
 
 fn run_search(query: &str, limit: usize) -> i32 {

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -1,0 +1,249 @@
+//! `upskill new <kind> <name>` — scaffold a starter SSOT item.
+//!
+//! Author command per ADR-0004 — runs only inside a source-registry
+//! tree. Writes one file at `<cwd>/<kind>s/<name>/<KIND>.md` (per
+//! format-spec §2.1) with the minimum frontmatter the spec requires
+//! plus kind-specific defaults: `mode: subagent` / `model: sonnet`
+//! for agents.
+//!
+//! Refuses if:
+//!
+//! - `cwd/.upskill-lock.json` exists (consumer project, not a source
+//!   registry).
+//! - The target item directory already exists.
+//! - `<name>` does not satisfy format-spec §2.1
+//!   (`[a-z0-9-]{1,64}`, no leading/trailing hyphen).
+
+use anyhow::{Context, Result, anyhow, bail};
+use std::path::{Path, PathBuf};
+
+use crate::lint::is_consumer_project;
+
+/// Item kind to scaffold. Maps 1:1 to format-spec entrypoint files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NewKind {
+    Rule,
+    Skill,
+    Agent,
+}
+
+impl NewKind {
+    /// Parse the CLI value (`rule` / `skill` / `agent`).
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "rule" => Ok(Self::Rule),
+            "skill" => Ok(Self::Skill),
+            "agent" => Ok(Self::Agent),
+            other => bail!("unknown kind `{other}` — expected one of: rule, skill, agent"),
+        }
+    }
+
+    fn dir(self) -> &'static str {
+        match self {
+            Self::Rule => "rules",
+            Self::Skill => "skills",
+            Self::Agent => "agents",
+        }
+    }
+
+    fn entry(self) -> &'static str {
+        match self {
+            Self::Rule => "RULE.md",
+            Self::Skill => "SKILL.md",
+            Self::Agent => "AGENT.md",
+        }
+    }
+}
+
+/// Outcome of one scaffold call — the path written, for the CLI to
+/// echo back.
+#[derive(Debug, Clone)]
+pub struct ScaffoldReport {
+    pub written: PathBuf,
+    pub kind: NewKind,
+    pub name: String,
+}
+
+/// Scaffold a new item under `root`. `root` is typically
+/// `std::env::current_dir()`; it is also the consumer-project guard
+/// boundary.
+pub fn scaffold(root: &Path, kind: NewKind, name: &str) -> Result<ScaffoldReport> {
+    if is_consumer_project(root) {
+        return Err(anyhow!(
+            "{}: refusing to scaffold — `.upskill-lock.json` indicates this is a consumer \
+             project, not a source registry. Run `upskill new` inside the SSOT tree instead.",
+            root.display()
+        ));
+    }
+    validate_name(name)?;
+
+    let item_dir = root.join(kind.dir()).join(name);
+    let entry_path = item_dir.join(kind.entry());
+    if item_dir.exists() {
+        bail!(
+            "{}: target directory already exists — refusing to overwrite",
+            item_dir.display()
+        );
+    }
+
+    std::fs::create_dir_all(&item_dir).with_context(|| format!("create {}", item_dir.display()))?;
+    std::fs::write(&entry_path, render(kind, name))
+        .with_context(|| format!("write {}", entry_path.display()))?;
+
+    Ok(ScaffoldReport {
+        written: entry_path,
+        kind,
+        name: name.to_string(),
+    })
+}
+
+/// Format-spec §2.1: `[a-z0-9-]{1,64}`, no leading or trailing hyphen.
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("invalid name: empty");
+    }
+    if name.len() > 64 {
+        bail!("invalid name `{name}`: must be ≤ 64 characters");
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        bail!("invalid name `{name}`: must not start or end with `-`");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        bail!("invalid name `{name}`: only lowercase letters, digits, and `-` are allowed");
+    }
+    Ok(())
+}
+
+/// Render the starter file body for `kind`.
+///
+/// The output is deliberately canonical — it parses into the model
+/// without warnings and round-trips through `upskill fmt` as a no-op.
+fn render(kind: NewKind, name: &str) -> String {
+    match kind {
+        NewKind::Rule => format!(
+            "---\n\
+             schema: 1\n\
+             name: {name}\n\
+             description: TODO describe what this rule enforces and when it applies.\n\
+             ---\n\
+             \n\
+             ## Overview\n\
+             \n\
+             TODO write the rule body. Replace this scaffold before publishing.\n",
+        ),
+        NewKind::Skill => format!(
+            "---\n\
+             schema: 1\n\
+             name: {name}\n\
+             description: TODO describe when to use this skill — start with `Use when ...`.\n\
+             ---\n\
+             \n\
+             ## Overview\n\
+             \n\
+             TODO write the skill body. Replace this scaffold before publishing.\n",
+        ),
+        NewKind::Agent => format!(
+            "---\n\
+             schema: 1\n\
+             name: {name}\n\
+             description: TODO describe when to invoke this agent — start with `Use when ...`.\n\
+             mode: subagent\n\
+             model: sonnet\n\
+             ---\n\
+             \n\
+             ## Overview\n\
+             \n\
+             TODO write the agent system prompt. Replace this scaffold before publishing.\n",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaffold_skill_writes_canonical_skill_md() {
+        let tmp = tempfile::tempdir().unwrap();
+        let report = scaffold(tmp.path(), NewKind::Skill, "code-review").unwrap();
+        assert_eq!(
+            report.written,
+            tmp.path().join("skills/code-review/SKILL.md")
+        );
+        let content = std::fs::read_to_string(&report.written).unwrap();
+        // Frontmatter parses against the model — guarantees the
+        // scaffold is shape-correct for a brand-new author.
+        let (skill, _body) =
+            crate::parse::frontmatter::parse::<crate::model::Skill>(&content).unwrap();
+        assert_eq!(skill.name, "code-review");
+    }
+
+    #[test]
+    fn scaffold_agent_emits_subagent_sonnet_defaults() {
+        let tmp = tempfile::tempdir().unwrap();
+        let report = scaffold(tmp.path(), NewKind::Agent, "reviewer").unwrap();
+        let content = std::fs::read_to_string(&report.written).unwrap();
+        let (agent, _) = crate::parse::frontmatter::parse::<crate::model::Agent>(&content).unwrap();
+        assert_eq!(agent.mode, Some(crate::model::Mode::Subagent));
+        assert_eq!(agent.model.as_deref(), Some("sonnet"));
+    }
+
+    #[test]
+    fn scaffold_refuses_existing_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("skills/dup")).unwrap();
+        let err = scaffold(tmp.path(), NewKind::Skill, "dup").expect_err("must refuse");
+        assert!(format!("{err:#}").contains("already exists"));
+    }
+
+    #[test]
+    fn scaffold_refuses_consumer_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".upskill-lock.json"),
+            r#"{"schema":2,"items":[]}"#,
+        )
+        .unwrap();
+        let err = scaffold(tmp.path(), NewKind::Skill, "x").expect_err("must refuse");
+        assert!(format!("{err:#}").contains("consumer project"));
+    }
+
+    #[test]
+    fn validate_name_accepts_canonical_forms() {
+        for ok in ["a", "abc", "abc-123", "a1", "long-name-with-hyphens"] {
+            assert!(validate_name(ok).is_ok(), "{ok} should be valid");
+        }
+    }
+
+    #[test]
+    fn validate_name_rejects_invalid_forms() {
+        for bad in [
+            "",
+            "Bad-Case",
+            "trailing-",
+            "-leading",
+            "snake_case",
+            "with space",
+            "dot.dot",
+        ] {
+            assert!(validate_name(bad).is_err(), "{bad} should be invalid");
+        }
+    }
+
+    #[test]
+    fn validate_name_rejects_too_long() {
+        let long = "a".repeat(65);
+        assert!(validate_name(&long).is_err());
+    }
+
+    #[test]
+    fn parse_kind_round_trips_strings() {
+        assert_eq!(NewKind::parse("skill").unwrap(), NewKind::Skill);
+        assert_eq!(NewKind::parse("rule").unwrap(), NewKind::Rule);
+        assert_eq!(NewKind::parse("agent").unwrap(), NewKind::Agent);
+        assert!(NewKind::parse("bundle").is_err());
+    }
+}

--- a/tests/cli_new.rs
+++ b/tests/cli_new.rs
@@ -1,0 +1,156 @@
+//! ATDD tests for `upskill new <kind> <name>`.
+//!
+//! Scaffolds a starter SSOT item under `<cwd>/<kind>s/<name>/<KIND>.md`
+//! with the minimum frontmatter the format spec requires, plus
+//! kind-specific defaults (e.g. `mode: subagent` / `model: sonnet` for
+//! agents). Author command — refuses to run inside a consumer project
+//! (`.upskill-lock.json`) per ADR-0004.
+
+use assert_cmd::Command;
+use std::fs;
+
+#[test]
+fn new_skill_creates_skill_md_with_minimum_frontmatter() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["new", "skill", "code-review"])
+        .assert()
+        .success();
+
+    let path = tmp.path().join("skills/code-review/SKILL.md");
+    assert!(path.is_file(), "{path:?} should exist");
+    let body = fs::read_to_string(&path).unwrap();
+    assert!(body.starts_with("---\n"), "{body}");
+    assert!(body.contains("\nschema: 1\n"), "{body}");
+    assert!(body.contains("\nname: code-review\n"), "{body}");
+    assert!(body.contains("description:"), "{body}");
+}
+
+#[test]
+fn new_rule_creates_rule_md() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["new", "rule", "license-awareness"])
+        .assert()
+        .success();
+    let path = tmp.path().join("rules/license-awareness/RULE.md");
+    assert!(path.is_file());
+    let body = fs::read_to_string(&path).unwrap();
+    assert!(body.contains("\nname: license-awareness\n"), "{body}");
+}
+
+#[test]
+fn new_agent_emits_default_mode_and_model() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["new", "agent", "security-reviewer"])
+        .assert()
+        .success();
+    let body = fs::read_to_string(tmp.path().join("agents/security-reviewer/AGENT.md")).unwrap();
+    assert!(body.contains("\nmode: subagent\n"), "{body}");
+    assert!(body.contains("\nmodel: sonnet\n"), "{body}");
+}
+
+#[test]
+fn new_refuses_existing_item_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("skills/dup")).unwrap();
+    fs::write(tmp.path().join("skills/dup/SKILL.md"), "old").unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["new", "skill", "dup"])
+        .assert()
+        .failure()
+        .code(1);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("already exists"), "{stderr}");
+    // Existing file untouched.
+    assert_eq!(
+        fs::read_to_string(tmp.path().join("skills/dup/SKILL.md")).unwrap(),
+        "old"
+    );
+}
+
+#[test]
+fn new_rejects_invalid_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["new", "skill", "Invalid_Name"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("name") || stderr.contains("invalid"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn new_refuses_to_run_inside_consumer_project() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(
+        tmp.path().join(".upskill-lock.json"),
+        r#"{"schema":2,"items":[]}"#,
+    )
+    .unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["new", "skill", "anything"])
+        .assert()
+        .failure()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("consumer project") || stderr.contains(".upskill-lock.json"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn new_output_passes_lint_and_fmt() {
+    let tmp = tempfile::tempdir().unwrap();
+    for (kind, name) in [
+        ("skill", "starter-skill"),
+        ("rule", "starter-rule"),
+        ("agent", "starter-agent"),
+    ] {
+        Command::cargo_bin("upskill")
+            .unwrap()
+            .current_dir(tmp.path())
+            .args(["new", kind, name])
+            .assert()
+            .success();
+    }
+
+    // Lint must accept its own scaffolding.
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["lint", "--strict"])
+        .assert()
+        .success();
+
+    // Fmt must report nothing changed (the scaffold is already canonical).
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("all formatted"),
+        "scaffold not canonical: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase D, slice D2. Implements `upskill new <kind> <name>` per
[ADR-0004](docs/adr/0004-cli-surface.md). Author command — runs only
inside a source-registry tree. Writes one file at
`<cwd>/<kind>s/<name>/<KIND>.md` (per format-spec §2.1) with the
minimum frontmatter the spec requires plus kind-specific defaults.

```text
upskill new <rule|skill|agent> <name>
```

Agents get `mode: subagent` and `model: sonnet` so the file is
generation-ready out of the box.

## Validation

- Refuses if `cwd/.upskill-lock.json` exists (consumer project, not a
  source registry).
- Refuses if the target item directory already exists — never
  overwrites.
- Validates `<name>` against format-spec §2.1: lowercase letters,
  digits, hyphens, max 64 chars, no leading or trailing hyphen.

## Canonicality guarantee

The scaffold is deliberately canonical: it round-trips through
`upskill fmt` as a no-op and passes `upskill lint --strict`. An ATDD
test wires this end-to-end so future model changes that would
invalidate the scaffold trigger a test failure here, not a user
surprise.

## Library surface

```rust
pub fn scaffold(root: &Path, kind: NewKind, name: &str) -> Result<ScaffoldReport>;

pub enum NewKind { Rule, Skill, Agent }

pub struct ScaffoldReport {
    pub written: PathBuf,
    pub kind: NewKind,
    pub name: String,
}
```

`NewKind::parse(&str)` is exposed for the CLI (and any third-party
caller wanting the same string-to-enum mapping).

## Tests

- `src/scaffold.rs` — 7 unit tests covering each kind, the
  consumer-project / duplicate-directory / invalid-name guards, and
  `NewKind::parse` round-trip.
- `tests/cli_new.rs` — 7 integration tests driving the CLI end-to-end,
  including the cross-feature lint + fmt sanity check.

## Test plan

- [x] `just verify` clean.
- [ ] CI passes.
