### PR TITLE
docs(book): make book standalone, drop v0.1 stragglers

### DIFF
--- a/docs/adr/0000-implementation-baseline.md
+++ b/docs/adr/0000-implementation-baseline.md
@@ -115,8 +115,7 @@ src/
 ├── bundle.rs            Bundle dependency resolution (transitive items closure).
 ├── ancillary.rs         CLAUDE.md / opencode.json / .vscode/settings.json
 │                        first-time hand-shake files.
-├── lockfile_v2.rs       .upskill-lock.json (`schema: 2`) read/write
-│                        + in-place v0.1 → v0.2 migration on first load.
+├── lockfile.rs          .upskill-lock.json (`schema: 1`) read/write.
 │
 ├── lint.rs              Author command — validate SSOT against the format spec.
 ├── fmt.rs               Author command — canonicalise YAML frontmatter.
@@ -170,7 +169,7 @@ Live alongside modules. Coverage focuses on pure logic:
   input.
 - `pipeline.rs` — install / remove / update / doctor / list against
   in-memory lockfiles.
-- `lockfile_v2.rs` — v0.1 → v0.2 migration, schema rejection.
+- `lockfile.rs` — schema rejection, upsert/remove ordering.
 - `lint.rs`, `fmt.rs`, `scaffold.rs` — per-rule findings, canonical
   round-trip, name validation.
 - `auth.rs`, `bundle.rs`, `ancillary.rs` — per-module logic.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,9 +1,8 @@
 # Commands
 
-`upskill` ships nine commands per
-[ADR-0004](./adr/0004-cli-surface.md). They split cleanly into
-**consumer** (run inside a project that consumes AI-assistance content)
-and **author** (run inside a source-registry repo).
+`upskill` ships nine commands. They split cleanly into **consumer**
+(run inside a project that consumes AI-assistance content) and
+**author** (run inside a source-registry repo).
 
 | Command  | Role     | Purpose                                             |
 | -------- | -------- | --------------------------------------------------- |
