### PR TITLE
feat(cli): --json output for list and doctor

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -95,6 +95,21 @@ The `--available` view (items discoverable from configured sources) is
 deferred for a future release; v0.2.0 ships the installed-state view
 only.
 
+Pass `--json` for a stable machine-readable document:
+
+```json
+{
+  "rules":   [{ "kind": "rule",  "name": "...", "source": "...", "git_ref": null }],
+  "skills":  [{ "kind": "skill", "name": "...", "source": "...", "git_ref": null }],
+  "agents":  [{ "kind": "agent", "name": "...", "source": "...", "git_ref": null }],
+  "bundles": [{ "name": "...", "source": "...", "git_ref": null, "items": [] }]
+}
+```
+
+`kind` is one of `"rule"`, `"skill"`, `"agent"`. `git_ref` is the pinned
+ref/tag/branch when the source is a git URL, otherwise `null`. `source`
+matches the lockfile label (`local:/path` or `github:owner/repo` etc.).
+
 ### `upskill doctor`
 
 Verify on-disk state matches `.upskill-lock.json`. Reports drift in
@@ -109,6 +124,29 @@ three independent buckets:
 
 Exits 0 when clean, 1 when any bucket is non-empty. `doctor` never
 fetches; remote-source drift detection is `update --dry-run`.
+
+Pass `--json` for a stable machine-readable document. Exit code is
+unchanged.
+
+```json
+{
+  "missing_outputs": [
+    { "kind": "skill", "name": "...", "missing_files": ["..."] }
+  ],
+  "stale_hashes": [
+    { "kind": "rule",  "name": "...", "source": "local:...",
+      "stored_hash": "...", "current_hash": "..." }
+  ],
+  "orphan_entries": [
+    { "kind": "agent", "name": "...", "source": "local:...",
+      "reason": "local-path-gone" }
+  ]
+}
+```
+
+`reason` is `"local-path-gone"` or `"item-missing-in-source"`. Hashes
+may be `null` when the SSOT can't be hashed (e.g. unreadable). All three
+arrays are always present, possibly empty.
 
 ### `upskill search <query>`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,6 +128,10 @@ pub enum Commands {
         /// fallback to global when `cwd` is not inside a git repo.
         #[arg(short = 'p', long = "project")]
         project: bool,
+        /// Emit a stable JSON document instead of the human-readable
+        /// grouping. See `docs/commands.md` for the schema.
+        #[arg(long = "json")]
+        json: bool,
     },
     /// Verify installed-state consistency.
     ///
@@ -149,6 +153,11 @@ pub enum Commands {
         /// fallback to global when `cwd` is not inside a git repo.
         #[arg(short = 'p', long = "project")]
         project: bool,
+        /// Emit the three drift buckets as a stable JSON document. Exit
+        /// code is unchanged (0 clean, 1 drifted). See `docs/commands.md`
+        /// for the schema.
+        #[arg(long = "json")]
+        json: bool,
     },
     /// Search the public skills registry.
     #[command(after_help = "EXAMPLES:\n  \

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,16 @@ fn main() {
             global,
             project,
         } => run_update(&names, dry_run, global, project),
-        Commands::List { global, project } => run_list(global, project),
-        Commands::Doctor { global, project } => run_doctor(global, project),
+        Commands::List {
+            global,
+            project,
+            json,
+        } => run_list(global, project, json),
+        Commands::Doctor {
+            global,
+            project,
+            json,
+        } => run_doctor(global, project, json),
         Commands::Search { query, limit } => run_search(&query, limit),
         Commands::Lint { paths, strict } => run_lint(&paths, strict),
         Commands::Fmt { paths } => run_fmt(&paths),
@@ -358,7 +366,7 @@ fn short(h: &Option<String>) -> String {
     }
 }
 
