### PR TITLE
feat(cli): implement [items...] subset filter on add

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,12 +43,17 @@ pub enum Commands {
             upskill add owner/repo\n  \
             upskill add owner/repo@v1.2\n  \
             upskill add owner/repo:skills/code-review\n  \
+            upskill add owner/repo code-review secret-scanner\n  \
             upskill add gitlab:team/repo\n  \
             upskill add ./local-source\n  \
             upskill add owner/repo --global")]
     Add {
         /// Source: `owner/repo[@ref][:subfolder]`, full https URL, or local path.
         source: String,
+        /// Optional subset filter — only items whose name matches one of
+        /// these is installed. Empty means install everything in the
+        /// source (the default).
+        items: Vec<String>,
         /// Install into `$HOME` instead of the current directory.
         #[arg(short = 'g', long = "global", conflicts_with = "project")]
         global: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,9 +44,10 @@ fn main() {
     let mut exit_code = match cli.command {
         Commands::Add {
             source,
+            items,
             global,
             project,
-        } => run_add(&source, global, project),
+        } => run_add(&source, &items, global, project),
         Commands::Remove {
             names,
             source,
@@ -121,7 +122,7 @@ fn map_clap_error(err: &clap::Error) -> i32 {
     }
 }
 
-fn run_add(source: &str, global: bool, project: bool) -> i32 {
+fn run_add(source: &str, items: &[String], global: bool, project: bool) -> i32 {
     let parsed = match parse_install_source(source) {
         Ok(s) => s,
         Err(err) => {
@@ -139,7 +140,7 @@ fn run_add(source: &str, global: bool, project: bool) -> i32 {
     };
 
     print_install_progress(&parsed);
-    match install_with_lockfile(&parsed, &target) {
+    match install_with_lockfile(&parsed, &target, items) {
         Ok(report) => {
             print_install_report(&report, source);
             EXIT_SUCCESS

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -74,14 +74,18 @@ const ALL_CLIENTS: [Client; 3] = [Client::Claude, Client::Copilot, Client::OpenC
 /// and installs only the resolved items. The reached bundles are
 /// surfaced via [`InstallReport::bundles`] so the lockfile slice can
 /// record them.
-pub fn install_from_local_path(source: &Path, target: &Path) -> Result<InstallReport> {
+pub fn install_from_local_path(
+    source: &Path,
+    target: &Path,
+    filter: Option<&crate::bundle::ResolvedItems>,
+) -> Result<InstallReport> {
     if is_bundle_file(source) {
         return install_bundle_file(source, target);
     }
     let mut report = InstallReport::default();
-    install_skills(source, target, &mut report, None)?;
-    install_rules(source, target, &mut report, None)?;
-    install_agents(source, target, &mut report, None)?;
+    install_skills(source, target, &mut report, filter)?;
+    install_rules(source, target, &mut report, filter)?;
+    install_agents(source, target, &mut report, filter)?;
     Ok(report)
 }
 
@@ -180,8 +184,29 @@ fn bundle_item_names(bundle: &crate::model::Bundle) -> Vec<String> {
 /// `git_ref` recorded per item is taken from the source variant when one
 /// is pinned (Github/Gitlab `git_ref`); local-path sources record `None`.
 /// `source` label is the [`InstallSource`] `Display` form.
-pub fn install_with_lockfile(source: &InstallSource, target: &Path) -> Result<InstallReport> {
-    let report = install_from_source(source, target)?;
+pub fn install_with_lockfile(
+    source: &InstallSource,
+    target: &Path,
+    items: &[String],
+) -> Result<InstallReport> {
+    // Empty list means "install everything" (the historical default).
+    // Otherwise build a `ResolvedItems` filter with each name copied
+    // into all three buckets — the per-kind walks check by `(kind,
+    // name)` so unrelated kinds simply skip names that aren't theirs.
+    let resolved = if items.is_empty() {
+        None
+    } else {
+        Some(crate::bundle::ResolvedItems {
+            rules: items.to_vec(),
+            skills: items.to_vec(),
+            agents: items.to_vec(),
+        })
+    };
+    let report = install_from_source(source, target, resolved.as_ref())?;
+
+    if !items.is_empty() && report.items.is_empty() {
+        anyhow::bail!("no matching items in source for: {}", items.join(", "));
+    }
 
     let label = source.to_string();
     let git_ref = match source {
@@ -581,7 +606,7 @@ pub fn update(target: &Path, names: &[String], mode: UpdateMode) -> Result<Updat
 
         match mode {
             UpdateMode::Apply => {
-                let install_report = install_with_lockfile(&source, target)?;
+                let install_report = install_with_lockfile(&source, target, &[])?;
                 let mut new_hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> =
                     std::collections::BTreeMap::new();
                 for it in &install_report.items {
@@ -765,15 +790,23 @@ pub fn list(target: &Path) -> Result<ListReport> {
 /// `https://<user>:<token>@<host>/...`. With no token, the clone falls
 /// back to git's own credential helpers (keychain, manager, etc.) so the
 /// previous behaviour is unchanged for users who rely on those.
-pub fn install_from_source(source: &InstallSource, target: &Path) -> Result<InstallReport> {
+pub fn install_from_source(
+    source: &InstallSource,
+    target: &Path,
+    filter: Option<&crate::bundle::ResolvedItems>,
+) -> Result<InstallReport> {
     match source {
-        InstallSource::LocalPath(path) => install_from_local_path(path, target),
-        InstallSource::Github(repo) => install_from_github(repo, target),
-        InstallSource::Gitlab(repo) => install_from_gitlab(repo, target),
+        InstallSource::LocalPath(path) => install_from_local_path(path, target, filter),
+        InstallSource::Github(repo) => install_from_github(repo, target, filter),
+        InstallSource::Gitlab(repo) => install_from_gitlab(repo, target, filter),
     }
 }
 
-fn install_from_github(repo: &GithubRepo, target: &Path) -> Result<InstallReport> {
+fn install_from_github(
+    repo: &GithubRepo,
+    target: &Path,
+    filter: Option<&crate::bundle::ResolvedItems>,
+) -> Result<InstallReport> {
     install_from_git_url(
         &github_authenticated_url(repo)?,
         repo.git_ref.as_deref(),
@@ -781,10 +814,15 @@ fn install_from_github(repo: &GithubRepo, target: &Path) -> Result<InstallReport
         &repo.owner,
         &repo.name,
         target,
+        filter,
     )
 }
 
-fn install_from_gitlab(repo: &GitlabRepo, target: &Path) -> Result<InstallReport> {
+fn install_from_gitlab(
+    repo: &GitlabRepo,
+    target: &Path,
+    filter: Option<&crate::bundle::ResolvedItems>,
+) -> Result<InstallReport> {
     install_from_git_url(
         &gitlab_authenticated_url(repo)?,
         repo.git_ref.as_deref(),
@@ -792,6 +830,7 @@ fn install_from_gitlab(repo: &GitlabRepo, target: &Path) -> Result<InstallReport
         &repo.owner,
         &repo.name,
         target,
+        filter,
     )
 }
 
@@ -920,13 +959,14 @@ pub fn install_from_git_url(
     owner: &str,
     name: &str,
     target: &Path,
+    filter: Option<&crate::bundle::ResolvedItems>,
 ) -> Result<InstallReport> {
     let tmp = tempfile::tempdir().context("create temp dir for clone")?;
     fetch::shallow_clone(url, git_ref, "clone", tmp.path())
         .map_err(|e| anyhow!("git clone {}: {}", url, e))?;
     let source = fetch::resolve_subfolder(&tmp.path().join("clone"), subfolder, owner, name)
         .map_err(|e| anyhow!("{}", e))?;
-    install_from_local_path(&source, target)
+    install_from_local_path(&source, target, filter)
 }
 
 fn install_skills(

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -88,3 +88,75 @@ fn add_invalid_source_returns_usage_error() {
         .failure()
         .code(2);
 }
+
+#[test]
+fn add_with_items_subset_installs_only_named_items() {
+    // Spec §2.1: `upskill add <source> [items...]` filters the install
+    // to a subset. Pick the skill (`create-api-endpoint`) and one rule
+    // (`license-awareness`); leave the agent and the second rule out.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args([
+            "add",
+            source.to_str().unwrap(),
+            "create-api-endpoint",
+            "license-awareness",
+        ])
+        .assert()
+        .success();
+
+    // Selected items are present.
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists()
+    );
+    assert!(target.join(".claude/rules/license-awareness.md").exists());
+    // Non-selected items are absent (skipped during the filtered walk).
+    assert!(
+        !target.join(".claude/agents/security-reviewer.md").exists(),
+        "agent should not have been installed when not in the subset"
+    );
+    assert!(
+        !target.join(".claude/rules/api-conventions.md").exists(),
+        "second rule should not have been installed when not in the subset"
+    );
+}
+
+#[test]
+fn add_with_items_no_match_is_general_error() {
+    // No name in the list matches anything in the source — the install
+    // should refuse rather than silently emitting nothing.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args([
+            "add",
+            source.to_str().unwrap(),
+            "nope-not-real",
+            "also-fictional",
+        ])
+        .assert()
+        .failure()
+        .code(1);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("nope-not-real") || stderr.contains("no matching"),
+        "stderr should name the missing items or say no match: {stderr}"
+    );
+}

--- a/tests/pipeline_local.rs
+++ b/tests/pipeline_local.rs
@@ -61,7 +61,7 @@ fn install_writes_per_client_output_for_all_kinds() {
     let target = tmp.path().join("target");
     stage_source(&source);
 
-    let report: InstallReport = install_from_local_path(&source, &target).expect("install");
+    let report: InstallReport = install_from_local_path(&source, &target, None).expect("install");
 
     // Skill — written to .claude/skills/<n>/SKILL.md, .github/skills/<n>/SKILL.md,
     // .agents/skills/<n>/SKILL.md (opencode canonical-store).
@@ -147,10 +147,10 @@ fn install_is_idempotent() {
     let target = tmp.path().join("target");
     stage_source(&source);
 
-    install_from_local_path(&source, &target).expect("install 1");
+    install_from_local_path(&source, &target, None).expect("install 1");
     let snapshot = read_target_tree(&target);
 
-    install_from_local_path(&source, &target).expect("install 2");
+    install_from_local_path(&source, &target, None).expect("install 2");
     let snapshot2 = read_target_tree(&target);
 
     assert_eq!(snapshot, snapshot2, "second install must be byte-identical");
@@ -203,7 +203,7 @@ Hello.
     )
     .unwrap();
 
-    upskill::pipeline::install_from_local_path(&source, &target).expect("install");
+    upskill::pipeline::install_from_local_path(&source, &target, None).expect("install");
 
     assert!(
         target

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -43,7 +43,8 @@ fn install_writes_lockfile_at_target_root() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
+        .expect("install");
 
     let lock_path = target.join(".upskill-lock.json");
     assert!(
@@ -91,12 +92,14 @@ fn re_install_upserts_existing_entries() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install 1");
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
+        .expect("install 1");
     let lock1: Lockfile =
         serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
             .unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install 2");
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
+        .expect("install 2");
     let lock2: Lockfile =
         serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
             .unwrap();
@@ -127,7 +130,8 @@ fn install_preserves_unrelated_existing_entries() {
     });
     seed.save(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
+        .expect("install");
 
     let lock = Lockfile::load(&target).expect("load");
     // 4 from the install + 1 pre-seeded = 5.
@@ -149,7 +153,8 @@ fn install_creates_claude_bridge_when_absent() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
+        .expect("install");
 
     let claude_md = target.join("CLAUDE.md");
     assert!(claude_md.exists(), "CLAUDE.md must be created");
@@ -166,7 +171,8 @@ fn install_registers_opencode_rules_glob_when_rules_present() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
+        .expect("install");
 
     let raw = fs::read_to_string(target.join("opencode.json")).expect("opencode.json present");
     let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -189,7 +195,8 @@ fn install_registers_vscode_instructions_location_when_rules_present() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
+        .expect("install");
 
     let raw = fs::read_to_string(target.join(".vscode/settings.json"))
         .expect(".vscode/settings.json present");
@@ -215,7 +222,8 @@ fn install_preserves_existing_claude_bridge() {
     let user_content = "# Project CLAUDE.md\n\n@AGENTS.md\n\nExtra project notes here.\n";
     fs::write(target.join("CLAUDE.md"), user_content).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
+        .expect("install");
 
     assert_eq!(
         fs::read_to_string(target.join("CLAUDE.md")).unwrap(),

--- a/tests/pipeline_source.rs
+++ b/tests/pipeline_source.rs
@@ -49,7 +49,8 @@ fn install_from_source_local_path() {
     stage_source(&source);
 
     let report: InstallReport =
-        install_from_source(&InstallSource::LocalPath(source.clone()), &target).expect("install");
+        install_from_source(&InstallSource::LocalPath(source.clone()), &target, None)
+            .expect("install");
 
     // Same expectation as the local-path direct test: 12 outputs.
     assert_eq!(report.items.len(), 12);
@@ -141,8 +142,9 @@ fn install_from_source_clones_local_bare_repo_via_file_url() {
     let target = tmp.path().join("target");
     let url = format!("file://{}", bare.display());
 
-    let report = upskill::pipeline::install_from_git_url(&url, None, None, "test", "ssot", &target)
-        .expect("install via git url");
+    let report =
+        upskill::pipeline::install_from_git_url(&url, None, None, "test", "ssot", &target, None)
+            .expect("install via git url");
 
     assert_eq!(report.items.len(), 12);
     assert!(
@@ -209,6 +211,7 @@ fn install_from_source_clone_subfolder() {
         "test",
         "ssot",
         &target,
+        None,
     )
     .expect("install via git url with subfolder");
 
@@ -262,8 +265,9 @@ fn re_install_after_upstream_push_picks_up_new_content() {
     git(&["push"], Some(&work));
 
     // First install — captures original SSOT hashes per (kind, name).
-    let first = upskill::pipeline::install_from_git_url(&url, None, None, "test", "ssot", &target)
-        .expect("first install");
+    let first =
+        upskill::pipeline::install_from_git_url(&url, None, None, "test", "ssot", &target, None)
+            .expect("first install");
     let original_hashes: std::collections::BTreeMap<(_, _), _> = first
         .items
         .iter()
@@ -290,8 +294,9 @@ fn re_install_after_upstream_push_picks_up_new_content() {
 
     // Second install from the same URL — must clone the new commit and
     // emit changed content.
-    let second = upskill::pipeline::install_from_git_url(&url, None, None, "test", "ssot", &target)
-        .expect("second install");
+    let second =
+        upskill::pipeline::install_from_git_url(&url, None, None, "test", "ssot", &target, None)
+            .expect("second install");
 
     // The mutated skill's hash must differ; an unrelated rule's hash
     // must not.


### PR DESCRIPTION
## Summary

Spec §2.1 promised `upskill add <source> [items...]` but the CLI's
`Add` only took `source: String`. The pipeline already knew how to
filter — `install_skills/rules/agents` accept an
`Option<&ResolvedItems>` — it just had no caller.

- Adds `items: Vec<String>` to `Commands::Add` (positional, optional).
- Plumbs `Option<&ResolvedItems>` through the install path:
  `install_from_local_path`, `install_from_source`,
  `install_from_github`, `install_from_gitlab`, and
  `install_from_git_url` all gain a trailing `filter` arg.
- `install_with_lockfile` takes `items: &[String]`. Empty means
  "install everything" (the historical default; `update()` passes
  `&[]`). Non-empty builds a `ResolvedItems` with each name copied
  into all three buckets, so the per-kind walks naturally skip
  unrelated kinds.
- A non-empty filter that yields zero installed items returns
  `no matching items in source for: <names>` (general error / exit 1).

## Test plan

- [x] 2 new ATDD cases in `tests/cli_add.rs`:
      - subset install (`add <src> create-api-endpoint license-awareness`)
        installs only the named items, leaves siblings alone.
      - all-misses install errors with exit 1 and names the misses.
- [x] All existing pipeline / lockfile / source tests still pass after
      the signature changes (each call site was updated).
- [x] `just verify` (fmt, clippy `-D warnings`, full test suite,
      build).

Closes #124