@@ -171,15 +170,10 @@ Files whose frontmatter is already canonical are left untouched (no
 | `.upskill-lock.json`        | Per-project | Yes        | Deterministic regeneration in CI.    |
 | `~/.upskill/installed.json` | Per-user    | No         | Global install state, source caches. |
 
-v0.1 users keep the same `.upskill-lock.json` filename. v0.2 stamps a
-`schema: 2` field on first run and rewrites the file in place with the
-new entry shape — see
-[ADR-0003](./adr/0003-generation-pipeline.md). No manual migration
-step.
+The lockfile carries a top-level `schema: 1` field for forward
+compatibility.
 
 ## Per-client output paths
-
-Per [ADR-0003](./adr/0003-generation-pipeline.md):
 
 | Item kind | Claude Code                | GitHub Copilot                                | opencode                       |
 | --------- | -------------------------- | --------------------------------------------- | ------------------------------ |
@@ -188,8 +182,7 @@ Per [ADR-0003](./adr/0003-generation-pipeline.md):
 | Agent     | `.claude/agents/<name>.md` | `.github/agents/<name>.agent.md`              | `.opencode/agents/<name>.md`   |
 
 All output is **copy** (not symlink) — Windows portability without
-Developer Mode. The deliberate divergence from skills.sh is documented
-in [ADR-0005](./adr/0005-skills-sh-ecosystem-interop.md).
+Developer Mode.
 
 ## Exit codes
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -637,8 +637,7 @@ SHOULD verify output against actual client behavior.
 
 This section is deliberately scoped to "what file and frontmatter each client reads". Adjacent
 behavior — bridging files, IDE configuration mutation, third-party config-file management — is
-installer behavior owned by the implementing tool (see, e.g., upskill's
-[ADR-0003](./adr/0003-generation-pipeline.md)) and intentionally out of this specification.
+installer behavior owned by the implementing tool and intentionally out of this specification.
 
 ### 7.1 Claude Code
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -92,12 +92,3 @@ upskill lint --strict
 
 `upskill fmt` is idempotent — files already in canonical form aren't
 rewritten, so you can run it on every commit hook without churn.
-
-## Migrating from v0.1
-
-v0.1 users on `.upskill-lock.json` get an automatic in-place migration
-on the first run of any v0.2 command — the file is rewritten with the
-new `schema: 2` entry shape and no manual step is required.
-
-The legacy verbs `install` and `uninstall` are gone in v0.2; use
-`add` and `remove` instead. `check` is replaced by `doctor`.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -13,9 +13,7 @@ truth.
 
 The central abstraction is **generation**: the SSOT (Single Source of Truth)
 on disk is portable; per-client output is produced on demand by a generation
-pipeline. v0.1's fetch-and-copy installer model is replaced with this
-SSOT-to-client pipeline; see [ADR-0001](./adr/0001-multi-kind-compiler-architecture.md)
-for the umbrella decision.
+pipeline.
 
 ### 1.1 Three item kinds
 
@@ -37,8 +35,6 @@ This document describes upskill's behaviour against that contract.
 
 ### 1.3 Two roles
 
-Per [ADR-0004](./adr/0004-cli-surface.md):
-
 - **Source registry** — repository where SSOT items are authored. Holds the
   canonical `RULE.md` / `SKILL.md` / `AGENT.md` files. Author commands
   (`new`, `lint`, `fmt`) operate here.
@@ -52,7 +48,7 @@ in the same tree.
 
 ## 2. CLI surface
 
-Per [ADR-0004](./adr/0004-cli-surface.md). No overlap between verbs.
+No overlap between verbs.
 
 | Command  | Role     | Purpose                                             |
 | -------- | -------- | --------------------------------------------------- |
@@ -72,8 +68,7 @@ Per [ADR-0004](./adr/0004-cli-surface.md). No overlap between verbs.
 upskill add <source> [items...] [--global|--project]
 ```
 
-`<source>` accepts (per [ADR-0005](./adr/0005-skills-sh-ecosystem-interop.md),
-parity with `npx skills add`):
+`<source>` accepts (parity with `npx skills add`):
 
 - `owner/repo` — GitHub shorthand
 - `owner/repo@ref` — pinned ref (branch, tag, or commit SHA)
@@ -150,14 +145,12 @@ Author commands. Run inside a source-registry working tree.
 ### 2.6 Aliases
 
 `add` does **not** alias to `install`. `remove` does **not** alias to
-`uninstall`. v0.1's `install` and `uninstall` verbs are dropped — the unified
-verb names are canonical. Migration is covered in v0.2.0 release notes.
+`uninstall`. The unified verb names are canonical.
 
 ## 3. Generation pipeline
 
-Per [ADR-0003](./adr/0003-generation-pipeline.md). SSOT → per-client output
-runs on the developer's machine, on every install or update. No CI generation
-step. No committed `dist/` artifacts.
+SSOT → per-client output runs on the developer's machine, on every install
+or update. No CI generation step. No committed `dist/` artifacts.
 
 ### 3.1 Per-client output paths
 
@@ -168,24 +161,20 @@ step. No committed `dist/` artifacts.
 | Agent     | `.claude/agents/<name>.md`              | `.github/agents/<name>.agent.md`                              | `.opencode/agents/<name>.md`                       |
 
 Per-client frontmatter mapping is defined in [format-spec §7](./format-spec.md#7-generation-client-specific-output)
-and Appendix B; behaviour rationale is in
-[ADR-0003](./adr/0003-generation-pipeline.md).
+and Appendix B.
 
 ### 3.2 Copy, not symlink
 
 All installation is file copy or generated output. No symlinks anywhere. One
 code path; Windows portability without Developer Mode or
-`core.symlinks=true`. The deliberate divergence from skills.sh's symlink
-default is documented in
-[ADR-0005](./adr/0005-skills-sh-ecosystem-interop.md).
+`core.symlinks=true`.
 
 ### 3.3 Markdown formatting
 
 Generated output passes through embedded `dprint-plugin-markdown`
 (exact-pinned at `=0.21.1`) before writing. This guarantees idempotence under
 the same formatter in `dprint.json`. Authors who run `dprint` locally see no
-diffs on generated files. Rationale and version-pin discipline are in
-[ADR-0003](./adr/0003-generation-pipeline.md).
+diffs on generated files.
 
 ### 3.4 Ancillary file handling
 
@@ -202,8 +191,7 @@ Three files outside the per-item path tree are managed idempotently:
 
 ## 4. State files
 
-Per [ADR-0003](./adr/0003-generation-pipeline.md). State is split between
-two files, both schema-versioned (`schema: 1`).
+State is split between two files, both schema-versioned (`schema: 1`).
 
 ### 4.1 `.upskill-lock.json` (per-project, committed)
 
@@ -285,22 +273,17 @@ Self-hosted GitLab is supported via full URL form
 
 ## 7. Implementation status
 
-Per [ADR-0001](./adr/0001-multi-kind-compiler-architecture.md). All
-phases shipped in v0.2.0.
+All phases shipped in v0.2.0.
 
-| Phase | Scope                                                                                             | Status |
-| ----- | ------------------------------------------------------------------------------------------------- | ------ |
-| 0     | Tag, branch, deps, ADRs, model skeleton.                                                          | Done.  |
-| 1     | SSOT parser + generation pipeline for skills × all 3 clients.                                     | Done.  |
-| 2     | Pipeline extension to rules and agents.                                                           | Done.  |
-| 3     | `add` / `update` / `remove` over the pipeline; bundles; v0.1 lockfile migration; ancillary files. | Done.  |
-| 5     | `lint` + `fmt`.                                                                                   | Done.  |
-| 6     | `new` (scaffolding).                                                                              | Done.  |
-| 7     | Polish + v0.2.0 release.                                                                          | Done.  |
-
-v0.1's surface (`install` / `uninstall` / `check` against the legacy
-lockfile) is dropped in v0.2.0; the unified verbs (`add` / `remove` /
-`doctor`) are canonical. Lockfile migration is automatic — see §4.3.
+| Phase | Scope                                                                    | Status |
+| ----- | ------------------------------------------------------------------------ | ------ |
+| 0     | Tag, branch, deps, model skeleton.                                       | Done.  |
+| 1     | SSOT parser + generation pipeline for skills × all 3 clients.            | Done.  |
+| 2     | Pipeline extension to rules and agents.                                  | Done.  |
+| 3     | `add` / `update` / `remove` over the pipeline; bundles; ancillary files. | Done.  |
+| 5     | `lint` + `fmt`.                                                          | Done.  |
+| 6     | `new` (scaffolding).                                                     | Done.  |
+| 7     | Polish + v0.2.0 release.                                                 | Done.  |
 
 ## 8. Out of scope
 
@@ -313,13 +296,6 @@ lockfile) is dropped in v0.2.0; the unified verbs (`add` / `remove` /
 ## 9. References
 
 - Format spec: [`docs/format-spec.md`](./format-spec.md)
-- Architecture decisions:
-  [ADR-0000](./adr/0000-implementation-baseline.md) (implementation baseline),
-  [ADR-0001](./adr/0001-multi-kind-compiler-architecture.md) (umbrella),
-  [ADR-0002](./adr/0002-portable-content-format.md) (format),
-  [ADR-0003](./adr/0003-generation-pipeline.md) (pipeline),
-  [ADR-0004](./adr/0004-cli-surface.md) (CLI),
-  [ADR-0005](./adr/0005-skills-sh-ecosystem-interop.md) (interop)
 - User guide: [Getting started](./getting-started.md), [Commands](./commands.md), [Recipes](./recipes.md)
 - Agent Skills open standard: <https://agentskills.io>
 - skills.sh ecosystem: <https://skills.sh>


### PR DESCRIPTION
## Summary

The book should be standalone — readers shouldn't need to follow ADR cross-references to understand current behaviour. Also drops residual v0.1 migration references missed in #103.

## Changes

### Book pages — drop ADR cross-refs and v0.1 mentions

- `docs/recipes.md`: drop "Migrating from v0.1" section.
- `docs/commands.md`: drop v0.1 migration paragraph; remove ADR-0003/0004/0005 attributions in prose (the content describes the result; the ADRs are the rationale).
- `docs/specification.md`: scrub ADR-0001/0003/0004/0005 attributions throughout, drop the trailing "Architecture decisions" link list and the dangling §4.3 reference, drop the "v0.1 lockfile migration" row from the phase status table.
- `docs/format-spec.md`: drop ADR-0003 cross-ref.

### ADR-0000 baseline (live snapshot, not historical)

- Module map: `lockfile_v2.rs` → `lockfile.rs`, schema 2 → 1, drop migration comment.
- Test list: drop "v0.1 → v0.2 migration" bullet for the lockfile module.

### Untouched

ADRs 0001 / 0003 / 0004 / 0005 remain the historical record of past decisions; their content is correct as-of-the-decision-being-made.

## Test plan
- [x] `just fmt`
- [x] `just verify`
