### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,8 @@ upskill is a Rust CLI for authoring and distributing AI-assistance content
 Copilot, opencode) from a single source of truth. The central abstraction is
 **generation** — SSOT in, per-client output out.
 
-**v0.2 redesign in progress.** The shipped binary (`v0.1.x`, on `main`) is a
-skills-installer with the old fetch-and-copy model. The current branch
-(`v0.2-redesign`) is rebuilding around the SSOT-to-client pipeline. See
+**v0.2.0 shipped.** The redesign around the SSOT-to-client generation
+pipeline is complete and released. See
 [ADR-0001](docs/adr/0001-multi-kind-compiler-architecture.md) for the
 umbrella decision and the rest of `docs/adr/` for concern-specific design.
 
@@ -61,14 +60,14 @@ Primary crate:
 
 ### Module layout
 
-```
+```text
 src/
 ├── main.rs              CLI entry point, clap derive, command dispatch
 ├── lib.rs               Module declarations and re-exports
 │
-├── model/               SSOT data model (Phase 0): Rule, Skill, Agent + common
-├── parse/               SSOT parsing (Phase 0): YAML frontmatter
-├── generate/            SSOT → per-client rendering (Phase 1–2):
+├── model/               SSOT data model: Rule, Skill, Agent, Bundle + common
+├── parse/               SSOT parsing: YAML frontmatter + bundle loader/discovery
+├── generate/            SSOT → per-client rendering:
 │                        Client enum + claude/copilot/opencode + directives + dprint
 │
 ├── source.rs            Source URL parsing and classification (typed errors)
@@ -77,7 +76,12 @@ src/
 ├── search.rs            skills.sh API search
 │
 ├── pipeline.rs          Local + git → per-client install pipeline,
-│                        token-injected clone URLs, SSOT hashing
+│                        token-injected clone URLs, SSOT hashing,
+│                        list / remove / update / doctor over the lockfile
+├── bundle.rs            Bundle dependency resolution
+├── lint.rs              Author command — validate SSOT against the format spec
+├── fmt.rs               Author command — canonicalise YAML frontmatter
+├── scaffold.rs          Author command — `upskill new <kind> <name>`
 ├── ancillary.rs         CLAUDE.md / opencode.json / .vscode/settings.json
 │                        first-time hand-shake files
 └── lockfile_v2.rs       .upskill-lock.json (`schema: 2`) read/write