-fn run_doctor(global: bool, project: bool) -> i32 {
+fn run_doctor(global: bool, project: bool, json: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
@@ -369,7 +377,11 @@ fn run_doctor(global: bool, project: bool) -> i32 {
 
     match doctor(&target) {
         Ok(report) => {
-            print_doctor_report(&report);
+            if json {
+                print_doctor_json(&report);
+            } else {
+                print_doctor_report(&report);
+            }
             if report.is_clean() {
                 EXIT_SUCCESS
             } else {
@@ -381,6 +393,16 @@ fn run_doctor(global: bool, project: bool) -> i32 {
             EXIT_ERROR
         }
     }
+}
+
+fn print_doctor_json(report: &DoctorReport) {
+    if style::is_quiet() {
+        return;
+    }
+    // serde_json::to_string_pretty cannot fail for owned data — every
+    // field on DoctorReport derives Serialize and contains no maps with
+    // non-string keys. unwrap is safe.
+    println!("{}", serde_json::to_string_pretty(report).unwrap());
 }
 
 fn print_doctor_report(report: &DoctorReport) {
@@ -456,7 +478,7 @@ fn kind_label(kind: ItemKind) -> &'static str {
     }
 }
 
-fn run_list(global: bool, project: bool) -> i32 {
+fn run_list(global: bool, project: bool, json: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
@@ -467,7 +489,11 @@ fn run_list(global: bool, project: bool) -> i32 {
 
     match list(&target) {
         Ok(report) => {
-            print_list_report(&report);
+            if json {
+                print_list_json(&report);
+            } else {
+                print_list_report(&report);
+            }
             EXIT_SUCCESS
         }
         Err(err) => {
@@ -475,6 +501,16 @@ fn run_list(global: bool, project: bool) -> i32 {
             EXIT_ERROR
         }
     }
+}
+
+fn print_list_json(report: &ListReport) {
+    if style::is_quiet() {
+        return;
+    }
+    // serde_json::to_string_pretty cannot fail for owned data — every
+    // field on ListReport derives Serialize and contains no maps with
+    // non-string keys. unwrap is safe.
+    println!("{}", serde_json::to_string_pretty(report).unwrap());
 }
 
 fn print_list_report(report: &ListReport) {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -21,6 +21,7 @@
 //! restricts emission to listed clients; absence means all clients.
 
 use anyhow::{Context, Result, anyhow};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -31,7 +32,8 @@ use crate::model::{Agent, Audience, Rule, Skill};
 use crate::parse::frontmatter;
 use crate::source::{GithubRepo, GitlabRepo, InstallSource};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ItemKind {
     Rule,
     Skill,
@@ -348,7 +350,7 @@ fn kind_subdir(kind: ItemKind) -> &'static str {
 }
 
 /// One per-client output file the lockfile said should exist but doesn't.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct MissingOutput {
     pub kind: ItemKind,
     pub name: String,
@@ -359,7 +361,7 @@ pub struct MissingOutput {
 /// SSOT content hash differs from what the lockfile recorded at install
 /// time. Only computed for `local:` sources still on disk —
 /// remote-source drift is the job of `update --dry-run`, which fetches.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct StaleHash {
     pub kind: ItemKind,
     pub name: String,
@@ -372,7 +374,7 @@ pub struct StaleHash {
 /// path is gone or the named item has been removed from the SSOT
 /// directory. The user has to `remove` it explicitly to clear the
 /// lockfile, since `update` would just fail trying to fetch.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct OrphanEntry {
     pub kind: ItemKind,
     pub name: String,
@@ -380,7 +382,8 @@ pub struct OrphanEntry {
     pub reason: OrphanReason,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum OrphanReason {
     /// `local:<path>` source no longer resolves to a directory on disk.
     LocalPathGone,
@@ -389,7 +392,7 @@ pub enum OrphanReason {
     ItemMissingInSource,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct DoctorReport {
     pub missing_outputs: Vec<MissingOutput>,
     pub stale_hashes: Vec<StaleHash>,
@@ -664,7 +667,7 @@ fn hash_source_items(
 
 /// One entry in a [`ListReport`] — a single installed item as recorded
 /// in the lockfile. Mirrors the lockfile shape; no per-client expansion.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ListedItem {
     pub kind: ItemKind,
     pub name: String,
@@ -674,7 +677,7 @@ pub struct ListedItem {
 
 /// One installed bundle as recorded in the lockfile (the per-bundle
 /// breakdown — see [`crate::lockfile::LockedBundle`]).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ListedBundle {
     pub name: String,
     pub source: String,
@@ -685,7 +688,7 @@ pub struct ListedBundle {
 /// What `upskill list` reports: every item the lockfile records, plus
 /// any installed bundles. Items are grouped by kind; the per-kind
 /// vectors are sorted by name for deterministic output.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct ListReport {
     pub rules: Vec<ListedItem>,
     pub skills: Vec<ListedItem>,

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -204,3 +204,102 @@ fn doctor_detects_orphan_when_item_removed_from_source() {
         "expected orphan with reason: {out}"
     );
 }
+
+#[test]
+fn doctor_json_clean_install_emits_empty_buckets() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["doctor", "--json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout was:\n{stdout}"));
+    for bucket in ["missing_outputs", "stale_hashes", "orphan_entries"] {
+        let arr = v[bucket].as_array().unwrap_or_else(|| {
+            panic!("expected {bucket} to be an array, got: {v}");
+        });
+        assert!(arr.is_empty(), "expected empty {bucket}, got: {arr:?}");
+    }
+}
+
+#[test]
+fn doctor_json_orphan_entry_has_kebab_case_reason() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    fs::remove_dir_all(&source).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["doctor", "--json"])
+        .assert()
+        .failure()
+        .code(1);
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout was:\n{stdout}"));
+    let orphans = v["orphan_entries"].as_array().unwrap();
+    assert!(!orphans.is_empty(), "expected at least one orphan entry");
+    for o in orphans {
+        assert_eq!(o["reason"].as_str(), Some("local-path-gone"));
+        assert_eq!(o["kind"].as_str().unwrap_or("").len() > 0, true);
+        assert!(o["name"].is_string());
+        assert!(o["source"].as_str().unwrap().starts_with("local:"));
+    }
+}
+
+#[test]
+fn doctor_json_missing_output_lists_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    let stolen = target.join(".claude/skills/create-api-endpoint/SKILL.md");
+    fs::remove_file(&stolen).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["doctor", "--json"])
+        .assert()
+        .failure()
+        .code(1);
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout was:\n{stdout}"));
+    let missing = v["missing_outputs"].as_array().unwrap();
+    assert_eq!(missing.len(), 1);
+    let entry = &missing[0];
+    assert_eq!(entry["name"].as_str(), Some("create-api-endpoint"));
+    assert_eq!(entry["kind"].as_str(), Some("skill"));
+    let files: Vec<&str> = entry["missing_files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f.as_str().unwrap())
+        .collect();
+    assert!(
+        files.iter().any(|p| p.contains("create-api-endpoint")),
+        "expected missing path entry, got: {files:?}"
+    );
+}

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -154,3 +154,58 @@ fn list_bundle_install_surfaces_bundles_section() {
         "expected bundle name in output: {out}"
     );
 }
+
+#[test]
+fn list_json_empty_lockfile_emits_empty_buckets() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["list", "--json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout was:\n{stdout}"));
+    for bucket in ["rules", "skills", "agents", "bundles"] {
+        let arr = v[bucket].as_array().unwrap_or_else(|| {
+            panic!("expected {bucket} to be an array, got: {v}");
+        });
+        assert!(arr.is_empty(), "expected empty {bucket}, got: {arr:?}");
+    }
+}
+
+#[test]
+fn list_json_groups_installed_items_by_kind() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["list", "--json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout was:\n{stdout}"));
+
+    assert_eq!(v["rules"].as_array().unwrap().len(), 2);
+    assert_eq!(v["skills"].as_array().unwrap().len(), 1);
+    assert_eq!(v["agents"].as_array().unwrap().len(), 1);
+
+    // Stable item shape: { name, source, git_ref }.
+    let first_rule = &v["rules"][0];
+    assert!(first_rule["name"].is_string());
+    assert!(first_rule["source"].as_str().unwrap().starts_with("local:"));
+    assert!(
+        first_rule.get("git_ref").is_some(),
+        "git_ref key required (null when absent)"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `--json` to `upskill list` and `upskill doctor`. Stable schema:
  `ItemKind` is `"rule"` / `"skill"` / `"agent"`, `OrphanReason` is
  `"local-path-gone"` / `"item-missing-in-source"`. All buckets always
  present (possibly empty).
- Backed by `Serialize` derives on the public `pipeline` types:
  `ListReport`, `DoctorReport`, plus their constituents. No new
  wrapper types — the JSON shape tracks the data shape.
- `--quiet` still suppresses everything from stdout, JSON included.
  Exit codes unchanged (`doctor` still returns 1 on drift).
- Schema documented in `docs/commands.md` for both commands.

## Test plan

- [x] ATDD: 5 new cases in `tests/cli_list.rs` / `tests/cli_doctor.rs`
      — empty buckets, populated install, kebab-case orphan reason,
      missing-files array shape.
- [x] `just verify` (fmt, clippy `-D warnings`, full test suite,
      build).

Closes #114
