### PR TITLE
feat(cli): add -q/--quiet global flag

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,17 @@
 | `lint`   | Author   | Validate SSOT files against the format spec.        |
 | `fmt`    | Author   | Canonicalise YAML frontmatter (key order, quoting). |
 
+## Global flags
+
+These work on every subcommand:
+
+| Flag              | Effect                                                              |
+| ----------------- | ------------------------------------------------------------------- |
+| `--no-color`      | Disable colored output. Honored alongside `NO_COLOR`, `TERM=dumb`.  |
+| `-q`, `--quiet`   | Suppress informational stdout. Errors and exit codes are unchanged. |
+| `-h`, `--help`    | Show help.                                                          |
+| `-V`, `--version` | Show version.                                                       |
+
 ## Consumer commands
 
 ### `upskill add <source> [items...]`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -257,6 +257,8 @@ Self-hosted GitLab is supported via full URL form
 - POSIX/GNU long flags (`--flag-name`) and short flags (`-f`).
 - Stdout for data, stderr for progress and errors.
 - Honors `NO_COLOR` and TTY detection (no color in pipes/CI).
+- Global `-q` / `--quiet` suppresses informational stdout. Errors on
+  stderr and exit codes are unaffected.
 - Single static binary, no runtime dependencies.
 
 ### 6.3 Environment variables

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,11 @@ struct Cli {
     /// `UPSKILL_NO_COLOR`, `TERM=dumb`, and TTY auto-detection.
     #[arg(long = "no-color", global = true)]
     no_color: bool,
+    /// Suppress informational stdout. Errors on stderr and exit codes
+    /// are unaffected. Useful for CI use of `lint`, `update --dry-run`,
+    /// etc.
+    #[arg(short = 'q', long = "quiet", global = true)]
+    quiet: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -229,6 +234,7 @@ fn main() {
     };
 
     style::init(cli.no_color);
+    style::set_quiet(cli.quiet);
 
     if let Err(err) = install_signal_handlers() {
         print_error(&err);
@@ -379,6 +385,9 @@ fn is_inside_git_repo() -> bool {
 }
 
 fn print_install_report(report: &InstallReport, source: &str) {
+    if style::is_quiet() {
+        return;
+    }
     use std::collections::BTreeMap;
 
     println!(
@@ -445,6 +454,9 @@ fn run_remove(names: &[String], source: Option<&str>, global: bool, project: boo
 }
 
 fn print_remove_report(report: &RemoveReport) {
+    if style::is_quiet() {
+        return;
+    }
     if report.items.is_empty() {
         println!("no matching items in lockfile");
         return;
@@ -496,6 +508,9 @@ fn run_update(names: &[String], dry_run: bool, global: bool, project: bool) -> i
 }
 
 fn print_update_report(report: &UpdateReport, dry_run: bool) {
+    if style::is_quiet() {
+        return;
+    }
     if report.items.is_empty() {
         println!("nothing to update — lockfile is empty");
         return;
@@ -569,6 +584,9 @@ fn run_doctor(global: bool, project: bool) -> i32 {
 }
 
 fn print_doctor_report(report: &DoctorReport) {
+    if style::is_quiet() {
+        return;
+    }
     if report.is_clean() {
         println!("{} clean", style::success("doctor:"));
         return;
@@ -660,6 +678,9 @@ fn run_list(global: bool, project: bool) -> i32 {
 }
 
 fn print_list_report(report: &ListReport) {
+    if style::is_quiet() {
+        return;
+    }
     if report.is_empty() {
         println!("no items installed");
         return;
@@ -728,6 +749,9 @@ fn run_lint(paths: &[PathBuf], strict: bool) -> i32 {
 }
 
 fn print_lint_report(report: &LintReport) {
+    if style::is_quiet() {
+        return;
+    }
     for f in &report.findings {
         let line = f.line.map(|n| format!(":{n}")).unwrap_or_default();
         let severity_label = match f.severity {
@@ -764,6 +788,9 @@ fn run_fmt(paths: &[PathBuf]) -> i32 {
 }
 
 fn print_fmt_report(report: &FmtReport) {
+    if style::is_quiet() {
+        return;
+    }
     if report.files_changed.is_empty() {
         println!("{} file(s) checked, all formatted", report.files_checked);
         return;
@@ -817,6 +844,9 @@ fn run_new(kind: &str, name: &str) -> i32 {
 }
 
 fn print_scaffold_report(report: &ScaffoldReport) {
+    if style::is_quiet() {
+        return;
+    }
     let kind_label = match report.kind {
         NewKind::Rule => "rule",
         NewKind::Skill => "skill",
@@ -838,21 +868,25 @@ fn run_search(query: &str, limit: usize) -> i32 {
             EXIT_ERROR
         }
         Ok(results) if results.is_empty() => {
-            println!("no skills found for '{}'", query);
+            if !style::is_quiet() {
+                println!("no skills found for '{}'", query);
+            }
             EXIT_SUCCESS
         }
         Ok(results) => {
-            for skill in &results {
-                let repo = skill
-                    .source
-                    .trim_start_matches("github/")
-                    .trim_start_matches("gitlab/");
-                println!(
-                    "{}\t{}\t{}",
-                    style::name(&skill.name),
-                    style::dim(&format!("{} installs", skill.installs)),
-                    style::dim(&format!("upskill add {repo} --skill {}", skill.name))
-                );
+            if !style::is_quiet() {
+                for skill in &results {
+                    let repo = skill
+                        .source
+                        .trim_start_matches("github/")
+                        .trim_start_matches("gitlab/");
+                    println!(
+                        "{}\t{}\t{}",
+                        style::name(&skill.name),
+                        style::dim(&format!("{} installs", skill.installs)),
+                        style::dim(&format!("upskill add {repo} --skill {}", skill.name))
+                    );
+                }
             }
             EXIT_SUCCESS
         }

--- a/src/style.rs
+++ b/src/style.rs
@@ -11,9 +11,25 @@
 //!
 //! `FORCE_COLOR` (or `CLICOLOR_FORCE`) re-enables color even when piped.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use colored::ColoredString;
 use colored::Colorize;
 use colored::control;
+
+static QUIET: AtomicBool = AtomicBool::new(false);
+
+/// Enable or disable quiet mode. Set once from `main()` after parsing
+/// `--quiet`. Read by every `print_*` site to short-circuit informational
+/// stdout. Errors on stderr are unaffected.
+pub fn set_quiet(quiet: bool) {
+    QUIET.store(quiet, Ordering::SeqCst);
+}
+
+/// True when `--quiet` was passed (or `set_quiet(true)` was called).
+pub fn is_quiet() -> bool {
+    QUIET.load(Ordering::SeqCst)
+}
 
 /// Apply the disable chain at startup. Honors `--no-color` from the CLI plus
 /// the env-var signals listed in the module docs. Should be called once,

--- a/tests/cli_quiet.rs
+++ b/tests/cli_quiet.rs
@@ -1,0 +1,107 @@
+//! ATDD tests for the global `-q` / `--quiet` flag.
+//!
+//! `--quiet` suppresses informational stdout (state-change reports,
+//! "no items" messages, search results). Errors on stderr are unaffected,
+//! exit codes are unaffected.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+#[test]
+fn lint_quiet_on_clean_corpus_emits_no_stdout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&source)
+        .args(["lint", "--quiet"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(stdout.is_empty(), "expected empty stdout, got: {stdout:?}");
+}
+
+#[test]
+fn lint_short_q_on_clean_corpus_emits_no_stdout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    for kind in ["skills", "rules", "agents"] {
+        let from = format!("{FIXTURES}/{kind}");
+        let to = source.join(kind);
+        copy_dir_all(Path::new(&from), &to).unwrap();
+    }
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&source)
+        .args(["lint", "-q"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(stdout.is_empty(), "expected empty stdout, got: {stdout:?}");
+}
+
+#[test]
+fn quiet_does_not_silence_errors_on_stderr() {
+    // Invalid source string: parser rejects it, error goes to stderr,
+    // exit code is 2 (usage error). --quiet must not swallow that.
+    let tmp = tempfile::tempdir().unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "not a valid source", "--quiet"])
+        .assert()
+        .failure()
+        .code(2);
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stdout.is_empty(),
+        "expected empty stdout under --quiet, got: {stdout:?}"
+    );
+    assert!(
+        !stderr.is_empty(),
+        "expected error on stderr even under --quiet"
+    );
+}
+
+#[test]
+fn list_quiet_on_empty_lockfile_emits_no_stdout() {
+    // No lockfile in the temp dir, but --project forces project scope so
+    // list short-circuits to "no items installed" — that informational
+    // message must be silenced under --quiet.
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir(tmp.path().join(".git")).unwrap(); // pretend repo
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["list", "--project", "--quiet"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(stdout.is_empty(), "expected empty stdout, got: {stdout:?}");
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let to_path = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &to_path)?;
+        } else {
+            fs::copy(entry.path(), &to_path)?;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `-q` / `--quiet` as a global CLI flag (parallel to `--no-color`).
  Suppresses every informational stdout site — `add` / `remove` /
  `update` / `list` / `doctor` / `search` / `lint` / `fmt` / `new`.
- Errors on stderr (`print_error`, `print_error_chain`) and exit codes
  are unaffected.
- Backed by an `AtomicBool` in `style.rs` (same shape as
  `colored::control::set_override`); `main()` calls
  `style::set_quiet(cli.quiet)` once after `style::init`.
- Specification §6.2 + `commands.md` global-flags table updated.

## Test plan

- [x] ATDD: `tests/cli_quiet.rs` — `lint --quiet` and `lint -q` on the
      clean fixture corpus produce no stdout (exit 0); `list --quiet` on
      an empty lockfile produces no stdout; `add <bad source> --quiet`
      still prints to stderr and exits 2.
- [x] `just verify` (fmt, clippy `-D warnings`, full test suite, build).

Closes #115