@@ -107,19 +111,13 @@ Core docs (published as mdBook at <https://driftsys.github.io/upskill/>):
 
 ### Install layout
 
-**v0.1 (shipped on `main`).** Skills install to `.agents/skills/` (project)
-or `~/.agents/skills/` (global) with per-agent symlinks. State in
-`.upskill-lock.json`. v0.1 lives only on the `main` branch now — its
-modules and tests have been removed from `v0.2-redesign`.
-
-**v0.2 (this branch).** Per-item generated output, copy only (no
-symlinks). State split between `.upskill-lock.json` (per-project,
-committed, schema-versioned) and `~/.upskill/installed.json` (per-user).
-The lockfile filename is unchanged from v0.1; v0.2 bumps a `schema:`
-field and rewrites in place on first invocation. Per-client output paths
-and ancillary files (`CLAUDE.md`, `.vscode/settings.json`,
-`opencode.json`) are specified in
-[ADR-0003](docs/adr/0003-generation-pipeline.md) and
+Per-item generated output, copy only (no symlinks). State split between
+`.upskill-lock.json` (per-project, committed, schema-versioned) and
+`~/.upskill/installed.json` (per-user). v0.1 lockfiles are migrated in
+place on first invocation — the filename is unchanged, the new file
+gains a `schema: 2` field. Per-client output paths and ancillary files
+(`CLAUDE.md`, `.vscode/settings.json`, `opencode.json`) are specified
+in [ADR-0003](docs/adr/0003-generation-pipeline.md) and
 [format-spec §7](docs/format-spec.md).
 
 ### Source format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "upskill"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "upskill"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
-description = "Upskill your coding agents — ultra-lightweight agent skills package manager"
+description = "Author and distribute AI-assistance content across coding agents"
 license = "MIT"
 repository = "https://github.com/driftsys/upskill"
 homepage = "https://driftsys.github.io/upskill/"

--- a/README.md
+++ b/README.md
@@ -10,27 +10,70 @@ A single Rust binary for authoring and distributing AI-assistance content
 
 No Node.js. No npm. No runtime dependencies.
 
+## Install (consumer)
+
 ```bash
 cargo install upskill
 
-upskill add owner/repo               # install everything from a source repo
-upskill update                       # pull latest, regenerate per-client files
-upskill list                         # see what's installed
+# Install everything from a source repo (auto-fans out to .claude/, .github/, .agents/)
+upskill add driftsys/skills
+
+# Or install a curated bundle — one entry, dependency-resolved
+upskill add driftsys/bundles:platform-baseline.bundle.md
+
+# Pull latest and regenerate
+upskill update
+
+# Inspect installed state
+upskill list
+upskill doctor
 ```
 
-## Status
+`.upskill-lock.json` records what was installed at which ref and hash —
+commit it alongside the project.
 
-- **v0.1.x** — shipped on `main`, `cargo install upskill`. Skills-only
-  installer with the original fetch-and-copy model.
-- **v0.2** — in progress on `v0.2-redesign`. Adds rules and agents alongside
-  skills, with an SSOT-to-client generation pipeline. Phases 0–2 (model,
-  parser, generation) have shipped on the branch; Phase 3+ (install / update
-  over the pipeline, bundles, lockfile migration) is in flight.
+## Author
 
-See [`docs/specification.md`](docs/specification.md) for the v0.2 design and
-[`docs/adr/`](docs/adr/) for the architecture decisions
-([ADR-0001](docs/adr/0001-multi-kind-compiler-architecture.md) is the
-umbrella).
+```bash
+# In a source-registry repo (where SSOT items live)
+upskill new skill code-review
+upskill lint --strict
+upskill fmt
+```
+
+## Two roles, no overlap
+
+- **Source registry** — repo where SSOT items live. Author commands run
+  here: `new`, `lint`, `fmt`.
+- **Consumer project** — repo where generated outputs land. Consumer
+  commands run here: `add`, `remove`, `update`, `list`, `doctor`,
+  `search`.
+
+The same repo can be both, but SSOT and generated outputs do not mix in
+the same tree.
+
+## Bundles
+
+A bundle is a flat manifest (`*.bundle.md`) that names the items it
+includes, and optionally other bundles it depends on. Installing a
+bundle resolves the transitive closure once and writes per-item output:
+
+```bash
+upskill add driftsys/bundles:platform-baseline.bundle.md
+```
+
+The lockfile records the bundle entry alongside the items, so
+`remove --source <bundle-label>` and future `remove <bundle-name>`
+flows know which items came from which bundle.
+
+## Documentation
+
+- User guide: [`docs/usage.md`](docs/usage.md).
+- Behavioural spec: [`docs/specification.md`](docs/specification.md).
+- On-disk contract: [`docs/format-spec.md`](docs/format-spec.md).
+- Architecture decisions: [`docs/adr/`](docs/adr/) — see
+  [ADR-0001](docs/adr/0001-multi-kind-compiler-architecture.md) for the
+  umbrella decision.
 
 ## License
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2,8 +2,7 @@
 
 > Upskill your coding agents.
 
-**Status**: v0.2 design (in progress). Phases 0–2 implemented; Phase 3+ pending
-— see [§7 Implementation status](#7-implementation-status).
+**Status**: v0.2 — shipped in v0.2.0.
 
 ## 1. Overview
 
@@ -45,7 +44,7 @@ Per [ADR-0004](./adr/0004-cli-surface.md):
   (`new`, `lint`, `fmt`) operate here.
 - **Consumer project** — repository where generated outputs are installed
   for use by AI clients. Holds only generated per-client files. Consumer
-  commands (`add`, `remove`, `update`, `list`, `info`, `doctor`) operate
+  commands (`add`, `remove`, `update`, `list`, `doctor`, `search`) operate
   here.
 
 The same repository can be both, but SSOT and generated outputs do not mix
@@ -53,19 +52,19 @@ in the same tree.
 
 ## 2. CLI surface
 
-Per [ADR-0004](./adr/0004-cli-surface.md). Nine commands, no overlap.
+Per [ADR-0004](./adr/0004-cli-surface.md). No overlap between verbs.
 
-| Command  | Role     | Purpose                                                 |
-| -------- | -------- | ------------------------------------------------------- |
-| `add`    | Consumer | Install content from any source.                        |
-| `remove` | Consumer | Remove installed content.                               |
-| `update` | Consumer | Pull latest, regenerate changed items.                  |
-| `list`   | Consumer | Show installed content (or `--available` from sources). |
-| `info`   | Consumer | Show item or bundle details.                            |
-| `doctor` | Consumer | Verify installation consistency.                        |
-| `new`    | Author   | Scaffold a new rule, skill, or agent.                   |
-| `lint`   | Author   | Validate SSOT files against the format spec.            |
-| `fmt`    | Author   | Canonicalise YAML frontmatter (key order, quoting).     |
+| Command  | Role     | Purpose                                             |
+| -------- | -------- | --------------------------------------------------- |
+| `add`    | Consumer | Install content from any source.                    |
+| `remove` | Consumer | Remove installed content.                           |
+| `update` | Consumer | Pull latest, regenerate changed items.              |
+| `list`   | Consumer | Show installed content from the lock file.          |
+| `doctor` | Consumer | Verify installation consistency.                    |
+| `search` | Consumer | Look up skills via the public registry.             |
+| `new`    | Author   | Scaffold a new rule, skill, or agent.               |
+| `lint`   | Author   | Validate SSOT files against the format spec.        |
+| `fmt`    | Author   | Canonicalise YAML frontmatter (key order, quoting). |
 
 ### 2.1 `add`
 
@@ -116,19 +115,26 @@ covered by passing local paths to `add` / `update`.
 ### 2.3 `remove`
 
 ```text
-upskill remove [name...] [--global|--project]
+upskill remove [name...] [--source <label>] [--global]
 ```
 
-Removes installed items from the matching scope. Without arguments,
-implementations may prompt or require an explicit name list.
+Removes installed items from the matching scope. Either name one or more
+items, or pass `--source <label>` to remove every item that came from a
+single source. Bare `upskill remove` is rejected — be explicit. Ancillary
+files (`CLAUDE.md`, `opencode.json`, `.vscode/settings.json`) are not
+touched.
 
-### 2.4 `list` / `info` / `doctor`
+### 2.4 `list` / `doctor`
 
-- `list [--available]` — show installed content, or available content from
-  configured sources.
-- `info <name>` — show item or bundle details (resolved source, version,
-  hash, generated paths).
-- `doctor` — verify on-disk state matches the lock file; report drift.
+- `list` — show installed content from `.upskill-lock.json`, grouped by
+  kind. Bundles are surfaced in a separate section. The `--available`
+  view (items discoverable from configured sources) is deferred for a
+  future release.
+- `doctor` — verify on-disk state matches the lock file. Three
+  independent buckets: missing per-client outputs (reinstall fixes),
+  SSOT hash drift on `local:` sources (`update` fixes), and lockfile
+  entries with no recoverable source (`remove` fixes). Exit 0 when
+  clean, 1 when any drift is found.
 
 ### 2.5 `new` / `lint` / `fmt`
 
@@ -289,21 +295,22 @@ Self-hosted GitLab is supported via full URL form
 
 ## 7. Implementation status
 
-Per [ADR-0001](./adr/0001-multi-kind-compiler-architecture.md).
+Per [ADR-0001](./adr/0001-multi-kind-compiler-architecture.md). All
+phases shipped in v0.2.0.
 
-| Phase | Scope                                                                                             | Status       |
-| ----- | ------------------------------------------------------------------------------------------------- | ------------ |
-| 0     | Tag, branch, deps, ADRs, model skeleton.                                                          | Done.        |
-| 1     | SSOT parser + generation pipeline for skills × all 3 clients.                                     | Done.        |
-| 2     | Pipeline extension to rules and agents.                                                           | Done.        |
-| 3     | `add` / `update` / `remove` over the pipeline; bundles; v0.1 lockfile migration; ancillary files. | In progress. |
-| 5     | `lint` + `fmt`.                                                                                   | Pending.     |
-| 6     | `new` (scaffolding).                                                                              | Pending.     |
-| 7     | Polish + v0.2.0 release.                                                                          | Pending.     |
+| Phase | Scope                                                                                             | Status |
+| ----- | ------------------------------------------------------------------------------------------------- | ------ |
+| 0     | Tag, branch, deps, ADRs, model skeleton.                                                          | Done.  |
+| 1     | SSOT parser + generation pipeline for skills × all 3 clients.                                     | Done.  |
+| 2     | Pipeline extension to rules and agents.                                                           | Done.  |
+| 3     | `add` / `update` / `remove` over the pipeline; bundles; v0.1 lockfile migration; ancillary files. | Done.  |
+| 5     | `lint` + `fmt`.                                                                                   | Done.  |
+| 6     | `new` (scaffolding).                                                                              | Done.  |
+| 7     | Polish + v0.2.0 release.                                                                          | Done.  |
 
-The v0.1 CLI surface (`add` / `list` / `remove` / `check` / `search` /
-`update` against `.upskill-lock.json`) remains the **shipped** behaviour
-until v0.2.0. v0.1 is supported via patch releases of the `v0.1.x` line.
+v0.1's surface (`install` / `uninstall` / `check` against the legacy
+lockfile) is dropped in v0.2.0; the unified verbs (`add` / `remove` /
+`doctor`) are canonical. Lockfile migration is automatic — see §4.3.
 
 ## 8. Out of scope
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,15 +12,8 @@ upskill list                         # see what's installed
 upskill new skill code-review        # scaffold a new SSOT skill (in a registry)
 ```
 
-> **Status.** v0.2 is in active development on the `v0.2-redesign` branch.
-> Phases 0–2 (model, parser, generation pipeline) have shipped; Phase 3+
-> (install/update/remove over the pipeline, bundles, lock file migration) is
-> in progress. The latest released binary (`cargo install upskill`) is
-> v0.1.x and exposes the v0.1 skills-installer surface; this guide describes
-> the v0.2 surface that lands in v0.2.0.
->
-> For the full design, see [`specification.md`](./specification.md). For the
-> on-disk contract, see [`format-spec.md`](./format-spec.md).
+For the full behavioural spec, see [`specification.md`](./specification.md).
+For the on-disk contract, see [`format-spec.md`](./format-spec.md).
 
 ## Installation
 
@@ -122,20 +115,20 @@ upskill remove code-review
 upskill remove --global code-review
 ```
 
-#### `upskill list [--available]`
+#### `upskill list`
 
-Show installed content. With `--available`, list items the configured sources
-expose.
-
-#### `upskill info <name>`
-
-Show details for an item or bundle: resolved source, version, hash, generated
-output paths.
+Show installed content from `.upskill-lock.json`, grouped by kind. Bundles,
+when present, are surfaced as a separate section. (`--available` to dump
+items discoverable from configured sources is deferred for a future release;
+v0.2.0 ships the installed-state view only.)
 
 #### `upskill doctor`
 
-Verify on-disk state matches `.upskill-lock.json`. Reports drift (manual edits to
-generated files, missing files, hash mismatches).
+Verify on-disk state matches `.upskill-lock.json`. Reports drift in three
+independent buckets: missing per-client output files (reinstall fixes),
+SSOT hash drift on `local:` sources (`update` fixes), and lockfile
+entries with no recoverable source (`remove` fixes). Exits non-zero
+when any bucket is non-empty.
 
 ### Author commands
 
@@ -217,7 +210,7 @@ Per [specification §4](./specification.md#4-state-files):
 v0.1 users keep the same `.upskill-lock.json` filename. v0.2 stamps a
 `schema: 2` field on first run and rewrites the file in place with the new
 entry shape — see
-[ADR-0003](./adr/0003-generation-pipeline.md).
+[ADR-0003](./adr/0003-generation-pipeline.md). No manual migration step.
 
 ## Per-client output paths
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,6 @@
 //! **generation** — SSOT in, per-client output out.
 //!
 //! No Node.js. No npm. No async runtime. Single static binary.
-//!
-//! ## Status
-//!
-//! v0.2 in development on the `v0.2-redesign` branch. v0.1.x (the
-//! skills-installer) is shipped from `main`. See the repository for
-//! progress.
 
 pub mod ancillary;
 pub mod auth;


### PR DESCRIPTION
## Summary

Phase D, slice D3 (release prep). Refresh `README.md`, `docs/usage.md`,
`docs/specification.md`, and `AGENTS.md` to describe the shipped v0.2
surface — drop "in progress" / "Phase X pending" callouts and update
the implementation-status table to all Done.

Bump `Cargo.toml` to `0.2.0` and refresh the package description to
match the new scope (authoring + distributing across clients, not just
an installer).

## Notable doc edits

- README leads with a concrete consumer + bundle workflow and points
  at the existing docs. The old "v0.1 shipped on `main`, v0.2 in
  progress" status block is gone.
- `usage.md` drops the in-progress Status callout. `list` is described
  as the installed-state view (per ADR-0004 the `--available` mode is
  deferred).
- `specification.md` §7 implementation-status table marks every phase
  Done and replaces the "v0.1 surface remains shipped" caveat with the
  v0.1→v0.2 verb migration note.
- `AGENTS.md` Install-layout section drops the v0.1-vs-v0.2 split.
  Module-layout tree is refreshed to list `bundle`, `lint`, `fmt`,
  `scaffold` alongside the existing modules.

## No code changes

`src/lib.rs` only loses its now-stale "v0.2 in development" status
comment. `just verify` clean.

## Test plan

- [x] `just verify` clean.
- [ ] CI passes.
- [ ] After merge: `just release` to tag v0.2.0, then confirm with
      maintainer before `just publish`.
