### PR TITLE
docs: strike §4.2, simplify lockfile to one shape in two locations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,12 @@ Core docs (published as mdBook at <https://driftsys.github.io/upskill/>):
 
 ### Install layout
 
-Per-item generated output, copy only (no symlinks). State split between
-`.upskill-lock.json` (per-project, committed, `schema: 1`) and
-`~/.upskill/installed.json` (per-user). Per-client output paths and
-ancillary files (`CLAUDE.md`, `.vscode/settings.json`, `opencode.json`)
-are specified in [ADR-0003](docs/adr/0003-generation-pipeline.md) and
+Per-item generated output, copy only (no symlinks). One lockfile
+shape (`.upskill-lock.json`, `schema: 1`) in two possible locations:
+`<cwd>/` (project scope, committed) or `$HOME/` (global scope, not
+committed). Per-client output paths and ancillary files (`CLAUDE.md`,
+`.vscode/settings.json`, `opencode.json`) are specified in
+[ADR-0003](docs/adr/0003-generation-pipeline.md) and
 [format-spec §7](docs/format-spec.md).
 
 ### Source format

--- a/docs/adr/0000-implementation-baseline.md
+++ b/docs/adr/0000-implementation-baseline.md
@@ -37,7 +37,7 @@ Rust 2024 edition. MSRV: 1.85 (first stable release to support edition
 | `anyhow`                 | 1         | Ergonomic error chains via `.context()`. |
 | `thiserror`              | 2         | Typed parse errors (`source.rs`).        |
 | `serde`                  | 1         | Serialisation framework.                 |
-| `serde_json`             | 1         | Lockfile and `installed.json` I/O.       |
+| `serde_json`             | 1         | Lockfile I/O.                            |
 | `serde_yaml_ng`          | 0.10      | SSOT YAML frontmatter parsing.           |
 | `pulldown-cmark`         | 0.11      | Markdown body parsing for directives.    |
 | `dprint-plugin-markdown` | `=0.21.1` | Embedded markdown formatter (exact pin). |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -165,10 +165,12 @@ Files whose frontmatter is already canonical are left untouched (no
 
 ## State files
 
-| File                        | Scope       | Committed? | Purpose                              |
-| --------------------------- | ----------- | ---------- | ------------------------------------ |
-| `.upskill-lock.json`        | Per-project | Yes        | Deterministic regeneration in CI.    |
-| `~/.upskill/installed.json` | Per-user    | No         | Global install state, source caches. |
+`.upskill-lock.json` lives in one of two places depending on scope:
+
+| Scope   | Location                   | Committed? | Purpose                                    |
+| ------- | -------------------------- | ---------- | ------------------------------------------ |
+| Project | `<cwd>/.upskill-lock.json` | Yes        | Deterministic regeneration in CI.          |
+| Global  | `$HOME/.upskill-lock.json` | No         | Cross-repo continuity for global installs. |
 
 The lockfile carries a top-level `schema: 1` field for forward
 compatibility.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -191,14 +191,18 @@ Three files outside the per-item path tree are managed idempotently:
 
 ## 4. State files
 
-State is split between two files, both schema-versioned (`schema: 1`).
+`.upskill-lock.json` records what was installed, from where, at what
+resolved git ref, with what content hashes. Same schema (`schema: 1`),
+two possible locations:
 
-### 4.1 `.upskill-lock.json` (per-project, committed)
+| Scope   | Location                   | Committed? |
+| ------- | -------------------------- | ---------- |
+| Project | `<cwd>/.upskill-lock.json` | Yes        |
+| Global  | `$HOME/.upskill-lock.json` | No         |
 
-Lives at the consumer-project root. Records what was installed, from where,
-at what resolved git ref, with what content hashes. Plays the same role as
-`package-lock.json`: deterministic regeneration on another developer's
-machine and in CI.
+The lockfile plays the same role as `package-lock.json`: deterministic
+regeneration on another developer's machine and in CI for project scope,
+and across-repo continuity for global scope.
 
 ```json
 {
@@ -222,11 +226,6 @@ machine and in CI.
   ]
 }
 ```
-
-### 4.2 `~/.upskill/installed.json` (per-user)
-
-Tracks the user-global view: items installed at the global scope, drift
-state for the global location, and source-registry caches. Not committed.
 
 ## 5. Source format and authentication
 


### PR DESCRIPTION
Closes #110.

## Summary

Doc-only PR. Following the `npx skills` reference model: the lockfile is one shape (`.upskill-lock.json`, `schema: 1`) regardless of scope, just in two possible locations. No separate per-user aggregator file needed.

## Changes

- `docs/specification.md` §4.2 dropped; §4 rewritten to describe a single lockfile in two locations (project = `<cwd>/`, global = `$HOME/`)
- `docs/commands.md` State files table updated to match
- `AGENTS.md` Install layout description updated
- `docs/adr/0000-implementation-baseline.md` serde_json bullet — drop `installed.json` mention

## Untouched

ADR-0003 still references the original `installed.json` decision as historical record.

## Why

#110 in epic #105 — preparing for #109 (`--global` test + auto-fallback work). With the spec simplified, #109 doesn't have to reckon with two separate state files.

## Test plan
- [x] `just fmt`
- [x] `just verify`
