### PR TITLE
feat(scope): -p/--project flag, auto-fallback, positive --global tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,12 @@ enum Commands {
         /// Source: `owner/repo[@ref][:subfolder]`, full https URL, or local path.
         source: String,
         /// Install into `$HOME` instead of the current directory.
-        #[arg(short = 'g', long = "global")]
+        #[arg(short = 'g', long = "global", conflicts_with = "project")]
         global: bool,
+        /// Force project scope (current directory). Overrides the auto-detect
+        /// fallback to global when `cwd` is not inside a git repo.
+        #[arg(short = 'p', long = "project")]
+        project: bool,
     },
     /// Remove installed content.
     ///
@@ -61,8 +65,12 @@ enum Commands {
         #[arg(long = "source")]
         source: Option<String>,
         /// Operate on `$HOME` instead of the current directory.
-        #[arg(short = 'g', long = "global")]
+        #[arg(short = 'g', long = "global", conflicts_with = "project")]
         global: bool,
+        /// Force project scope (current directory). Overrides the auto-detect
+        /// fallback to global when `cwd` is not inside a git repo.
+        #[arg(short = 'p', long = "project")]
+        project: bool,
     },
     /// Pull latest sources and regenerate changed items.
     ///
@@ -77,8 +85,12 @@ enum Commands {
         #[arg(long = "dry-run")]
         dry_run: bool,
         /// Operate on `$HOME` instead of the current directory.
-        #[arg(short = 'g', long = "global")]
+        #[arg(short = 'g', long = "global", conflicts_with = "project")]
         global: bool,
+        /// Force project scope (current directory). Overrides the auto-detect
+        /// fallback to global when `cwd` is not inside a git repo.
+        #[arg(short = 'p', long = "project")]
+        project: bool,
     },
     /// List installed content recorded in `.upskill-lock.json`.
     ///
