### PR TITLE
feat(style): color output with clig.dev disable chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1157,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "colored",
  "ctrlc",
  "dprint-plugin-markdown",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }
+colored = "3"
 ctrlc = "3.4"
 dprint-plugin-markdown = "=0.21.1"
 pulldown-cmark = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,6 @@ pub mod pipeline;
 pub mod scaffold;
 pub mod search;
 pub mod source;
+pub mod style;
 
 pub use source::{InstallSource, parse_install_source};

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use upskill::pipeline::{
 use upskill::scaffold::{NewKind, ScaffoldReport, scaffold};
 use upskill::search;
 use upskill::source::parse_install_source;
+use upskill::style;
 
 const EXIT_SUCCESS: i32 = 0;
 const EXIT_ERROR: i32 = 1;
@@ -26,6 +27,10 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 #[command(version)]
 #[command(about = "Author and distribute AI-assistance content across coding agents")]
 struct Cli {
+    /// Disable colored output. Honored alongside `NO_COLOR`,
+    /// `UPSKILL_NO_COLOR`, `TERM=dumb`, and TTY auto-detection.
+    #[arg(long = "no-color", global = true)]
+    no_color: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -173,11 +178,6 @@ enum Commands {
 }
 
 fn main() {
-    if let Err(err) = install_signal_handlers() {
-        eprintln!("error: {}", err);
-        std::process::exit(EXIT_ERROR);
-    }
-
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
         Err(err) => {
@@ -186,6 +186,13 @@ fn main() {
             std::process::exit(code);
         }
     };
+
+    style::init(cli.no_color);
+
+    if let Err(err) = install_signal_handlers() {
+        print_error(&err);
+        std::process::exit(EXIT_ERROR);
+    }
 
     let mut exit_code = match cli.command {
         Commands::Add {
@@ -231,6 +238,19 @@ fn was_interrupted() -> bool {
     INTERRUPTED.load(Ordering::SeqCst)
 }
 
+/// Print `error: <message>` to stderr, with the label colored when allowed
+/// by the disable chain. Centralises the convention so every error site
+/// uses the same shape.
+fn print_error(err: impl std::fmt::Display) {
+    eprintln!("{} {err}", style::error_label("error:"));
+}
+
+/// Like [`print_error`] but uses the `:#` formatter to print the full
+/// anyhow context chain (root cause last).
+fn print_error_chain(err: &anyhow::Error) {
+    eprintln!("{} {err:#}", style::error_label("error:"));
+}
+
 fn map_clap_error(err: &clap::Error) -> i32 {
     match err.kind() {
         ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => EXIT_SUCCESS,
@@ -242,7 +262,7 @@ fn run_add(source: &str, global: bool, project: bool) -> i32 {
     let parsed = match parse_install_source(source) {
         Ok(s) => s,
         Err(err) => {
-            eprintln!("error: {}", err);
+            print_error(&err);
             return EXIT_USAGE;
         }
     };
@@ -250,7 +270,7 @@ fn run_add(source: &str, global: bool, project: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
-            eprintln!("error: {}", err);
+            print_error(&err);
             return EXIT_ERROR;
         }
     };
@@ -261,7 +281,7 @@ fn run_add(source: &str, global: bool, project: bool) -> i32 {
             EXIT_SUCCESS
         }
         Err(err) => {
-            eprintln!("error: {:#}", err);
+            print_error_chain(&err);
             EXIT_ERROR
         }
     }
@@ -320,7 +340,12 @@ fn is_inside_git_repo() -> bool {
 fn print_install_report(report: &InstallReport, source: &str) {
     use std::collections::BTreeMap;
 
-    println!("Installed {} files from {}", report.items.len(), source);
+    println!(
+        "{} {} files from {}",
+        style::success("Installed"),
+        report.items.len(),
+        style::dim(source)
+    );
 
     let mut grouped: BTreeMap<(ItemKind, String), Vec<&'static str>> = BTreeMap::new();
     for item in &report.items {
@@ -335,7 +360,12 @@ fn print_install_report(report: &InstallReport, source: &str) {
             ItemKind::Skill => "skill",
             ItemKind::Agent => "agent",
         };
-        println!("  {} {:<32} → {}", kind_label, name, clients.join(", "));
+        println!(
+            "  {} {:<32} → {}",
+            style::dim(kind_label),
+            style::name(&name),
+            clients.join(", ")
+        );
     }
 }
 
@@ -344,13 +374,11 @@ fn run_remove(names: &[String], source: Option<&str>, global: bool, project: boo
         (true, Some(s)) => RemoveFilter::BySource(s.to_string()),
         (false, None) => RemoveFilter::ByNames(names.to_vec()),
         (true, None) => {
-            eprintln!(
-                "error: nothing to remove — pass one or more item names, or `--source <label>`"
-            );
+            print_error("nothing to remove — pass one or more item names, or `--source <label>`");
             return EXIT_USAGE;
         }
         (false, Some(_)) => {
-            eprintln!("error: `--source` and item names are mutually exclusive");
+            print_error("`--source` and item names are mutually exclusive");
             return EXIT_USAGE;
         }
     };
@@ -358,7 +386,7 @@ fn run_remove(names: &[String], source: Option<&str>, global: bool, project: boo
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
-            eprintln!("error: {}", err);
+            print_error(&err);
             return EXIT_ERROR;
         }
     };
@@ -369,7 +397,7 @@ fn run_remove(names: &[String], source: Option<&str>, global: bool, project: boo
             EXIT_SUCCESS
         }
         Err(err) => {
-            eprintln!("error: {:#}", err);
+            print_error_chain(&err);
             EXIT_ERROR
         }
     }
@@ -380,7 +408,11 @@ fn print_remove_report(report: &RemoveReport) {
         println!("no matching items in lockfile");
         return;
     }
-    println!("Removed {} item(s)", report.items.len());
+    println!(
+        "{} {} item(s)",
+        style::success("Removed"),
+        report.items.len()
+    );
     for item in &report.items {
         let kind_label = match item.kind {
             ItemKind::Rule => "rule ",
@@ -388,10 +420,10 @@ fn print_remove_report(report: &RemoveReport) {
             ItemKind::Agent => "agent",
         };
         println!(
-            "  {} {:<32} ({} file(s))",
-            kind_label,
-            item.name,
-            item.deleted_files.len()
+            "  {} {:<32} {}",
+            style::dim(kind_label),
+            style::name(&item.name),
+            style::dim(&format!("({} file(s))", item.deleted_files.len())),
         );
     }
 }
@@ -400,7 +432,7 @@ fn run_update(names: &[String], dry_run: bool, global: bool, project: bool) -> i
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
-            eprintln!("error: {}", err);
+            print_error(&err);
             return EXIT_ERROR;
         }
     };
@@ -416,7 +448,7 @@ fn run_update(names: &[String], dry_run: bool, global: bool, project: bool) -> i
             EXIT_SUCCESS
         }
         Err(err) => {
-            eprintln!("error: {:#}", err);
+            print_error_chain(&err);
             EXIT_ERROR
         }
     }
@@ -427,10 +459,10 @@ fn print_update_report(report: &UpdateReport, dry_run: bool) {
         println!("nothing to update — lockfile is empty");
         return;
     }
-    let header = if dry_run {
-        "Dry-run: would update"
+    let header: colored::ColoredString = if dry_run {
+        style::warn("Dry-run: would update")
     } else {
-        "Updated"
+        style::success("Updated")
     };
     let changes = report
         .items
@@ -444,14 +476,21 @@ fn print_update_report(report: &UpdateReport, dry_run: bool) {
             ItemKind::Skill => "skill",
             ItemKind::Agent => "agent",
         };
-        let status = match &item.status {
-            UpdateStatus::UpToDate => "up to date".to_string(),
-            UpdateStatus::Updated { new_hash, .. } => format!("updated → {}", short(new_hash)),
+        let status: colored::ColoredString = match &item.status {
+            UpdateStatus::UpToDate => style::dim("up to date"),
+            UpdateStatus::Updated { new_hash, .. } => {
+                style::success(&format!("updated → {}", short(new_hash)))
+            }
             UpdateStatus::WouldChange { new_hash, .. } => {
-                format!("would change → {}", short(new_hash))
+                style::warn(&format!("would change → {}", short(new_hash)))
             }
         };
-        println!("  {} {:<32} {}", kind_label, item.name, status);
+        println!(
+            "  {} {:<32} {}",
+            style::dim(kind_label),
+            style::name(&item.name),
+            status
+        );
     }
 }
 
@@ -467,7 +506,7 @@ fn run_doctor(global: bool, project: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
-            eprintln!("error: {}", err);
+            print_error(&err);
             return EXIT_ERROR;
         }
     };
