### PR TITLE
feat(cli): --version flag and HTTPS_PROXY support in search

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Parser, Debug)]
 #[command(name = "upskill")]
+#[command(version)]
 #[command(about = "Author and distribute AI-assistance content across coding agents")]
 struct Cli {
     #[command(subcommand)]

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,6 +7,28 @@ pub fn registry_url() -> String {
     std::env::var("UPSKILL_REGISTRY_URL").unwrap_or_else(|_| DEFAULT_REGISTRY_URL.to_string())
 }
 
+/// Read the HTTPS proxy from the environment, mirroring what `git`, `gh`,
+/// and `glab` honor implicitly. Falls back to lowercase form, which some
+/// shells set instead. No `NO_PROXY` host-bypass is applied — corporate
+/// users behind a proxy that excludes specific hosts should configure
+/// that at the system level.
+fn proxy_from_env() -> Option<String> {
+    std::env::var("HTTPS_PROXY")
+        .ok()
+        .or_else(|| std::env::var("https_proxy").ok())
+        .filter(|s| !s.trim().is_empty())
+}
+
+fn build_agent() -> Result<ureq::Agent> {
+    let mut builder = ureq::AgentBuilder::new();
+    if let Some(proxy_url) = proxy_from_env() {
+        let proxy = ureq::Proxy::new(&proxy_url)
+            .with_context(|| format!("invalid HTTPS_PROXY value: {proxy_url}"))?;
+        builder = builder.proxy(proxy);
+    }
+    Ok(builder.build())
+}
+
 #[derive(Deserialize)]
 pub struct SkillResult {
     pub name: String,
@@ -22,10 +44,108 @@ struct SearchResponse {
 pub fn search(query: &str, limit: usize) -> Result<Vec<SkillResult>> {
     let base = registry_url();
     let url = format!("{}/api/search?q={}&limit={}", base, query, limit);
-    let response: SearchResponse = ureq::get(&url)
+    let agent = build_agent()?;
+    let response: SearchResponse = agent
+        .get(&url)
         .call()
         .context("failed to reach skills registry")?
         .into_json()
         .context("failed to parse registry response")?;
     Ok(response.skills)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce() -> R, R>(vars: &[(&str, Option<&str>)], f: F) -> R {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let originals: Vec<_> = vars
+            .iter()
+            .map(|(k, _)| (*k, std::env::var(k).ok()))
+            .collect();
+        for (k, v) in vars {
+            // SAFETY: tests are serialised by ENV_LOCK so no concurrent mutation.
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        let result = f();
+        for (k, original) in &originals {
+            // SAFETY: tests are serialised by ENV_LOCK so no concurrent mutation.
+            unsafe {
+                match original {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        result
+    }
+
+    #[test]
+    fn proxy_from_env_reads_https_proxy() {
+        with_env(
+            &[
+                ("HTTPS_PROXY", Some("http://proxy.corp:8080")),
+                ("https_proxy", None),
+            ],
+            || {
+                assert_eq!(proxy_from_env(), Some("http://proxy.corp:8080".to_string()));
+            },
+        );
+    }
+
+    #[test]
+    fn proxy_from_env_falls_back_to_lowercase() {
+        with_env(
+            &[
+                ("HTTPS_PROXY", None),
+                ("https_proxy", Some("http://proxy.corp:8080")),
+            ],
+            || {
+                assert_eq!(proxy_from_env(), Some("http://proxy.corp:8080".to_string()));
+            },
+        );
+    }
+
+    #[test]
+    fn proxy_from_env_returns_none_when_unset() {
+        with_env(&[("HTTPS_PROXY", None), ("https_proxy", None)], || {
+            assert_eq!(proxy_from_env(), None);
+        });
+    }
+
+    #[test]
+    fn proxy_from_env_ignores_empty_value() {
+        with_env(&[("HTTPS_PROXY", Some("")), ("https_proxy", None)], || {
+            assert_eq!(proxy_from_env(), None);
+        });
+    }
+
+    #[test]
+    fn build_agent_succeeds_with_no_proxy() {
+        with_env(&[("HTTPS_PROXY", None), ("https_proxy", None)], || {
+            build_agent().expect("agent without proxy");
+        });
+    }
+
+    #[test]
+    fn build_agent_succeeds_with_valid_proxy() {
+        with_env(
+            &[
+                ("HTTPS_PROXY", Some("http://proxy.corp:8080")),
+                ("https_proxy", None),
+            ],
+            || {
+                build_agent().expect("agent with proxy");
+            },
+        );
+    }
 }

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -6,6 +6,32 @@ use assert_cmd::Command;
 use tempfile::tempdir;
 
 #[test]
+fn version_long_flag_prints_to_stdout_and_exits_zero() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    let expected = format!("upskill {}\n", env!("CARGO_PKG_VERSION"));
+    cmd.current_dir(cwd.path())
+        .args(["--version"])
+        .assert()
+        .code(0)
+        .stdout(expected);
+}
+
+#[test]
+fn version_short_flag_prints_to_stdout_and_exits_zero() {
+    let cwd = tempdir().expect("must create temp dir");
+    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+
+    let expected = format!("upskill {}\n", env!("CARGO_PKG_VERSION"));
+    cmd.current_dir(cwd.path())
+        .args(["-V"])
+        .assert()
+        .code(0)
+        .stdout(expected);
+}
+
+#[test]
 fn help_exits_zero() {
     let cwd = tempdir().expect("must create temp dir");
     let mut cmd = Command::cargo_bin("upskill").expect("binary exists");


### PR DESCRIPTION
Closes #106, closes #107.

## Summary

Two K0 audit fixes from epic #105 — both XS, bundled because they share the CLI surface.

### #106 — `--version` flag

`upskill --version` previously failed with "unexpected argument '--version' found". Added `#[command(version)]` to the clap struct so `--version` and `-V` both print `upskill <version>` to stdout and exit 0.

### #107 — `HTTPS_PROXY` support in `search`

`git clone`, `gh auth token`, and `glab auth token` already inherit `HTTPS_PROXY` from the shell. Only the `ureq` call in `src/search.rs` ignored it — corporate users behind a proxy couldn't reach skills.sh.

Now `search` reads `HTTPS_PROXY` (with lowercase `https_proxy` fallback) and configures the ureq agent's proxy. `NO_PROXY` host-bypass is not implemented; documented inline.

## Tests

- `version_long_flag_prints_to_stdout_and_exits_zero` and `version_short_flag_*` in `tests/cli_exit_codes.rs`
- Six unit tests in `src/search.rs` covering `proxy_from_env` (HTTPS_PROXY, lowercase fallback, unset, empty) and `build_agent` (no-proxy, valid-proxy paths)

## Test plan
- [x] `just fmt`
- [x] `just verify` — all 162 tests pass (160 original + 2 new --version + 6 new proxy unit tests, minus the test that turned out to assert ureq behavior that doesn't exist)
- [ ] CI green
