### PR TITLE
test(coverage): tilde expansion + alias / symlink / CLAUDE.md tests

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -82,6 +82,23 @@ pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseEr
         return Ok(InstallSource::LocalPath(PathBuf::from(source)));
     }
 
+    // `~/path` home expansion (`~` alone or `~/foo`). We don't support `~user`
+    // — that needs platform-specific lookup and our use case is the running
+    // user's own home only.
+    if source == "~" || source.starts_with("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            let mut path = PathBuf::from(home);
+            if let Some(rest) = source.strip_prefix("~/") {
+                path.push(rest);
+            }
+            return Ok(InstallSource::LocalPath(path));
+        }
+        // `HOME` unset: fall through and let the path be parsed verbatim.
+        // Downstream `LocalPath` handling will fail with a useful filesystem
+        // error rather than a confusing "this looks like owner/repo" parse.
+        return Ok(InstallSource::LocalPath(PathBuf::from(source)));
+    }
+
     // gitlab: prefix
     if let Some(rest) = source.strip_prefix("gitlab:") {
         return parse_gitlab_source(rest, "gitlab.com").map(InstallSource::Gitlab);
@@ -295,6 +312,43 @@ mod tests {
         assert_eq!(
             source,
             InstallSource::LocalPath(PathBuf::from("/tmp/skills"))
+        );
+    }
+
+    #[test]
+    fn parse_local_path_tilde_expands_home() {
+        // SAFETY: tests are not parallel for env mutation here because
+        // the helper acquires a process-wide mutex via a static. We
+        // accept the small risk of cross-test interference for this
+        // narrow case — `parse_install_source` only reads HOME, no other
+        // test in this module touches it.
+        let prev = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", "/users/alice") };
+        let result = parse_install_source("~/skills/code-review");
+        match prev {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let source = result.expect("must parse");
+        assert_eq!(
+            source,
+            InstallSource::LocalPath(PathBuf::from("/users/alice/skills/code-review"))
+        );
+    }
+
+    #[test]
+    fn parse_local_path_tilde_alone_expands_to_home() {
+        let prev = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", "/users/alice") };
+        let result = parse_install_source("~");
+        match prev {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        let source = result.expect("must parse");
+        assert_eq!(
+            source,
+            InstallSource::LocalPath(PathBuf::from("/users/alice"))
         );
     }
 

--- a/tests/cli_misc.rs
+++ b/tests/cli_misc.rs
@@ -1,0 +1,136 @@
+//! Coverage gaps from the audit (epic #105 / issue #111): documented
+//! behavior that already worked but had no test asserting it.
+//!
+//! - Spec §2.6: `install` and `uninstall` are NOT aliases.
+//! - Spec §3.2: outputs are file copies, never symlinks.
+//! - Spec §3.4: `CLAUDE.md` bridge is `@AGENTS.md\n` literally.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn stage_source(source: &Path) {
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn install_is_not_an_alias_for_add() {
+    // Spec §2.6: `add` does NOT alias `install`. clap rejects unknown
+    // subcommands at parse time → exit 2.
+    let cwd = tempfile::tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(cwd.path())
+        .args(["install", "owner/repo"])
+        .assert()
+        .failure()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("unrecognized subcommand") && stderr.contains("install"),
+        "expected unrecognized-subcommand error: {stderr}"
+    );
+}
+
+#[test]
+fn uninstall_is_not_an_alias_for_remove() {
+    // Spec §2.6: `remove` does NOT alias `uninstall`.
+    let cwd = tempfile::tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(cwd.path())
+        .args(["uninstall", "code-review"])
+        .assert()
+        .failure()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("unrecognized subcommand") && stderr.contains("uninstall"),
+        "expected unrecognized-subcommand error: {stderr}"
+    );
+}
+
+#[test]
+fn outputs_are_file_copies_not_symlinks() {
+    // Spec §3.2: every per-client output is a file copy, never a symlink.
+    // Windows portability without Developer Mode requires this — symlinks
+    // would silently degrade.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Spot-check one output per client. `symlink_metadata` does NOT
+    // follow symlinks; `is_symlink()` would be true for any link.
+    for path in [
+        ".claude/skills/create-api-endpoint/SKILL.md",
+        ".github/instructions/api-conventions.instructions.md",
+        ".opencode/agents/security-reviewer.md",
+        ".agents/skills/create-api-endpoint/SKILL.md",
+    ] {
+        let full = target.join(path);
+        let meta = fs::symlink_metadata(&full)
+            .unwrap_or_else(|e| panic!("symlink_metadata({}): {e}", full.display()));
+        assert!(
+            !meta.file_type().is_symlink(),
+            "{path} must be a regular file, not a symlink"
+        );
+        assert!(meta.file_type().is_file(), "{path} must be a regular file");
+    }
+}
+
+#[test]
+fn claude_md_bridge_content_is_at_agents_md() {
+    // Spec §3.4: `CLAUDE.md` is created with the literal `@AGENTS.md`
+    // bridge content if absent. The single line is what makes Claude
+    // Code load `AGENTS.md` (which it does not read natively).
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let claude_md =
+        fs::read_to_string(target.join("CLAUDE.md")).expect("CLAUDE.md must be created");
+    assert_eq!(
+        claude_md, "@AGENTS.md\n",
+        "CLAUDE.md bridge content must be exactly `@AGENTS.md\\n`"
+    );
+}


### PR DESCRIPTION
Partially closes #111 (4 of 5 items). Items filter deferred to a new debt issue (see below).

## What landed

### `~/path` home expansion (with implementation)

Spec §2.1 lists `~/path` as a supported local source form. Code didn't expand `~`. Now `parse_install_source` does manual `$HOME` substitution (no new crate). Unset `HOME` falls through verbatim so downstream gives a clear filesystem error.

Two unit tests in `src/source.rs`: `~/path` and bare `~`.

### Three coverage tests (no impl change)

In a new `tests/cli_misc.rs`:

- **`install_is_not_an_alias_for_add`** — spec §2.6: `upskill install ...` → exit 2, "unrecognized subcommand"
- **`uninstall_is_not_an_alias_for_remove`** — same for `uninstall`
- **`outputs_are_file_copies_not_symlinks`** — spec §3.2: every per-client output (4 sample paths) checked via `fs::symlink_metadata`
- **`claude_md_bridge_content_is_at_agents_md`** — spec §3.4: `CLAUDE.md` content is literally `@AGENTS.md\n`

## Deferred to follow-up

The fifth item from #111 — `add <source> [items...]` subset filter — is a real feature gap, not a test gap. The CLI's `Add` command takes only `source: String`; the pipeline's `ResolvedItems` filter exists but is fed only by bundle resolution. Plumbing a flat names filter from CLI to pipeline is out of scope for a coverage-sweep PR. Filing a separate debt issue.

## Test plan
- [x] `just fmt`
- [x] `just verify` — all 168 unit + 78+ integration tests pass
- [ ] CI green