@@ -482,7 +521,7 @@ fn run_doctor(global: bool, project: bool) -> i32 {
             }
         }
         Err(err) => {
-            eprintln!("error: {:#}", err);
+            print_error_chain(&err);
             EXIT_ERROR
         }
     }
@@ -490,36 +529,48 @@ fn run_doctor(global: bool, project: bool) -> i32 {
 
 fn print_doctor_report(report: &DoctorReport) {
     if report.is_clean() {
-        println!("doctor: clean");
+        println!("{} clean", style::success("doctor:"));
         return;
     }
 
     if !report.missing_outputs.is_empty() {
         println!(
-            "doctor: missing per-client outputs ({} item(s)) — reinstall to fix",
+            "{} missing per-client outputs ({} item(s)) — reinstall to fix",
+            style::error_label("doctor:"),
             report.missing_outputs.len()
         );
         for m in &report.missing_outputs {
-            println!("  {} {}", kind_label(m.kind), m.name);
+            println!(
+                "  {} {}",
+                style::dim(kind_label(m.kind)),
+                style::name(&m.name)
+            );
             for path in &m.missing_files {
-                println!("    - {}", path.display());
+                println!("    - {}", style::dim(&path.display().to_string()));
             }
         }
     }
 
     if !report.stale_hashes.is_empty() {
         println!(
-            "doctor: SSOT hash drift on local sources ({} item(s)) — `upskill update` to fix",
+            "{} SSOT hash drift on local sources ({} item(s)) — `upskill update` to fix",
+            style::warn("doctor:"),
             report.stale_hashes.len()
         );
         for s in &report.stale_hashes {
-            println!("  {} {} ({})", kind_label(s.kind), s.name, s.source);
+            println!(
+                "  {} {} {}",
+                style::dim(kind_label(s.kind)),
+                style::name(&s.name),
+                style::dim(&format!("({})", s.source))
+            );
         }
     }
 
     if !report.orphan_entries.is_empty() {
         println!(
-            "doctor: lockfile entries with no recoverable source ({} item(s)) — `upskill remove` to clear",
+            "{} lockfile entries with no recoverable source ({} item(s)) — `upskill remove` to clear",
+            style::dim("doctor:"),
             report.orphan_entries.len()
         );
         for o in &report.orphan_entries {
@@ -528,11 +579,11 @@ fn print_doctor_report(report: &DoctorReport) {
                 OrphanReason::ItemMissingInSource => "item not in source",
             };
             println!(
-                "  {} {} ({}) — {}",
-                kind_label(o.kind),
-                o.name,
-                o.source,
-                reason
+                "  {} {} {} — {}",
+                style::dim(kind_label(o.kind)),
+                style::name(&o.name),
+                style::dim(&format!("({})", o.source)),
+                style::dim(reason),
             );
         }
     }
@@ -550,7 +601,7 @@ fn run_list(global: bool, project: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
-            eprintln!("error: {}", err);
+            print_error(&err);
             return EXIT_ERROR;
         }
     };
@@ -561,7 +612,7 @@ fn run_list(global: bool, project: bool) -> i32 {
             EXIT_SUCCESS
         }
         Err(err) => {
-            eprintln!("error: {:#}", err);
+            print_error_chain(&err);
             EXIT_ERROR
         }
     }