@@ -88,8 +100,12 @@ enum Commands {
     /// `upskill doctor`.
     List {
         /// Read `$HOME/.upskill-lock.json` instead of the current directory.
-        #[arg(short = 'g', long = "global")]
+        #[arg(short = 'g', long = "global", conflicts_with = "project")]
         global: bool,
+        /// Force project scope (current directory). Overrides the auto-detect
+        /// fallback to global when `cwd` is not inside a git repo.
+        #[arg(short = 'p', long = "project")]
+        project: bool,
     },
     /// Verify installed-state consistency.
     ///
@@ -102,8 +118,12 @@ enum Commands {
     /// `update --dry-run`. Exit 0 when clean, 1 when any drift is found.
     Doctor {
         /// Operate on `$HOME` instead of the current directory.
-        #[arg(short = 'g', long = "global")]
+        #[arg(short = 'g', long = "global", conflicts_with = "project")]
         global: bool,
+        /// Force project scope (current directory). Overrides the auto-detect
+        /// fallback to global when `cwd` is not inside a git repo.
+        #[arg(short = 'p', long = "project")]
+        project: bool,
     },
     /// Search the public skills registry.
     Search {
@@ -168,19 +188,25 @@ fn main() {
     };
 
     let mut exit_code = match cli.command {
-        Commands::Add { source, global } => run_add(&source, global),
+        Commands::Add {
+            source,
+            global,
+            project,
+        } => run_add(&source, global, project),
         Commands::Remove {
             names,
             source,
             global,
-        } => run_remove(&names, source.as_deref(), global),
+            project,
+        } => run_remove(&names, source.as_deref(), global, project),
         Commands::Update {
             names,
             dry_run,
             global,
-        } => run_update(&names, dry_run, global),
-        Commands::List { global } => run_list(global),
-        Commands::Doctor { global } => run_doctor(global),
+            project,
+        } => run_update(&names, dry_run, global, project),
+        Commands::List { global, project } => run_list(global, project),
+        Commands::Doctor { global, project } => run_doctor(global, project),
         Commands::Search { query, limit } => run_search(&query, limit),
         Commands::Lint { paths, strict } => run_lint(&paths, strict),
         Commands::Fmt { paths } => run_fmt(&paths),
@@ -212,7 +238,7 @@ fn map_clap_error(err: &clap::Error) -> i32 {
     }
 }
 
-fn run_add(source: &str, global: bool) -> i32 {
+fn run_add(source: &str, global: bool, project: bool) -> i32 {
     let parsed = match parse_install_source(source) {
         Ok(s) => s,
         Err(err) => {
@@ -221,7 +247,7 @@ fn run_add(source: &str, global: bool) -> i32 {
         }
     };
 
-    let target = match install_target(global) {
+    let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
             eprintln!("error: {}", err);
@@ -241,13 +267,53 @@ fn run_add(source: &str, global: bool) -> i32 {
     }
 }
 
-fn install_target(global: bool) -> anyhow::Result<PathBuf> {
-    if global {
-        std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| anyhow::anyhow!("HOME is not set"))
+/// Resolve the install target from the `-g/--global` and `-p/--project` flags.
+///
+/// Precedence:
+/// - `--project` (explicit) → cwd, regardless of git-repo state.
+/// - `--global` (explicit) → `$HOME`.
+/// - Neither → cwd if inside a git repo, else `$HOME` (per spec §2.1
+///   auto-fallback). The two flags are mutually exclusive at the clap layer.
+fn install_target(global: bool, project: bool) -> anyhow::Result<PathBuf> {
+    let scope = if project {
+        Scope::Project
+    } else if global {
+        Scope::Global
+    } else if is_inside_git_repo() {
+        Scope::Project
     } else {
-        std::env::current_dir().context("failed to get current directory")
+        Scope::Global
+    };
+
+    match scope {
+        Scope::Project => std::env::current_dir().context("failed to get current directory"),
+        Scope::Global => std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| anyhow::anyhow!("HOME is not set")),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Scope {
+    Project,
+    Global,
+}
+
+/// Walk up from `cwd` looking for a `.git` entry (file or directory). Returns
+/// `false` on any I/O error so the caller falls back to global scope rather
+/// than crashing — that matches user expectation when `cwd` is unreadable.
+fn is_inside_git_repo() -> bool {
+    let mut dir = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+    loop {
+        if dir.join(".git").exists() {
+            return true;
+        }
+        if !dir.pop() {
+            return false;
+        }
     }
 }
 
@@ -273,7 +339,7 @@ fn print_install_report(report: &InstallReport, source: &str) {
     }
 }
 
-fn run_remove(names: &[String], source: Option<&str>, global: bool) -> i32 {
+fn run_remove(names: &[String], source: Option<&str>, global: bool, project: bool) -> i32 {
     let filter = match (names.is_empty(), source) {
         (true, Some(s)) => RemoveFilter::BySource(s.to_string()),
         (false, None) => RemoveFilter::ByNames(names.to_vec()),
@@ -289,7 +355,7 @@ fn run_remove(names: &[String], source: Option<&str>, global: bool) -> i32 {
         }
     };
 
-    let target = match install_target(global) {
+    let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
             eprintln!("error: {}", err);
@@ -330,8 +396,8 @@ fn print_remove_report(report: &RemoveReport) {
     }
 }
 
-fn run_update(names: &[String], dry_run: bool, global: bool) -> i32 {
-    let target = match install_target(global) {
+fn run_update(names: &[String], dry_run: bool, global: bool, project: bool) -> i32 {
+    let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
             eprintln!("error: {}", err);
@@ -397,8 +463,8 @@ fn short(h: &Option<String>) -> String {
     }
 }
 
-fn run_doctor(global: bool) -> i32 {
-    let target = match install_target(global) {
+fn run_doctor(global: bool, project: bool) -> i32 {
+    let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
             eprintln!("error: {}", err);
@@ -480,8 +546,8 @@ fn kind_label(kind: ItemKind) -> &'static str {
     }
 }
 
-fn run_list(global: bool) -> i32 {
-    let target = match install_target(global) {
+fn run_list(global: bool, project: bool) -> i32 {
+    let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
             eprintln!("error: {}", err);

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -42,6 +42,9 @@ fn add_installs_local_ssot_to_cwd() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    // Mark `target` as a project directory so auto-fallback picks
+    // project scope (cwd) instead of global ($HOME).
+    fs::create_dir_all(target.join(".git")).unwrap();
 
     let assert = Command::cargo_bin("upskill")
         .unwrap()

--- a/tests/cli_bundle_install.rs
+++ b/tests/cli_bundle_install.rs
@@ -45,6 +45,7 @@ fn bundle_install_writes_only_referenced_items() {
     let target = tmp.path().join("target");
     stage_registry(&registry);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
 
     let bundle = registry.join("bundles/platform-baseline.bundle.md");
     Command::cargo_bin("upskill")
@@ -81,6 +82,7 @@ fn bundle_install_records_bundle_in_lockfile() {
     let target = tmp.path().join("target");
     stage_registry(&registry);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
 
     let bundle = registry.join("bundles/platform-baseline.bundle.md");
     Command::cargo_bin("upskill")
@@ -122,6 +124,7 @@ fn bundle_install_resolves_transitive_requires() {
     let target = tmp.path().join("target");
     stage_registry(&registry);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
 
     // `extras` has rule `license-awareness`; baseline has the rest.
     // Mark them disjoint so the union is exact (no conflict).
@@ -177,6 +180,7 @@ fn bundle_install_errors_on_item_conflict() {
     let target = tmp.path().join("target");
     stage_registry(&registry);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
 
     let extras = registry.join("bundles/platform-extras.bundle.md");
     let assert = Command::cargo_bin("upskill")

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -51,6 +51,7 @@ fn doctor_clean_install_exits_zero() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let assert = Command::cargo_bin("upskill")
@@ -66,6 +67,7 @@ fn doctor_clean_install_exits_zero() {
 #[test]
 fn doctor_empty_lockfile_exits_zero() {
     let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
     Command::cargo_bin("upskill")
         .unwrap()
         .current_dir(tmp.path())
@@ -83,6 +85,7 @@ fn doctor_detects_missing_output_files() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let stolen = target.join(".claude/skills/create-api-endpoint/SKILL.md");
@@ -115,6 +118,7 @@ fn doctor_detects_ssot_hash_drift() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let skill_md = source.join("skills/create-api-endpoint/SKILL.md");
@@ -148,6 +152,7 @@ fn doctor_detects_orphan_when_local_path_gone() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     fs::remove_dir_all(&source).unwrap();
@@ -181,6 +186,7 @@ fn doctor_detects_orphan_when_item_removed_from_source() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     fs::remove_dir_all(source.join("skills/create-api-endpoint")).unwrap();

--- a/tests/cli_global_scope.rs
+++ b/tests/cli_global_scope.rs
@@ -1,0 +1,220 @@
+//! ATDD tests for global vs project scope and the auto-fallback rule.
+//!
+//! Spec §1.2 / §2.1: project (`<cwd>/`) is the default; global (`$HOME/`)
+//! kicks in when `-g/--global` is passed OR when `cwd` is not inside a git
+//! repo. `-p/--project` forces project regardless. `-g` and `-p` are
+//! mutually exclusive at the clap layer.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn add_global_writes_under_home_not_cwd() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let home = tmp.path().join("fakehome");
+    let cwd = tmp.path().join("cwd");
+    stage_source(&source);
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    // Mark cwd as a project so without `-g` we'd go project — proves the
+    // flag is what flips the scope, not the missing `.git`.
+    fs::create_dir_all(cwd.join(".git")).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .args(["add", "--global", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Outputs land under HOME, not cwd.
+    assert!(
+        home.join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists(),
+        "global skill output under HOME"
+    );
+    assert!(
+        home.join(".upskill-lock.json").exists(),
+        "global lockfile under HOME"
+    );
+    assert!(
+        !cwd.join(".upskill-lock.json").exists(),
+        "no project lockfile under cwd"
+    );
+    assert!(
+        !cwd.join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists(),
+        "no project output under cwd"
+    );
+}
+
+#[test]
+fn add_short_g_flag_works_too() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let home = tmp.path().join("fakehome");
+    let cwd = tmp.path().join("cwd");
+    stage_source(&source);
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(cwd.join(".git")).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .args(["add", "-g", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(home.join(".upskill-lock.json").exists());
+}
+
+#[test]
+fn auto_fallback_when_not_in_git_repo_uses_global() {
+    // No `.git` anywhere up the tree — auto-fallback to global.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let home = tmp.path().join("fakehome");
+    let cwd = tmp.path().join("cwd");
+    stage_source(&source);
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    // No `.git` marker — cwd is NOT a project.
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        home.join(".upskill-lock.json").exists(),
+        "auto-fallback wrote to HOME"
+    );
+    assert!(
+        !cwd.join(".upskill-lock.json").exists(),
+        "auto-fallback did NOT write to cwd"
+    );
+}
+
+#[test]
+fn project_flag_overrides_auto_fallback() {
+    // `cwd` is NOT in a git repo, so auto-fallback would pick global.
+    // `-p/--project` forces project anyway.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let home = tmp.path().join("fakehome");
+    let cwd = tmp.path().join("cwd");
+    stage_source(&source);
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    // No `.git` marker.
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .args(["add", "--project", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        cwd.join(".upskill-lock.json").exists(),
+        "--project forced lockfile under cwd despite no .git"
+    );
+    assert!(
+        !home.join(".upskill-lock.json").exists(),
+        "--project did NOT write to HOME"
+    );
+}
+
+#[test]
+fn global_and_project_flags_conflict() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "--global", "--project", "owner/repo"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn list_global_reads_home_lockfile() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let home = tmp.path().join("fakehome");
+    let cwd = tmp.path().join("cwd");
+    stage_source(&source);
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(cwd.join(".git")).unwrap();
+
+    // Install globally.
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .args(["add", "--global", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // `list` without `-g` from project cwd: reports nothing (project lockfile is absent).
+    let project_assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .args(["list"])
+        .assert()
+        .success();
+    let project_out = String::from_utf8(project_assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        project_out.contains("no items installed"),
+        "project list empty: {project_out}"
+    );
+
+    // `list -g` reads the global lockfile.
+    let global_assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .args(["list", "-g"])
+        .assert()
+        .success();
+    let global_out = String::from_utf8(global_assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        global_out.contains("create-api-endpoint"),
+        "global list shows installed skill: {global_out}"
+    );
+}

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -45,6 +45,7 @@ fn install(target: &Path, source: &Path) {
 #[test]
 fn list_empty_lockfile_reports_no_items() {
     let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
     let assert = Command::cargo_bin("upskill")
         .unwrap()
         .current_dir(tmp.path())
@@ -65,6 +66,7 @@ fn list_groups_installed_items_by_kind() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let assert = Command::cargo_bin("upskill")
@@ -111,6 +113,7 @@ fn list_bundle_install_surfaces_bundles_section() {
     let target = tmp.path().join("target");
     fs::create_dir_all(&source).unwrap();
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
 
     // Stage SSOT items + bundle file.
     stage_source(&source);

--- a/tests/cli_remove.rs
+++ b/tests/cli_remove.rs
@@ -50,6 +50,7 @@ fn remove_by_name_deletes_all_per_client_outputs_and_lockfile_entry() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     // Sanity check: install put the skill files in place.
@@ -113,6 +114,7 @@ fn remove_by_source_drops_every_entry_from_that_source() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let source_label = format!("local:{}", source.display());
@@ -145,6 +147,7 @@ fn remove_preserves_ancillary_files() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let source_label = format!("local:{}", source.display());
@@ -203,6 +206,7 @@ fn remove_unknown_name_is_general_error() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let assert = Command::cargo_bin("upskill")

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -68,6 +68,7 @@ fn update_no_change_reports_up_to_date() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let assert = Command::cargo_bin("upskill")
@@ -94,6 +95,7 @@ fn update_after_ssot_mutation_rewrites_outputs_and_lockfile_hash() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let original_hash = lockfile_hash_for(&target, "create-api-endpoint").unwrap();
@@ -133,6 +135,7 @@ fn update_dry_run_reports_change_without_writing() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let original_hash = lockfile_hash_for(&target, "create-api-endpoint").unwrap();
@@ -174,6 +177,7 @@ fn update_unknown_name_is_general_error() {
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
     install(&target, &source);
 
     let assert = Command::cargo_bin("upskill")
@@ -193,6 +197,7 @@ fn update_unknown_name_is_general_error() {
 #[test]
 fn update_empty_lockfile_is_no_op() {
     let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
     let assert = Command::cargo_bin("upskill")
         .unwrap()
         .current_dir(tmp.path())


### PR DESCRIPTION
Closes #109.

## Summary

Completes the partial `--global` scope implementation surfaced by the audit. Before this PR, `-g/--global` was wired to `install_target(global: bool)` but with no positive integration test, no `-p/--project` override, and no auto-fallback to global when `cwd` is not inside a git repo (a spec §2.1 promise).

## Changes

### Code

- New `Scope` enum (`Project` / `Global`) in `src/main.rs`.
- `install_target(global, project)` resolves scope with this precedence:
  1. `--project` (explicit) → cwd
  2. `--global` (explicit) → `$HOME`
  3. Neither → cwd if `is_inside_git_repo()`, else `$HOME`
- `is_inside_git_repo()` walks up from cwd looking for `.git` (file or directory).
- `-p/--project` flag added to `add`, `remove`, `update`, `list`, `doctor`. Mutually exclusive with `-g/--global` at the clap layer (`conflicts_with`).

### Tests

New `tests/cli_global_scope.rs` (6 tests):

- `add_global_writes_under_home_not_cwd` — explicit `--global` writes lockfile + outputs under `$HOME`, not `cwd`
- `add_short_g_flag_works_too` — `-g` parity
- `auto_fallback_when_not_in_git_repo_uses_global` — no flag + no `.git` → global
- `project_flag_overrides_auto_fallback` — `--project` outside git repo still picks project
- `global_and_project_flags_conflict` — both → exit 2
- `list_global_reads_home_lockfile` — round-trip: install global, list shows nothing in project, `list -g` shows the item

### Tests touched (existing)

The 17 existing tests that simulated "in a project" via `current_dir(tmp.path())` without a `.git` marker now break under auto-fallback. Each was updated to `fs::create_dir_all(target.join(".git")).unwrap()` so they continue to test project-scope behavior.

Files: `cli_add.rs`, `cli_bundle_install.rs`, `cli_doctor.rs`, `cli_list.rs`, `cli_remove.rs`, `cli_update.rs`.

## Spec

No spec changes. §2.1 already describes the auto-fallback rule and "either flag can be passed explicitly" — this PR makes the spec true.

## Test plan
- [x] `just fmt`
- [x] `just verify`
