### PR TITLE
feat(help): bug-report URL, examples per subcommand, drop ADR refs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,10 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 #[command(name = "upskill")]
 #[command(version)]
 #[command(about = "Author and distribute AI-assistance content across coding agents")]
+#[command(
+    after_help = "DOCUMENTATION:\n  https://driftsys.github.io/upskill/\n\n\
+        REPORT BUGS:\n  https://github.com/driftsys/upskill/issues"
+)]
 struct Cli {
     /// Disable colored output. Honored alongside `NO_COLOR`,
     /// `UPSKILL_NO_COLOR`, `TERM=dumb`, and TTY auto-detection.
@@ -39,9 +43,17 @@ struct Cli {
 enum Commands {
     /// Install rules / skills / agents from a source.
     ///
-    /// Runs the v0.2 SSOT generation pipeline: parses each item from the
-    /// source, renders per-client output, and records the install in
-    /// `.upskill-lock.json`. Per format-spec §7 / ADR-0003.
+    /// Parses each item from the source, renders per-client output, and
+    /// records the install in `.upskill-lock.json`. Default scope is the
+    /// current project; falls back to global (`$HOME`) when `cwd` is not
+    /// inside a git repo.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill add owner/repo\n  \
+            upskill add owner/repo@v1.2\n  \
+            upskill add owner/repo:skills/code-review\n  \
+            upskill add gitlab:team/repo\n  \
+            upskill add ./local-source\n  \
+            upskill add owner/repo --global")]
     Add {
         /// Source: `owner/repo[@ref][:subfolder]`, full https URL, or local path.
         source: String,
@@ -57,9 +69,14 @@ enum Commands {
     ///
     /// Either name one or more items, or pass `--source <label>` to
     /// remove every item that came from a single source. Bare
-    /// `upskill remove` is rejected — be explicit per ADR-0004. Ancillary
-    /// files (`CLAUDE.md`, `opencode.json`, `.vscode/settings.json`) are
-    /// not touched.
+    /// `upskill remove` is rejected — be explicit. Ancillary files
+    /// (`CLAUDE.md`, `opencode.json`, `.vscode/settings.json`) are not
+    /// touched.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill remove code-review\n  \
+            upskill remove rule-a skill-b agent-c\n  \
+            upskill remove --source github:owner/repo\n  \
+            upskill remove --global code-review")]
     Remove {
         /// Item names to remove. Mutually exclusive with `--source`.
         names: Vec<String>,
@@ -82,7 +99,12 @@ enum Commands {
     /// Re-fetches the source for every (or just the named) lockfile
     /// entries and reinstalls those sources. With `--dry-run`, hashes
     /// the new SSOT and reports what would change without writing.
-    /// `update` always fetches per ADR-0004.
+    /// `update` always fetches.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill update\n  \
+            upskill update code-review\n  \
+            upskill update --dry-run\n  \
+            upskill update --global")]
     Update {
         /// Item names to update (omit to update everything).
         names: Vec<String>,
@@ -103,6 +125,9 @@ enum Commands {
     /// present, are surfaced as a separate section. The command never
     /// fetches and never inspects per-client output files — for that, run
     /// `upskill doctor`.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill list\n  \
+            upskill list --global")]
     List {
         /// Read `$HOME/.upskill-lock.json` instead of the current directory.
         #[arg(short = 'g', long = "global", conflicts_with = "project")]
@@ -114,13 +139,16 @@ enum Commands {
     },
     /// Verify installed-state consistency.
     ///
-    /// Three independent buckets per ADR-0004:
+    /// Three independent drift buckets:
     /// - missing per-client output files (reinstall fixes)
-    /// - SSOT hash drift on `local:` sources (update fixes)
-    /// - lockfile entries with no recoverable source (manual remove)
+    /// - SSOT hash drift on `local:` sources (`update` fixes)
+    /// - lockfile entries with no recoverable source (manual `remove`)
     ///
     /// Doctor never fetches; remote-source drift detection is
     /// `update --dry-run`. Exit 0 when clean, 1 when any drift is found.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill doctor\n  \
+            upskill doctor --global")]
     Doctor {
         /// Operate on `$HOME` instead of the current directory.
         #[arg(short = 'g', long = "global", conflicts_with = "project")]
@@ -131,6 +159,9 @@ enum Commands {
         project: bool,
     },
     /// Search the public skills registry.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill search code-review\n  \
+            upskill search api --limit 5")]
     Search {
         /// Search query.
         query: String,
@@ -145,6 +176,10 @@ enum Commands {
     /// Default mode emits warnings and exits 0 unless an error rule
     /// fires; `--strict` promotes warnings to errors (CI mode). With no
     /// paths, lints the current directory.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill lint\n  \
+            upskill lint rules/\n  \
+            upskill lint --strict")]
     Lint {
         /// Files or directories to lint. Empty = current directory.
         paths: Vec<PathBuf>,
@@ -158,21 +193,27 @@ enum Commands {
     /// markdown is left untouched (dprint's job). Refuses to run inside
     /// a consumer project (detected by `.upskill-lock.json`). With no
     /// paths, formats the current directory.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill fmt\n  \
+            upskill fmt rules/")]
     Fmt {
         /// Files or directories to format. Empty = current directory.
         paths: Vec<PathBuf>,
     },
     /// Scaffold a new rule, skill, or agent.
     ///
-    /// Writes the minimum frontmatter the format spec requires plus
-    /// kind-specific defaults (e.g. `mode: subagent` / `model: sonnet`
-    /// for agents) into `<cwd>/<kind>s/<name>/<KIND>.md`. Author
-    /// command — refuses to run inside a consumer project.
+    /// Writes the minimum frontmatter required plus kind-specific
+    /// defaults (e.g. `mode: subagent` / `model: sonnet` for agents)
+    /// into `<cwd>/<kind>s/<name>/<KIND>.md`. Author command — refuses
+    /// to run inside a consumer project.
+    #[command(after_help = "EXAMPLES:\n  \
+            upskill new rule no-direct-database-access\n  \
+            upskill new skill code-review\n  \
+            upskill new agent security-reviewer")]
     New {
         /// One of `rule`, `skill`, `agent`.
         kind: String,
-        /// Item name. Lowercase letters, digits, hyphens; max 64 chars
-        /// per format-spec §2.1.
+        /// Item name. Lowercase letters, digits, hyphens; max 64 chars.
         name: String,
     },
 }


### PR DESCRIPTION
Closes #116.

## Summary

Three clig.dev §Help findings from the audit:

### Bug-report URL in top-level help

`upskill --help` now ends with:

```
DOCUMENTATION:
  https://driftsys.github.io/upskill/

REPORT BUGS:
  https://github.com/driftsys/upskill/issues
```

Wired via `#[command(after_help = ...)]` on the top-level `Cli` struct.

### Examples per subcommand

Every subcommand's `--help` now has an `EXAMPLES:` section. Sample (`upskill add --help`):

```
EXAMPLES:
  upskill add owner/repo
  upskill add owner/repo@v1.2
  upskill add owner/repo:skills/code-review
  upskill add gitlab:team/repo
  upskill add ./local-source
  upskill add owner/repo --global
```

Covers add / remove / update / list / doctor / search / lint / fmt / new.

### ADR refs stripped from help text

End-user help no longer references internal docs. Five doc comments mentioning `ADR-0003`, `ADR-0004`, or `format-spec §` are reworded to user-facing prose. ADRs remain the source of truth for contributors in `docs/adr/`.

## Test plan
- [x] `just fmt`
- [x] `just verify`
- [x] Manual: `upskill --help` and 9 subcommand `--help` outputs visually checked
- [ ] CI green