@@ -583,13 +634,17 @@ fn print_list_section(label: &str, items: &[ListedItem]) {
     if items.is_empty() {
         return;
     }
-    println!("{label} ({})", items.len());
+    println!("{} ({})", style::name(label), items.len());
     for item in items {
         let pinned = match &item.git_ref {
             Some(r) => format!("@{r}"),
             None => String::new(),
         };
-        println!("  {:<32} {}{}", item.name, item.source, pinned);
+        println!(
+            "  {:<32} {}",
+            style::name(&item.name),
+            style::dim(&format!("{}{pinned}", item.source))
+        );
     }
 }
 
@@ -597,13 +652,17 @@ fn print_list_bundles(bundles: &[ListedBundle]) {
     if bundles.is_empty() {
         return;
     }
-    println!("bundles ({})", bundles.len());
+    println!("{} ({})", style::name("bundles"), bundles.len());
     for bundle in bundles {
         let pinned = match &bundle.git_ref {
             Some(r) => format!("@{r}"),
             None => String::new(),
         };
-        println!("  {:<32} {}{}", bundle.name, bundle.source, pinned);
+        println!(
+            "  {:<32} {}",
+            style::name(&bundle.name),
+            style::dim(&format!("{}{pinned}", bundle.source))
+        );
     }
 }
 
@@ -618,7 +677,7 @@ fn run_lint(paths: &[PathBuf], strict: bool) -> i32 {
             }
         }
         Err(err) => {
-            eprintln!("error: {:#}", err);
+            print_error_chain(&err);
             // Author-command misuse (consumer-project / unreadable
             // path) maps to usage error. The lint module surfaces
             // those as Err(_); per-rule findings travel inside Ok.
@@ -630,12 +689,16 @@ fn run_lint(paths: &[PathBuf], strict: bool) -> i32 {
 fn print_lint_report(report: &LintReport) {
     for f in &report.findings {
         let line = f.line.map(|n| format!(":{n}")).unwrap_or_default();
+        let severity_label = match f.severity {
+            upskill::lint::Severity::Error => style::error_label(f.severity.label()),
+            upskill::lint::Severity::Warning => style::warn(f.severity.label()),
+        };
         println!(
-            "{}: {}{} [{}] {}",
-            f.severity.label(),
-            f.path.display(),
+            "{}: {}{} {} {}",
+            severity_label,
+            style::name(&f.path.display().to_string()),
             line,
-            f.rule_id,
+            style::dim(&format!("[{}]", f.rule_id)),
             f.message
         );
     }
@@ -653,7 +716,7 @@ fn run_fmt(paths: &[PathBuf]) -> i32 {
             EXIT_SUCCESS
         }
         Err(err) => {
-            eprintln!("error: {:#}", err);
+            print_error_chain(&err);
             EXIT_USAGE
         }
     }
@@ -665,7 +728,11 @@ fn print_fmt_report(report: &FmtReport) {
         return;
     }
     for path in &report.files_changed {
-        println!("formatted: {}", path.display());
+        println!(
+            "{} {}",
+            style::warn("formatted:"),
+            style::name(&path.display().to_string())
+        );
     }
     println!(
         "{} file(s) checked, {} file(s) changed",
@@ -678,14 +745,14 @@ fn run_new(kind: &str, name: &str) -> i32 {
     let parsed_kind = match NewKind::parse(kind) {
         Ok(k) => k,
         Err(err) => {
-            eprintln!("error: {}", err);
+            print_error(&err);
             return EXIT_USAGE;
         }
     };
     let cwd = match std::env::current_dir() {
         Ok(p) => p,
         Err(err) => {
-            eprintln!("error: get current directory: {}", err);
+            print_error(format!("get current directory: {err}"));
             return EXIT_ERROR;
         }
     };
@@ -696,7 +763,7 @@ fn run_new(kind: &str, name: &str) -> i32 {
         }
         Err(err) => {
             let msg = format!("{:#}", err);
-            eprintln!("error: {}", msg);
+            print_error(&msg);
             // Author-command misuse (consumer-project) → usage error;
             // every other failure → 1.
             if msg.contains("consumer project") {
@@ -715,9 +782,10 @@ fn print_scaffold_report(report: &ScaffoldReport) {
         NewKind::Agent => "agent",
     };
     println!(
-        "scaffolded {kind_label} `{}` at {}",
-        report.name,
-        report.written.display()
+        "{} {kind_label} `{}` at {}",
+        style::success("scaffolded"),
+        style::name(&report.name),
+        style::name(&report.written.display().to_string())
     );
     println!("edit the file and replace the TODO body before publishing.");
 }
@@ -725,7 +793,7 @@ fn print_scaffold_report(report: &ScaffoldReport) {
 fn run_search(query: &str, limit: usize) -> i32 {
     match search::search(query, limit) {
         Err(err) => {
-            eprintln!("error: {}", err);
+            print_error(&err);
             EXIT_ERROR
         }
         Ok(results) if results.is_empty() => {
@@ -739,8 +807,10 @@ fn run_search(query: &str, limit: usize) -> i32 {
                     .trim_start_matches("github/")
                     .trim_start_matches("gitlab/");
                 println!(
-                    "{}\t{} installs\tupskill add {} --skill {}",
-                    skill.name, skill.installs, repo, skill.name
+                    "{}\t{}\t{}",
+                    style::name(&skill.name),
+                    style::dim(&format!("{} installs", skill.installs)),
+                    style::dim(&format!("upskill add {repo} --skill {}", skill.name))
                 );
             }
             EXIT_SUCCESS

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,0 +1,223 @@
+//! Output styling: a small universal palette plus the
+//! [clig.dev](https://clig.dev) disable chain.
+//!
+//! Disable signals (highest precedence first):
+//!
+//! 1. `--no-color` flag — explicit user request.
+//! 2. `NO_COLOR` env var (any non-empty value).
+//! 3. `UPSKILL_NO_COLOR` env var (app-specific override).
+//! 4. `TERM=dumb`.
+//! 5. `!isatty(target stream)` — handled by `colored`'s default behaviour.
+//!
+//! `FORCE_COLOR` (or `CLICOLOR_FORCE`) re-enables color even when piped.
+
+use colored::ColoredString;
+use colored::Colorize;
+use colored::control;
+
+/// Apply the disable chain at startup. Honors `--no-color` from the CLI plus
+/// the env-var signals listed in the module docs. Should be called once,
+/// before any styled output.
+pub fn init(no_color_flag: bool) {
+    if no_color_flag || env_is_set("NO_COLOR") || env_is_set("UPSKILL_NO_COLOR") || term_is_dumb() {
+        control::set_override(false);
+    } else if env_is_set("FORCE_COLOR") || env_is_set("CLICOLOR_FORCE") {
+        control::set_override(true);
+    }
+    // Otherwise let `colored` auto-detect (respects isatty per stream).
+}
+
+fn env_is_set(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|v| !v.is_empty())
+}
+
+fn term_is_dumb() -> bool {
+    std::env::var("TERM").is_ok_and(|t| t == "dumb")
+}
+
+// --- palette helpers ------------------------------------------------------
+//
+// Universal palette per epic #105 §B1:
+//   red     = error / missing / drift
+//   yellow  = warning / would-change / pending
+//   green   = success / created / ✓
+//   gray    = secondary info (sources, paths, descriptions)
+//   bold    = primary identifier (names, paths)
+
+/// Bold red — for the "error:" label and similar fatal signals.
+pub fn error_label(text: &str) -> ColoredString {
+    text.red().bold()
+}
+
+/// Yellow — warnings, would-change in dry-run.
+pub fn warn(text: &str) -> ColoredString {
+    text.yellow()
+}
+
+/// Green — success, created, ✓.
+pub fn success(text: &str) -> ColoredString {
+    text.green()
+}
+
+/// Bold — primary identifier (names, paths).
+pub fn name(text: &str) -> ColoredString {
+    text.bold()
+}
+
+/// Dim — secondary info (sources, descriptions).
+pub fn dim(text: &str) -> ColoredString {
+    text.dimmed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(vars: &[(&str, Option<&str>)], f: F) {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let originals: Vec<_> = vars
+            .iter()
+            .map(|(k, _)| (*k, std::env::var(k).ok()))
+            .collect();
+        for (k, v) in vars {
+            // SAFETY: tests are serialised by ENV_LOCK so no concurrent mutation.
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        f();
+        for (k, original) in &originals {
+            // SAFETY: tests are serialised by ENV_LOCK so no concurrent mutation.
+            unsafe {
+                match original {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    fn rendered(text: ColoredString) -> String {
+        format!("{text}")
+    }
+
+    fn has_ansi(s: &str) -> bool {
+        s.contains('\x1b')
+    }
+
+    #[test]
+    fn no_color_flag_disables() {
+        with_env(
+            &[
+                ("NO_COLOR", None),
+                ("UPSKILL_NO_COLOR", None),
+                ("TERM", Some("xterm")),
+                ("FORCE_COLOR", None),
+                ("CLICOLOR_FORCE", None),
+            ],
+            || {
+                init(true);
+                assert!(!has_ansi(&rendered(error_label("error"))));
+                control::unset_override();
+            },
+        );
+    }
+
+    #[test]
+    fn no_color_env_disables() {
+        with_env(
+            &[
+                ("NO_COLOR", Some("1")),
+                ("UPSKILL_NO_COLOR", None),
+                ("TERM", Some("xterm")),
+                ("FORCE_COLOR", None),
+                ("CLICOLOR_FORCE", None),
+            ],
+            || {
+                init(false);
+                assert!(!has_ansi(&rendered(error_label("error"))));
+                control::unset_override();
+            },
+        );
+    }
+
+    #[test]
+    fn upskill_no_color_disables() {
+        with_env(
+            &[
+                ("NO_COLOR", None),
+                ("UPSKILL_NO_COLOR", Some("1")),
+                ("TERM", Some("xterm")),
+                ("FORCE_COLOR", None),
+                ("CLICOLOR_FORCE", None),
+            ],
+            || {
+                init(false);
+                assert!(!has_ansi(&rendered(error_label("error"))));
+                control::unset_override();
+            },
+        );
+    }
+
+    #[test]
+    fn term_dumb_disables() {
+        with_env(
+            &[
+                ("NO_COLOR", None),
+                ("UPSKILL_NO_COLOR", None),
+                ("TERM", Some("dumb")),
+                ("FORCE_COLOR", None),
+                ("CLICOLOR_FORCE", None),
+            ],
+            || {
+                init(false);
+                assert!(!has_ansi(&rendered(error_label("error"))));
+                control::unset_override();
+            },
+        );
+    }
+
+    #[test]
+    fn force_color_re_enables_when_piped() {
+        with_env(
+            &[
+                ("NO_COLOR", None),
+                ("UPSKILL_NO_COLOR", None),
+                ("TERM", Some("xterm")),
+                ("FORCE_COLOR", Some("1")),
+                ("CLICOLOR_FORCE", None),
+            ],
+            || {
+                init(false);
+                // assert_cmd-style runs are non-TTY; FORCE_COLOR must override that.
+                assert!(has_ansi(&rendered(error_label("error"))));
+                control::unset_override();
+            },
+        );
+    }
+
+    #[test]
+    fn empty_no_color_does_not_disable() {
+        // Per the NO_COLOR spec: the var must be non-empty to disable.
+        with_env(
+            &[
+                ("NO_COLOR", Some("")),
+                ("UPSKILL_NO_COLOR", None),
+                ("TERM", Some("xterm")),
+                ("FORCE_COLOR", Some("1")),
+                ("CLICOLOR_FORCE", None),
+            ],
+            || {
+                init(false);
+                assert!(has_ansi(&rendered(error_label("error"))));
+                control::unset_override();
+            },
+        );
+    }
+}

--- a/tests/cli_ci_mode.rs
+++ b/tests/cli_ci_mode.rs
@@ -1,18 +1,132 @@
-//! Verify CLI error output is plain text with no ANSI escapes when
-//! `NO_COLOR` is set, so CI logs and pipes stay readable.
+//! End-to-end tests for the color disable chain (clig.dev §Output).
+//!
+//! Five disable signals + one re-enable signal are wired in
+//! `src/style.rs`. The unit tests there cover the env-var precedence
+//! exhaustively. These integration tests pin the contract through the
+//! actual binary so a regression in `style::init` can't sneak past.
 
 use assert_cmd::Command;
 use tempfile::tempdir;
 
-#[test]
-fn no_color_produces_plain_error_output() {
-    let cwd = tempdir().expect("must create temp dir");
-    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+const ANSI_ESC: char = '\x1b';
 
-    cmd.current_dir(cwd.path())
+fn assert_no_ansi(output: &str) {
+    assert!(
+        !output.contains(ANSI_ESC),
+        "expected plain output, got ANSI: {output:?}"
+    );
+}
+
+fn assert_has_ansi(output: &str) {
+    assert!(
+        output.contains(ANSI_ESC),
+        "expected ANSI codes, got plain: {output:?}"
+    );
+}
+
+#[test]
+fn no_color_env_strips_ansi() {
+    let cwd = tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(cwd.path())
         .env("NO_COLOR", "1")
+        .env_remove("FORCE_COLOR")
+        .env_remove("CLICOLOR_FORCE")
         .args(["add", "not-a-valid-source"])
         .assert()
-        .code(2)
-        .stderr("error: source must be in owner/repo format\n");
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert_eq!(stderr, "error: source must be in owner/repo format\n");
+}
+
+#[test]
+fn no_color_flag_strips_ansi() {
+    let cwd = tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(cwd.path())
+        .env_remove("NO_COLOR")
+        .env("FORCE_COLOR", "1") // would force color, but --no-color takes precedence
+        .args(["--no-color", "add", "not-a-valid-source"])
+        .assert()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert_no_ansi(&stderr);
+}
+
+#[test]
+fn upskill_no_color_strips_ansi() {
+    let cwd = tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(cwd.path())
+        .env_remove("NO_COLOR")
+        .env("UPSKILL_NO_COLOR", "1")
+        .env_remove("FORCE_COLOR")
+        .args(["add", "not-a-valid-source"])
+        .assert()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert_no_ansi(&stderr);
+}
+
+#[test]
+fn term_dumb_strips_ansi() {
+    let cwd = tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(cwd.path())
+        .env("TERM", "dumb")
+        .env_remove("NO_COLOR")
+        .env_remove("FORCE_COLOR")
+        .args(["add", "not-a-valid-source"])
+        .assert()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert_no_ansi(&stderr);
+}
+
+#[test]
+fn piped_output_strips_ansi_by_default() {
+    // assert_cmd runs the binary with stderr/stdout NOT a TTY. With no
+    // FORCE_COLOR override, `colored` should auto-disable.
+    let cwd = tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(cwd.path())
+        .env_remove("NO_COLOR")
+        .env_remove("UPSKILL_NO_COLOR")
+        .env_remove("FORCE_COLOR")
+        .env_remove("CLICOLOR_FORCE")
+        .env("TERM", "xterm")
+        .args(["add", "not-a-valid-source"])
+        .assert()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert_no_ansi(&stderr);
+}
+
+#[test]
+fn force_color_re_enables_when_piped() {
+    // Even though stderr is piped (assert_cmd subprocess), FORCE_COLOR
+    // tells `colored` to emit ANSI anyway. clig.dev §Environment Variables.
+    let cwd = tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(cwd.path())
+        .env_remove("NO_COLOR")
+        .env_remove("UPSKILL_NO_COLOR")
+        .env("FORCE_COLOR", "1")
+        .env("TERM", "xterm")
+        .args(["add", "not-a-valid-source"])
+        .assert()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert_has_ansi(&stderr);
+    // The "error:" label should be styled (red bold = sequence containing 31).
+    assert!(
+        stderr.contains("\x1b[1;31m") || stderr.contains("\x1b[31;1m"),
+        "expected red+bold on label: {stderr:?}"
+    );
 }


### PR DESCRIPTION
Closes #108. Last item in epic #105.

## Summary

Implements the color output the spec promised but the code never delivered. Five-signal disable chain per [clig.dev](https://clig.dev) §Output, universal palette across all 9 commands.

## What changed

### Color crate

`colored = "3"` — one new dep, idiomatic API. The crate auto-detects TTY; this PR wraps it with explicit overrides for the full clig disable chain.

### Disable chain (precedence)

Wired in `src/style.rs::init()`, called once at startup with the `--no-color` flag value:

1. `--no-color` flag (new global CLI flag)
2. `NO_COLOR` env var (non-empty)
3. `UPSKILL_NO_COLOR` env var (app-specific override)
4. `TERM=dumb`
5. `!isatty(target stream)` — `colored` default

`FORCE_COLOR` (or `CLICOLOR_FORCE`) re-enables color even when piped.

### Universal palette

| Color | Used for |
|---|---|
| red bold | `error:` labels, missing outputs in `doctor`, error severity in `lint` |
| yellow | warnings, `would change` in `update --dry-run`, hash drift, `formatted:` |
| green | `Installed`, `Removed`, `updated`, `scaffolded`, `doctor: clean` |
| dim | source labels, kind labels, paths, descriptions, orphan reasons |
| bold | item names, file paths, bundle names |

Decorated 30+ `println!` sites across all 9 commands.

### Centralised error printing

New `print_error(...)` and `print_error_chain(...)` helpers replace 18 direct `eprintln!("error: ...")` call sites — uniform shape, single place to change the look.

## Tests

- **6 unit tests** in `src/style.rs` exhaustively cover the disable chain (`NO_COLOR`, `UPSKILL_NO_COLOR`, `TERM=dumb`, `--no-color` flag, `FORCE_COLOR` re-enable, empty-`NO_COLOR`-doesn't-disable per the NO_COLOR spec).
- **6 integration tests** in `tests/cli_ci_mode.rs` pin the contract through the actual binary. Each runs `upskill add not-a-valid-source` with one disable signal at a time and asserts the stderr output for ANSI presence/absence.

The previous `cli_ci_mode.rs::no_color_produces_plain_error_output` test passed vacuously because no color existed; the new file replaces it with real assertions.

## Test plan
- [x] `just fmt`
- [x] `just verify` — all 232+ tests pass
- [ ] CI green
