### PR TITLE
feat: curl|sh installer and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,17 @@ jobs:
           chmod +x /usr/local/bin/convco
       - run: convco check ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: shellcheck install.sh
+
   ci:
     name: CI
     if: always()
-    needs: [fmt, clippy, test, convco]
+    needs: [fmt, clippy, test, convco, shellcheck]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: false
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            cross: false
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            cross: false
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - name: Build (cargo)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          archive="upskill-${{ matrix.target }}.tar.gz"
+          tar czf "dist/${archive}" -C "target/${{ matrix.target }}/release" upskill
+          ( cd dist && shasum -a 256 "${archive}" > "${archive}.sha256" )
+      - uses: actions/upload-artifact@v4
+        with:
+          name: upskill-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ No Node.js. No npm. No runtime dependencies.
 ## Install (consumer)
 
 ```bash
+# Linux / macOS (Windows: run inside WSL)
+curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+
+# Or, with a Rust toolchain:
 cargo install upskill
 
 # Install everything from a source repo (auto-fans out to .claude/, .github/, .agents/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,10 +3,21 @@
 ## Install
 
 ```bash
+# Linux / macOS (Windows: run inside WSL)
+curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+```
+
+`UPSKILL_VERSION` pins a release tag (default: latest) and
+`UPSKILL_INSTALL_DIR` overrides the install location (default
+`$HOME/.local/bin`). Windows users run the same command inside WSL.
+
+With a Rust toolchain instead:
+
+```bash
 cargo install upskill
 ```
 
-Or download a pre-built binary from the [releases page][releases].
+Or download a pre-built binary directly from the [releases page][releases].
 
 `upskill` is a single static binary with no runtime dependencies.
 

--- a/docs/superpowers/plans/2026-05-16-install-script.md
+++ b/docs/superpowers/plans/2026-05-16-install-script.md
@@ -1,0 +1,662 @@
+# install.sh + Release Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `curl … | sh` install path for `upskill` backed by a GitHub Releases workflow that builds a 4-target prebuilt-binary matrix.
+
+**Architecture:** A POSIX `install.sh` at the repo root detects OS/arch, downloads the matching `.tar.gz` from GitHub Releases (using the `releases/latest/download` redirect, or a pinned tag via `UPSKILL_VERSION`), verifies a sha256 sidecar, and installs the binary to `$HOME/.local/bin`. A tag-triggered `release.yml` builds `x86_64`/`aarch64` for Linux (musl, static) and macOS, archives each, writes checksums, and publishes them with `softprops/action-gh-release`. Windows is covered via WSL (Linux path) — no native Windows artifact.
+
+**Tech Stack:** POSIX `sh`, `shellcheck`, GitHub Actions (`dtolnay/rust-toolchain`, `taiki-e/install-action` for `cross`, `softprops/action-gh-release`), Rust integration tests (`assert_cmd` + `predicates` + `tempfile`).
+
+Spec: `docs/superpowers/specs/2026-05-16-install-script-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `install.sh` | POSIX installer: detect platform, download, verify, install | Create (repo root) |
+| `tests/cli_install.rs` | ATDD: `--help` and unsupported-platform behavior | Create |
+| `.github/workflows/release.yml` | Tag-triggered build matrix + release publish | Create |
+| `justfile` | Add `shellcheck install.sh` to the `lint` recipe | Modify |
+| `.github/workflows/ci.yml` | Add `shellcheck` job; add it to the `ci` gate | Modify |
+| `README.md` | Add the `curl` one-liner above `cargo install` | Modify (lines 15-16) |
+| `docs/getting-started.md` | Add the `curl` one-liner + env-var note | Modify (lines 3-11) |
+| `docs/superpowers/specs/2026-05-16-install-script-design.md` | Flip `Status` to approved | Modify (line 4) |
+
+---
+
+## Task 0: Tooling — ensure `shellcheck` is available
+
+`shellcheck` is not installed in the dev environment but is required by the
+new `lint` step and CI. Install it once before doing script work.
+
+**Files:** none.
+
+- [ ] **Step 1: Install shellcheck**
+
+Run:
+
+```bash
+sudo apt-get update && sudo apt-get install -y shellcheck
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Verify it runs**
+
+Run:
+
+```bash
+shellcheck --version
+```
+
+Expected: prints `ShellCheck - shell script analysis tool` and a version line.
+
+No commit (environment-only change).
+
+---
+
+## Task 1: ATDD tests for `install.sh`
+
+Write the acceptance tests first. They will fail because `install.sh` does
+not exist yet.
+
+**Files:**
+
+- Create: `tests/cli_install.rs`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `tests/cli_install.rs` with exactly this content:
+
+```rust
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+fn install_sh() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("install.sh")
+}
+
+#[test]
+fn help_flag_prints_usage_and_exits_zero() {
+    Command::new("sh")
+        .arg(install_sh())
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(contains("Usage"))
+        .stdout(contains("UPSKILL_VERSION"));
+}
+
+#[test]
+fn unsupported_platform_fails_with_cargo_hint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fake_uname = tmp.path().join("uname");
+    fs::write(
+        &fake_uname,
+        "#!/bin/sh\ncase \"$1\" in\n  -s) echo Linux ;;\n  -m) echo riscv64 ;;\n  *) echo unknown ;;\nesac\n",
+    )
+    .unwrap();
+    let mut perm = fs::metadata(&fake_uname).unwrap().permissions();
+    perm.set_mode(0o755);
+    fs::set_permissions(&fake_uname, perm).unwrap();
+
+    let orig_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", tmp.path().display(), orig_path);
+
+    Command::new("sh")
+        .arg(install_sh())
+        .env("PATH", new_path)
+        .assert()
+        .failure()
+        .stderr(contains("cargo install upskill"));
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --test cli_install
+```
+
+Expected: FAIL — both tests error because `sh` cannot open `install.sh`
+(`No such file or directory`), so the commands do not succeed / do not emit
+the expected output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/cli_install.rs
+git commit -m "test: add ATDD coverage for install.sh"
+```
+
+---
+
+## Task 2: Implement `install.sh`
+
+Make Task 1's tests pass and keep the script `shellcheck`-clean.
+
+**Files:**
+
+- Create: `install.sh`
+
+- [ ] **Step 1: Write the script**
+
+Create `install.sh` at the repo root with exactly this content:
+
+```sh
+#!/bin/sh
+# upskill installer — downloads a prebuilt release binary.
+#
+#   curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+#
+# Windows users: run this inside WSL.
+set -eu
+
+REPO="driftsys/upskill"
+BIN="upskill"
+INSTALL_DIR="${UPSKILL_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${UPSKILL_VERSION:-latest}"
+
+usage() {
+    cat <<EOF
+upskill installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh
+
+Environment:
+  UPSKILL_VERSION       Release tag to install (default: latest)
+  UPSKILL_INSTALL_DIR   Install directory (default: \$HOME/.local/bin)
+
+Options:
+  --help, -h            Show this help and exit
+EOF
+}
+
+err() {
+    echo "install.sh: $*" >&2
+    exit 1
+}
+
+download() {
+    # $1 = url, $2 = destination path
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$1" -o "$2"
+    else
+        wget -q "$1" -O "$2"
+    fi
+}
+
+verify() {
+    # $1 = checksum file (sibling archive must be in the cwd)
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c "$1"
+    else
+        shasum -a 256 -c "$1"
+    fi
+}
+
+for arg in "$@"; do
+    case "$arg" in
+    --help | -h)
+        usage
+        exit 0
+        ;;
+    *)
+        err "unknown argument: $arg (try --help)"
+        ;;
+    esac
+done
+
+os="$(uname -s)"
+arch="$(uname -m)"
+case "${os}/${arch}" in
+Linux/x86_64) target="x86_64-unknown-linux-musl" ;;
+Linux/aarch64 | Linux/arm64) target="aarch64-unknown-linux-musl" ;;
+Darwin/x86_64) target="x86_64-apple-darwin" ;;
+Darwin/arm64) target="aarch64-apple-darwin" ;;
+*) err "no prebuilt binary for ${os}/${arch}; install with: cargo install upskill" ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+    err "need curl or wget to download releases"
+fi
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+    err "need sha256sum or shasum to verify the download"
+fi
+
+asset="${BIN}-${target}.tar.gz"
+if [ "$VERSION" = "latest" ]; then
+    base="https://github.com/${REPO}/releases/latest/download"
+else
+    base="https://github.com/${REPO}/releases/download/${VERSION}"
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+echo "Downloading ${asset} (${VERSION})..." >&2
+download "${base}/${asset}" "${tmp}/${asset}" ||
+    err "download failed: ${base}/${asset}"
+download "${base}/${asset}.sha256" "${tmp}/${asset}.sha256" ||
+    err "checksum download failed: ${base}/${asset}.sha256"
+
+echo "Verifying checksum..." >&2
+(cd "$tmp" && verify "${asset}.sha256") >/dev/null 2>&1 ||
+    err "checksum verification failed for ${asset}"
+
+tar -xzf "${tmp}/${asset}" -C "$tmp"
+mkdir -p "$INSTALL_DIR"
+mv "${tmp}/${BIN}" "${INSTALL_DIR}/${BIN}"
+chmod +x "${INSTALL_DIR}/${BIN}"
+
+echo "Installed ${BIN} to ${INSTALL_DIR}/${BIN}" >&2
+case ":${PATH}:" in
+*":${INSTALL_DIR}:"*) ;;
+*)
+    echo "Note: ${INSTALL_DIR} is not on your PATH. Add it with:" >&2
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\"" >&2
+    ;;
+esac
+
+"${INSTALL_DIR}/${BIN}" --version
+```
+
+- [ ] **Step 2: Lint the script**
+
+Run:
+
+```bash
+shellcheck install.sh
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Run the ATDD tests to verify they pass**
+
+Run:
+
+```bash
+cargo test --test cli_install
+```
+
+Expected: PASS — `help_flag_prints_usage_and_exits_zero` and
+`unsupported_platform_fails_with_cargo_hint` both pass (2 passed).
+
+- [ ] **Step 4: Make the script executable and commit**
+
+```bash
+chmod +x install.sh
+git add install.sh
+git commit -m "feat: add install.sh release-binary installer"
+```
+
+---
+
+## Task 3: Wire `shellcheck` into `lint` and CI
+
+**Files:**
+
+- Modify: `justfile` (the `lint` recipe)
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add shellcheck to the `lint` recipe**
+
+In `justfile`, replace this block:
+
+```text
+# Lint and format check
+lint:
+    cargo clippy -- -D warnings
+    cargo fmt -- --check
+    dprint check
+    npx markdownlint-cli '**/*.md' --ignore node_modules
+```
+
+with:
+
+```text
+# Lint and format check
+lint:
+    cargo clippy -- -D warnings
+    cargo fmt -- --check
+    dprint check
+    npx markdownlint-cli '**/*.md' --ignore node_modules
+    shellcheck install.sh
+```
+
+- [ ] **Step 2: Add a `shellcheck` job to CI and add it to the gate**
+
+In `.github/workflows/ci.yml`, add this job immediately after the `convco`
+job and before the `ci` job:
+
+```yaml
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: shellcheck install.sh
+```
+
+Then change the `ci` job's `needs` line from:
+
+```yaml
+    needs: [fmt, clippy, test, convco]
+```
+
+to:
+
+```yaml
+    needs: [fmt, clippy, test, convco, shellcheck]
+```
+
+- [ ] **Step 3: Verify the lint recipe passes**
+
+Run:
+
+```bash
+just lint
+```
+
+Expected: exit 0 (clippy, fmt, dprint, markdownlint, and `shellcheck install.sh` all pass).
+
+- [ ] **Step 4: Validate the CI YAML parses**
+
+Run:
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('ok')"
+```
+
+Expected: prints `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add justfile .github/workflows/ci.yml
+git commit -m "chore: enforce shellcheck on install.sh in lint and CI"
+```
+
+---
+
+## Task 4: Release workflow
+
+**Files:**
+
+- Create: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/release.yml` with exactly this content:
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: false
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            cross: false
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            cross: false
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - name: Build (cargo)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          archive="upskill-${{ matrix.target }}.tar.gz"
+          tar czf "dist/${archive}" -C "target/${{ matrix.target }}/release" upskill
+          ( cd dist && shasum -a 256 "${archive}" > "${archive}.sha256" )
+      - uses: actions/upload-artifact@v4
+        with:
+          name: upskill-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+Run:
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('ok')"
+```
+
+Expected: prints `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: add tag-triggered release workflow (4-target matrix)"
+```
+
+---
+
+## Task 5: Documentation
+
+**Files:**
+
+- Modify: `README.md` (the `## Install (consumer)` code block, lines 15-16)
+- Modify: `docs/getting-started.md` (the `## Install` section, lines 3-11)
+
+- [ ] **Step 1: Update README install block**
+
+`README.md` line 16 is `cargo install upskill` inside a `bash` fence that
+continues with more commands. This is a pure **insertion** of three lines
+directly above line 16 — do not touch any line below it.
+
+Find this exact line (it is the first line inside the ```` ```bash ```` fence
+under `## Install (consumer)`):
+
+```text
+cargo install upskill
+```
+
+and replace just that line with:
+
+```text
+# Linux / macOS (Windows: run inside WSL)
+curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+
+# Or, with a Rust toolchain:
+cargo install upskill
+```
+
+The blank line and the `# Install everything from a source repo …` content
+that already follow `cargo install upskill` stay exactly as they are.
+
+- [ ] **Step 2: Update getting-started install section**
+
+In `docs/getting-started.md`, replace this exact block:
+
+```text
+## Install
+
+```bash
+cargo install upskill
+```
+
+Or download a pre-built binary from the [releases page][releases].
+
+`upskill` is a single static binary with no runtime dependencies.
+```
+
+with:
+
+```text
+## Install
+
+```bash
+# Linux / macOS (Windows: run inside WSL)
+curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+```
+
+`UPSKILL_VERSION` pins a release tag (default: latest) and
+`UPSKILL_INSTALL_DIR` overrides the install location (default
+`$HOME/.local/bin`). Windows users run the same command inside WSL.
+
+With a Rust toolchain instead:
+
+```bash
+cargo install upskill
+```
+
+Or download a pre-built binary directly from the [releases page][releases].
+
+`upskill` is a single static binary with no runtime dependencies.
+```
+
+(The `[releases]:` link reference at the bottom of the file stays as-is.)
+
+- [ ] **Step 3: Format and lint the docs**
+
+Run:
+
+```bash
+dprint fmt && npx markdownlint-cli '**/*.md' --ignore node_modules
+```
+
+Expected: exit 0, no markdownlint errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/getting-started.md
+git commit -m "docs: document curl|sh installer and env vars"
+```
+
+---
+
+## Task 6: Finalize
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-05-16-install-script-design.md` (line 4)
+
+- [ ] **Step 1: Flip the spec status**
+
+In `docs/superpowers/specs/2026-05-16-install-script-design.md`, change:
+
+```text
+Status: Approved (pending spec review)
+```
+
+to:
+
+```text
+Status: Approved
+```
+
+- [ ] **Step 2: Run the full local verification**
+
+Run:
+
+```bash
+cargo test && just lint
+```
+
+Expected: all tests pass; `just lint` exits 0 (clippy, fmt, dprint,
+markdownlint, shellcheck).
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add docs/superpowers/specs/2026-05-16-install-script-design.md
+git commit -m "docs(spec): mark install-script design approved"
+git push -u origin claude/add-install-script-eZubT
+```
+
+Expected: push succeeds. PR #135 already exists for this branch — do **not**
+open a new PR. The active PR-activity subscription will report CI status;
+investigate and fix any failure on PR #135.
+
+---
+
+## Notes for the implementer
+
+- The release workflow only runs on `v*` tag pushes / manual dispatch; it
+  will **not** run on the PR. Its correctness is verified by the first real
+  `just release` (out of scope for this PR) — within this PR, the YAML-parse
+  check in Task 4 Step 2 is the gate.
+- `install.sh`'s download/verify/install path needs a published release to
+  exercise end-to-end; the ATDD tests deliberately cover only the offline
+  paths (`--help`, unsupported platform) so they need no network.
+- `cross` (Task 4) runs the aarch64-musl build in a Docker container;
+  `ubuntu-latest` runners provide Docker. `shasum -a 256` exists on both
+  `ubuntu-latest` and `macos-latest`, so the packaging step is uniform.
+- Keep commits Conventional (`feat`, `test`, `chore`, `ci`, `docs`) — the
+  `convco` CI job checks the PR commit range.

--- a/docs/superpowers/plans/2026-05-16-install-script.md
+++ b/docs/superpowers/plans/2026-05-16-install-script.md
@@ -14,16 +14,16 @@ Spec: `docs/superpowers/specs/2026-05-16-install-script-design.md`
 
 ## File Structure
 
-| File | Responsibility | Action |
-| --- | --- | --- |
-| `install.sh` | POSIX installer: detect platform, download, verify, install | Create (repo root) |
-| `tests/cli_install.rs` | ATDD: `--help` and unsupported-platform behavior | Create |
-| `.github/workflows/release.yml` | Tag-triggered build matrix + release publish | Create |
-| `justfile` | Add `shellcheck install.sh` to the `lint` recipe | Modify |
-| `.github/workflows/ci.yml` | Add `shellcheck` job; add it to the `ci` gate | Modify |
-| `README.md` | Add the `curl` one-liner above `cargo install` | Modify (lines 15-16) |
-| `docs/getting-started.md` | Add the `curl` one-liner + env-var note | Modify (lines 3-11) |
-| `docs/superpowers/specs/2026-05-16-install-script-design.md` | Flip `Status` to approved | Modify (line 4) |
+| File                                                         | Responsibility                                              | Action               |
+| ------------------------------------------------------------ | ----------------------------------------------------------- | -------------------- |
+| `install.sh`                                                 | POSIX installer: detect platform, download, verify, install | Create (repo root)   |
+| `tests/cli_install.rs`                                       | ATDD: `--help` and unsupported-platform behavior            | Create               |
+| `.github/workflows/release.yml`                              | Tag-triggered build matrix + release publish                | Create               |
+| `justfile`                                                   | Add `shellcheck install.sh` to the `lint` recipe            | Modify               |
+| `.github/workflows/ci.yml`                                   | Add `shellcheck` job; add it to the `ci` gate               | Modify               |
+| `README.md`                                                  | Add the `curl` one-liner above `cargo install`              | Modify (lines 15-16) |
+| `docs/getting-started.md`                                    | Add the `curl` one-liner + env-var note                     | Modify (lines 3-11)  |
+| `docs/superpowers/specs/2026-05-16-install-script-design.md` | Flip `Status` to approved                                   | Modify (line 4)      |
 
 ---
 
@@ -339,27 +339,28 @@ lint:
 - [ ] **Step 2: Add a `shellcheck` job to CI and add it to the gate**
 
 In `.github/workflows/ci.yml`, add this job immediately after the `convco`
-job and before the `ci` job:
+job and before the `ci` job (2-space job-key indentation, matching the
+other jobs):
 
 ```yaml
-  shellcheck:
-    name: ShellCheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - run: shellcheck install.sh
+shellcheck:
+  name: ShellCheck
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v6
+    - run: shellcheck install.sh
 ```
 
 Then change the `ci` job's `needs` line from:
 
 ```yaml
-    needs: [fmt, clippy, test, convco]
+needs: [fmt, clippy, test, convco]
 ```
 
 to:
 
 ```yaml
-    needs: [fmt, clippy, test, convco, shellcheck]
+needs: [fmt, clippy, test, convco, shellcheck]
 ```
 
 - [ ] **Step 3: Verify the lint recipe passes**
@@ -515,18 +516,18 @@ git commit -m "ci: add tag-triggered release workflow (4-target matrix)"
 
 - [ ] **Step 1: Update README install block**
 
-`README.md` line 16 is `cargo install upskill` inside a `bash` fence that
+`README.md` line 16 is `cargo install upskill` inside a bash fence that
 continues with more commands. This is a pure **insertion** of three lines
 directly above line 16 — do not touch any line below it.
 
-Find this exact line (it is the first line inside the ```` ```bash ```` fence
-under `## Install (consumer)`):
+Find this exact line (the first line inside the bash fence under
+`## Install (consumer)`):
 
 ```text
 cargo install upskill
 ```
 
-and replace just that line with:
+and replace just that one line with these four lines:
 
 ```text
 # Linux / macOS (Windows: run inside WSL)
@@ -541,9 +542,10 @@ that already follow `cargo install upskill` stay exactly as they are.
 
 - [ ] **Step 2: Update getting-started install section**
 
-In `docs/getting-started.md`, replace this exact block:
+In `docs/getting-started.md`, replace this exact block (it is the entire
+current `## Install` section, lines 3-11):
 
-```text
+````text
 ## Install
 
 ```bash
@@ -553,11 +555,11 @@ cargo install upskill
 Or download a pre-built binary from the [releases page][releases].
 
 `upskill` is a single static binary with no runtime dependencies.
-```
+````
 
-with:
+with this block:
 
-```text
+````text
 ## Install
 
 ```bash
@@ -578,9 +580,9 @@ cargo install upskill
 Or download a pre-built binary directly from the [releases page][releases].
 
 `upskill` is a single static binary with no runtime dependencies.
-```
+````
 
-(The `[releases]:` link reference at the bottom of the file stays as-is.)
+The `[releases]:` link reference at the bottom of the file stays as-is.
 
 - [ ] **Step 3: Format and lint the docs**
 

--- a/docs/superpowers/specs/2026-05-16-install-script-design.md
+++ b/docs/superpowers/specs/2026-05-16-install-script-design.md
@@ -1,7 +1,7 @@
 # Design: `install.sh` + release workflow
 
 Date: 2026-05-16
-Status: Approved (pending spec review)
+Status: Approved
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-05-16-install-script-design.md
+++ b/docs/superpowers/specs/2026-05-16-install-script-design.md
@@ -1,4 +1,4 @@
-# Design: `install.sh` / `install.ps1` + release workflow
+# Design: `install.sh` + release workflow
 
 Date: 2026-05-16
 Status: Approved (pending spec review)
@@ -8,29 +8,32 @@ Status: Approved (pending spec review)
 `upskill` ships as a single static binary, but the only documented install
 paths are `cargo install upskill` (requires a Rust toolchain) and an
 unpopulated GitHub Releases page. There is no `curl | sh` one-liner, no
-Windows installer, no GitHub Releases, and no release CI. Users on a fresh
-machine cannot get the binary without Rust.
+GitHub Releases, and no release CI. Users on a fresh machine cannot get the
+binary without Rust.
 
-Goal: a best-practice `curl | sh` (Unix) and `irm | iex` (Windows) install
-experience backed by real release artifacts, documented in the README and
-getting-started guide.
+Goal: a best-practice `curl | sh` install experience backed by real release
+artifacts, documented in the README and getting-started guide.
 
 ## Scope
 
+Native Windows is intentionally **out of scope**: Windows users run
+`upskill` under WSL, which is Linux and is fully covered by `install.sh` +
+the Linux musl binary.
+
 In scope:
 
-- `install.sh` (POSIX `sh`) at repo root — Linux + macOS.
-- `install.ps1` (PowerShell 5+) at repo root — Windows.
-- `.github/workflows/release.yml` building a 6-target matrix and publishing
+- `install.sh` (POSIX `sh`) at repo root — Linux (incl. WSL) + macOS.
+- `.github/workflows/release.yml` building a 4-target matrix and publishing
   GitHub Releases.
-- README + `docs/getting-started.md` updated with the curl/irm one-liners.
-- Lint + ATDD coverage for the scripts.
+- README + `docs/getting-started.md` updated with the curl one-liner.
+- Lint + ATDD coverage for the script.
 
 Out of scope:
 
+- Native Windows installer / `*-pc-windows-msvc` targets — WSL covers
+  Windows via the Linux path. Revisit only if a non-WSL need appears.
 - Bundling man pages in release archives (`just man` already documents the
   generator; revisit later).
-- Native Windows ARM test execution (build-only is acceptable).
 - Homebrew tap / scoop manifest / distro packaging (future work).
 - Signing / notarization (future work).
 
@@ -46,26 +49,24 @@ Out of scope:
 - C: build from source via `cargo` — slow, needs a toolchain, defeats the
   static-binary value proposition. Rejected.
 
-**Release workflow shape:** a build matrix across runners (no single-job
-shortcut, since Windows/macOS need their own runners). `cross` is used only
-where native compilation is unavailable (Linux aarch64).
+**Release workflow shape:** a build matrix across runners (macOS needs its
+own runner). `cross` is used only where native compilation is unavailable
+(Linux aarch64).
 
-## Release target matrix — 6 artifacts
+## Release target matrix — 4 artifacts
 
-| OS      | Arch   | Rust target                   | Archive  | Binary        |
-| ------- | ------ | ----------------------------- | -------- | ------------- |
-| Linux   | x86_64 | `x86_64-unknown-linux-musl`   | `.tar.gz`| `upskill`     |
-| Linux   | arm64  | `aarch64-unknown-linux-musl`  | `.tar.gz`| `upskill`     |
-| macOS   | x86_64 | `x86_64-apple-darwin`         | `.tar.gz`| `upskill`     |
-| macOS   | arm64  | `aarch64-apple-darwin`        | `.tar.gz`| `upskill`     |
-| Windows | x86_64 | `x86_64-pc-windows-msvc`      | `.zip`   | `upskill.exe` |
-| Windows | arm64  | `aarch64-pc-windows-msvc`     | `.zip`   | `upskill.exe` |
+| OS    | Arch   | Rust target                  | Archive   | Binary    |
+| ----- | ------ | ---------------------------- | --------- | --------- |
+| Linux | x86_64 | `x86_64-unknown-linux-musl`  | `.tar.gz` | `upskill` |
+| Linux | arm64  | `aarch64-unknown-linux-musl` | `.tar.gz` | `upskill` |
+| macOS | x86_64 | `x86_64-apple-darwin`        | `.tar.gz` | `upskill` |
+| macOS | arm64  | `aarch64-apple-darwin`       | `.tar.gz` | `upskill` |
 
 Linux uses **musl** for a fully static binary that runs on any distro
-(Alpine, old glibc). Asset naming is fixed and shared by the installers and
-the workflow:
+(Alpine, old glibc) and under WSL. Asset naming is fixed and shared by the
+installer and the workflow:
 
-- Archive: `upskill-<target>.tar.gz` (Unix) / `upskill-<target>.zip` (Windows)
+- Archive: `upskill-<target>.tar.gz`
 - Checksum sidecar: `<archive-name>.sha256` (one line: `<sha256>  <archive>`)
 
 ## `install.sh` (POSIX `sh`, repo root)
@@ -104,27 +105,7 @@ Failure modes are explicit: unsupported platform, no downloader, download
 404 (release/asset missing), checksum mismatch — each prints a distinct
 stderr message and exits non-zero.
 
-## `install.ps1` (PowerShell 5+, repo root)
-
-Behavior mirrors `install.sh`:
-
-1. **Config:** `$env:UPSKILL_VERSION` (default latest),
-   `$env:UPSKILL_INSTALL_DIR` (default `$env:LOCALAPPDATA\upskill\bin`);
-   `-Help` switch.
-2. **Arch detection:** `$env:PROCESSOR_ARCHITECTURE` →
-   `AMD64`→`x86_64-pc-windows-msvc`, `ARM64`→`aarch64-pc-windows-msvc`;
-   else error + `cargo install upskill` hint.
-3. **Download:** `Invoke-WebRequest` archive `.zip` + `.sha256` to a temp
-   dir (`[System.IO.Path]::GetTempPath()` + GUID).
-4. **Verify:** `Get-FileHash -Algorithm SHA256` vs sidecar; mismatch →
-   `throw`.
-5. **Install:** `Expand-Archive`, ensure install dir, copy `upskill.exe`.
-6. **PATH:** if install dir not on the **user** `PATH`
-   (`[Environment]::GetEnvironmentVariable('Path','User')`), prepend it and
-   print a "restart your shell" hint.
-7. **Finish:** print installed version + path.
-
-`$ErrorActionPreference = 'Stop'`; clean temp dir in `finally`.
+Windows users run this under WSL; no PowerShell installer is provided.
 
 ## Release workflow (`.github/workflows/release.yml`)
 
@@ -140,43 +121,34 @@ Behavior mirrors `install.sh`:
   - `macos-latest` (arm64 runner): `aarch64-apple-darwin` native +
     `x86_64-apple-darwin` via `rustup target add` (Apple toolchain
     cross-compiles both).
-  - `windows-latest`: `x86_64-pc-windows-msvc` native +
-    `aarch64-pc-windows-msvc` via `rustup target add` (build-only).
 - **Per leg:** build with the existing release profile (`opt-level=z`,
-  `lto`, `strip`, `panic=abort`) → package archive (`.tar.gz` Unix, `.zip`
-  Windows) containing just the binary → write `<archive>.sha256` →
-  upload as a workflow artifact.
+  `lto`, `strip`, `panic=abort`) → package `.tar.gz` containing just the
+  binary → write `<archive>.sha256` → upload as a workflow artifact.
 - **Publish job:** downloads all artifacts, runs
-  `softprops/action-gh-release` on the tag with all 12 files (6 archives +
-  6 checksums) attached. Body autogenerated from the tag; release marked
+  `softprops/action-gh-release` on the tag with all 8 files (4 archives +
+  4 checksums) attached. Body autogenerated from the tag; release marked
   non-draft, non-prerelease.
 
 ## Documentation
 
 `README.md` "Install (consumer)" and `docs/getting-started.md` "Install"
-gain two primary one-liners, placed **above** `cargo install upskill`:
+gain one primary one-liner, placed **above** `cargo install upskill`:
 
 ```bash
-# Linux / macOS
+# Linux / macOS (Windows: run inside WSL)
 curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
 ```
 
-```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/driftsys/upskill/main/install.ps1 | iex
-```
-
-Followed by a short note: `UPSKILL_VERSION` pins a release,
-`UPSKILL_INSTALL_DIR` overrides the location, and `cargo install upskill`
-remains the fallback for unsupported platforms. The existing
-`docs/getting-started.md` releases-page link is kept.
+Followed by a short note: Windows users run the same command under WSL;
+`UPSKILL_VERSION` pins a release, `UPSKILL_INSTALL_DIR` overrides the
+location, and `cargo install upskill` remains the fallback for unsupported
+platforms. The existing `docs/getting-started.md` releases-page link is
+kept.
 
 ## Testing
 
 - **Lint:** add `shellcheck install.sh` to the `lint` recipe in `justfile`
-  and a `shellcheck` step in CI (zero-warnings policy). `install.ps1` gets
-  a PowerShell parse check (`[ScriptBlock]::Create`) where a runner is
-  available; otherwise lint is best-effort and not gated.
+  and a `shellcheck` step in CI (zero-warnings policy).
 - **ATDD (`tests/cli_install.rs`):**
   - `sh install.sh --help` → exit 0, usage text on stdout.
   - `install.sh` with a forced unsupported `uname` (via a stub on `PATH`)
@@ -186,12 +158,13 @@ remains the fallback for unsupported platforms. The existing
 
 ## Acceptance criteria
 
-1. `install.sh` and `install.ps1` exist at repo root and pass lint.
+1. `install.sh` exists at repo root and passes `shellcheck`.
 2. On a supported platform with a published release, the one-liner
    downloads, checksum-verifies, and installs a runnable `upskill`.
 3. Unsupported platform/arch fails fast with the cargo hint.
-4. Pushing a `v*` tag produces a GitHub Release with all 6 archives + 6
+4. Pushing a `v*` tag produces a GitHub Release with all 4 archives + 4
    checksums.
-5. README and getting-started document both one-liners and the env knobs.
+5. README and getting-started document the one-liner (incl. the WSL note
+   for Windows) and the env knobs.
 6. `just verify` passes (tests, clippy, fmt, dprint, markdownlint,
    shellcheck).

--- a/docs/superpowers/specs/2026-05-16-install-script-design.md
+++ b/docs/superpowers/specs/2026-05-16-install-script-design.md
@@ -1,0 +1,197 @@
+# Design: `install.sh` / `install.ps1` + release workflow
+
+Date: 2026-05-16
+Status: Approved (pending spec review)
+
+## Problem
+
+`upskill` ships as a single static binary, but the only documented install
+paths are `cargo install upskill` (requires a Rust toolchain) and an
+unpopulated GitHub Releases page. There is no `curl | sh` one-liner, no
+Windows installer, no GitHub Releases, and no release CI. Users on a fresh
+machine cannot get the binary without Rust.
+
+Goal: a best-practice `curl | sh` (Unix) and `irm | iex` (Windows) install
+experience backed by real release artifacts, documented in the README and
+getting-started guide.
+
+## Scope
+
+In scope:
+
+- `install.sh` (POSIX `sh`) at repo root — Linux + macOS.
+- `install.ps1` (PowerShell 5+) at repo root — Windows.
+- `.github/workflows/release.yml` building a 6-target matrix and publishing
+  GitHub Releases.
+- README + `docs/getting-started.md` updated with the curl/irm one-liners.
+- Lint + ATDD coverage for the scripts.
+
+Out of scope:
+
+- Bundling man pages in release archives (`just man` already documents the
+  generator; revisit later).
+- Native Windows ARM test execution (build-only is acceptable).
+- Homebrew tap / scoop manifest / distro packaging (future work).
+- Signing / notarization (future work).
+
+## Approaches considered
+
+**Release discovery in `install.sh`:**
+
+- **A (chosen):** GitHub `releases/latest/download/<asset>` redirect — zero
+  API calls, no rate limit, no JSON parsing. Pinning via
+  `UPSKILL_VERSION` switches to `releases/download/<tag>/<asset>`.
+- B: `api.github.com/.../releases/latest` + JSON parse — needs `jq` or
+  fragile `grep`, 60 req/hr unauthenticated rate limit. Rejected.
+- C: build from source via `cargo` — slow, needs a toolchain, defeats the
+  static-binary value proposition. Rejected.
+
+**Release workflow shape:** a build matrix across runners (no single-job
+shortcut, since Windows/macOS need their own runners). `cross` is used only
+where native compilation is unavailable (Linux aarch64).
+
+## Release target matrix — 6 artifacts
+
+| OS      | Arch   | Rust target                   | Archive  | Binary        |
+| ------- | ------ | ----------------------------- | -------- | ------------- |
+| Linux   | x86_64 | `x86_64-unknown-linux-musl`   | `.tar.gz`| `upskill`     |
+| Linux   | arm64  | `aarch64-unknown-linux-musl`  | `.tar.gz`| `upskill`     |
+| macOS   | x86_64 | `x86_64-apple-darwin`         | `.tar.gz`| `upskill`     |
+| macOS   | arm64  | `aarch64-apple-darwin`        | `.tar.gz`| `upskill`     |
+| Windows | x86_64 | `x86_64-pc-windows-msvc`      | `.zip`   | `upskill.exe` |
+| Windows | arm64  | `aarch64-pc-windows-msvc`     | `.zip`   | `upskill.exe` |
+
+Linux uses **musl** for a fully static binary that runs on any distro
+(Alpine, old glibc). Asset naming is fixed and shared by the installers and
+the workflow:
+
+- Archive: `upskill-<target>.tar.gz` (Unix) / `upskill-<target>.zip` (Windows)
+- Checksum sidecar: `<archive-name>.sha256` (one line: `<sha256>  <archive>`)
+
+## `install.sh` (POSIX `sh`, repo root)
+
+Constraints: no bashisms (no arrays, `[[ ]]`, `(( ))`), `set -eu`, runs
+under `dash`/`sh`/`bash`. Passes `shellcheck`.
+
+Behavior:
+
+1. **Config:** env `UPSKILL_VERSION` (default: latest),
+   `UPSKILL_INSTALL_DIR` (default `$HOME/.local/bin`); `--help` prints usage
+   and exits 0.
+2. **Platform detection:** `uname -s` + `uname -m` →
+   - `Linux`/`x86_64` → `x86_64-unknown-linux-musl`
+   - `Linux`/`aarch64`|`arm64` → `aarch64-unknown-linux-musl`
+   - `Darwin`/`x86_64` → `x86_64-apple-darwin`
+   - `Darwin`/`arm64` → `aarch64-apple-darwin`
+   - anything else → error to stderr, exit 1, message:
+     `no prebuilt binary for <os>/<arch>; install with: cargo install upskill`
+3. **Downloader:** prefer `curl -fsSL`, else `wget -qO-`; neither → error.
+4. **URL:** latest →
+   `https://github.com/driftsys/upskill/releases/latest/download/<asset>`;
+   pinned → `.../releases/download/$UPSKILL_VERSION/<asset>`.
+5. **Fetch:** download archive + `.sha256` into `mktemp -d`; `trap`
+   removes the temp dir on EXIT/INT/TERM.
+6. **Verify:** `sha256sum -c` or `shasum -a 256 -c`; mismatch → error,
+   exit 1.
+7. **Install:** extract, `mkdir -p "$UPSKILL_INSTALL_DIR"`, move `upskill`
+   into place (overwrite ok), `chmod +x`.
+8. **PATH check:** if install dir not found in `:$PATH:`, print a
+   shell-agnostic hint (`export PATH="<dir>:$PATH"`).
+9. **Finish:** run `"$UPSKILL_INSTALL_DIR/upskill" --version` and print the
+   resolved install path.
+
+Failure modes are explicit: unsupported platform, no downloader, download
+404 (release/asset missing), checksum mismatch — each prints a distinct
+stderr message and exits non-zero.
+
+## `install.ps1` (PowerShell 5+, repo root)
+
+Behavior mirrors `install.sh`:
+
+1. **Config:** `$env:UPSKILL_VERSION` (default latest),
+   `$env:UPSKILL_INSTALL_DIR` (default `$env:LOCALAPPDATA\upskill\bin`);
+   `-Help` switch.
+2. **Arch detection:** `$env:PROCESSOR_ARCHITECTURE` →
+   `AMD64`→`x86_64-pc-windows-msvc`, `ARM64`→`aarch64-pc-windows-msvc`;
+   else error + `cargo install upskill` hint.
+3. **Download:** `Invoke-WebRequest` archive `.zip` + `.sha256` to a temp
+   dir (`[System.IO.Path]::GetTempPath()` + GUID).
+4. **Verify:** `Get-FileHash -Algorithm SHA256` vs sidecar; mismatch →
+   `throw`.
+5. **Install:** `Expand-Archive`, ensure install dir, copy `upskill.exe`.
+6. **PATH:** if install dir not on the **user** `PATH`
+   (`[Environment]::GetEnvironmentVariable('Path','User')`), prepend it and
+   print a "restart your shell" hint.
+7. **Finish:** print installed version + path.
+
+`$ErrorActionPreference = 'Stop'`; clean temp dir in `finally`.
+
+## Release workflow (`.github/workflows/release.yml`)
+
+- **Trigger:** push of tags matching `v*` (matches `just release` →
+  `git std bump`), plus `workflow_dispatch`.
+- **Permissions:** `contents: write` (create release / upload assets).
+- **Build matrix:**
+  - `ubuntu-latest`: `x86_64-unknown-linux-musl` — `rustup target add` +
+    `sudo apt-get install -y musl-tools`, native `cargo build --release
+    --target`.
+  - `ubuntu-latest`: `aarch64-unknown-linux-musl` — via `cross`
+    (`cargo install cross` or the prebuilt action) for cross-compilation.
+  - `macos-latest` (arm64 runner): `aarch64-apple-darwin` native +
+    `x86_64-apple-darwin` via `rustup target add` (Apple toolchain
+    cross-compiles both).
+  - `windows-latest`: `x86_64-pc-windows-msvc` native +
+    `aarch64-pc-windows-msvc` via `rustup target add` (build-only).
+- **Per leg:** build with the existing release profile (`opt-level=z`,
+  `lto`, `strip`, `panic=abort`) → package archive (`.tar.gz` Unix, `.zip`
+  Windows) containing just the binary → write `<archive>.sha256` →
+  upload as a workflow artifact.
+- **Publish job:** downloads all artifacts, runs
+  `softprops/action-gh-release` on the tag with all 12 files (6 archives +
+  6 checksums) attached. Body autogenerated from the tag; release marked
+  non-draft, non-prerelease.
+
+## Documentation
+
+`README.md` "Install (consumer)" and `docs/getting-started.md` "Install"
+gain two primary one-liners, placed **above** `cargo install upskill`:
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/driftsys/upskill/main/install.ps1 | iex
+```
+
+Followed by a short note: `UPSKILL_VERSION` pins a release,
+`UPSKILL_INSTALL_DIR` overrides the location, and `cargo install upskill`
+remains the fallback for unsupported platforms. The existing
+`docs/getting-started.md` releases-page link is kept.
+
+## Testing
+
+- **Lint:** add `shellcheck install.sh` to the `lint` recipe in `justfile`
+  and a `shellcheck` step in CI (zero-warnings policy). `install.ps1` gets
+  a PowerShell parse check (`[ScriptBlock]::Create`) where a runner is
+  available; otherwise lint is best-effort and not gated.
+- **ATDD (`tests/cli_install.rs`):**
+  - `sh install.sh --help` → exit 0, usage text on stdout.
+  - `install.sh` with a forced unsupported `uname` (via a stub on `PATH`)
+    → non-zero exit, stderr contains `cargo install upskill`.
+- **Docs:** existing `dprint` + `markdownlint` cover the README and
+  getting-started edits.
+
+## Acceptance criteria
+
+1. `install.sh` and `install.ps1` exist at repo root and pass lint.
+2. On a supported platform with a published release, the one-liner
+   downloads, checksum-verifies, and installs a runnable `upskill`.
+3. Unsupported platform/arch fails fast with the cargo hint.
+4. Pushing a `v*` tag produces a GitHub Release with all 6 archives + 6
+   checksums.
+5. README and getting-started document both one-liners and the env knobs.
+6. `just verify` passes (tests, clippy, fmt, dprint, markdownlint,
+   shellcheck).

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+# upskill installer — downloads a prebuilt release binary.
+#
+#   curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+#
+# Windows users: run this inside WSL.
+set -eu
+
+REPO="driftsys/upskill"
+BIN="upskill"
+INSTALL_DIR="${UPSKILL_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${UPSKILL_VERSION:-latest}"
+
+usage() {
+    cat <<EOF
+upskill installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh
+
+Environment:
+  UPSKILL_VERSION       Release tag to install (default: latest)
+  UPSKILL_INSTALL_DIR   Install directory (default: \$HOME/.local/bin)
+
+Options:
+  --help, -h            Show this help and exit
+EOF
+}
+
+err() {
+    echo "install.sh: $*" >&2
+    exit 1
+}
+
+download() {
+    # $1 = url, $2 = destination path
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$1" -o "$2"
+    else
+        wget -q "$1" -O "$2"
+    fi
+}
+
+verify() {
+    # $1 = checksum file (sibling archive must be in the cwd)
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c "$1"
+    else
+        shasum -a 256 -c "$1"
+    fi
+}
+
+for arg in "$@"; do
+    case "$arg" in
+    --help | -h)
+        usage
+        exit 0
+        ;;
+    *)
+        err "unknown argument: $arg (try --help)"
+        ;;
+    esac
+done
+
+os="$(uname -s)"
+arch="$(uname -m)"
+case "${os}/${arch}" in
+Linux/x86_64) target="x86_64-unknown-linux-musl" ;;
+Linux/aarch64 | Linux/arm64) target="aarch64-unknown-linux-musl" ;;
+Darwin/x86_64) target="x86_64-apple-darwin" ;;
+Darwin/arm64) target="aarch64-apple-darwin" ;;
+*) err "no prebuilt binary for ${os}/${arch}; install with: cargo install upskill" ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+    err "need curl or wget to download releases"
+fi
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+    err "need sha256sum or shasum to verify the download"
+fi
+
+asset="${BIN}-${target}.tar.gz"
+if [ "$VERSION" = "latest" ]; then
+    base="https://github.com/${REPO}/releases/latest/download"
+else
+    base="https://github.com/${REPO}/releases/download/${VERSION}"
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+echo "Downloading ${asset} (${VERSION})..." >&2
+download "${base}/${asset}" "${tmp}/${asset}" ||
+    err "download failed: ${base}/${asset}"
+download "${base}/${asset}.sha256" "${tmp}/${asset}.sha256" ||
+    err "checksum download failed: ${base}/${asset}.sha256"
+
+echo "Verifying checksum..." >&2
+(cd "$tmp" && verify "${asset}.sha256") >/dev/null 2>&1 ||
+    err "checksum verification failed for ${asset}"
+
+tar -xzf "${tmp}/${asset}" -C "$tmp"
+mkdir -p "$INSTALL_DIR"
+mv "${tmp}/${BIN}" "${INSTALL_DIR}/${BIN}"
+chmod +x "${INSTALL_DIR}/${BIN}"
+
+echo "Installed ${BIN} to ${INSTALL_DIR}/${BIN}" >&2
+case ":${PATH}:" in
+*":${INSTALL_DIR}:"*) ;;
+*)
+    echo "Note: ${INSTALL_DIR} is not on your PATH. Add it with:" >&2
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\"" >&2
+    ;;
+esac
+
+"${INSTALL_DIR}/${BIN}" --version

--- a/justfile
+++ b/justfile
@@ -15,6 +15,7 @@ lint:
     cargo fmt -- --check
     dprint check
     npx markdownlint-cli '**/*.md' --ignore node_modules
+    shellcheck install.sh
 
 # Run all checks (test + lint)
 check: test lint

--- a/tests/cli_install.rs
+++ b/tests/cli_install.rs
@@ -1,0 +1,47 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+fn install_sh() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("install.sh")
+}
+
+#[test]
+fn help_flag_prints_usage_and_exits_zero() {
+    Command::new("sh")
+        .arg(install_sh())
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(contains("Usage"))
+        .stdout(contains("UPSKILL_VERSION"));
+}
+
+#[test]
+fn unsupported_platform_fails_with_cargo_hint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fake_uname = tmp.path().join("uname");
+    fs::write(
+        &fake_uname,
+        "#!/bin/sh\ncase \"$1\" in\n  -s) echo Linux ;;\n  -m) echo riscv64 ;;\n  *) echo unknown ;;\nesac\n",
+    )
+    .unwrap();
+    let mut perm = fs::metadata(&fake_uname).unwrap().permissions();
+    perm.set_mode(0o755);
+    fs::set_permissions(&fake_uname, perm).unwrap();
+
+    let orig_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", tmp.path().display(), orig_path);
+
+    Command::new("sh")
+        .arg(install_sh())
+        .env("PATH", new_path)
+        .assert()
+        .failure()
+        .stderr(contains("cargo install upskill"));
+}


### PR DESCRIPTION
## Summary

Adds a one-line install path for `upskill`, backed by a real GitHub Releases pipeline.

- **`install.sh`** (POSIX `sh`, repo root) — `curl -fsSL …/install.sh | sh`. Detects OS/arch, downloads the matching prebuilt `.tar.gz` from GitHub Releases (latest-download redirect, or pinned via `UPSKILL_VERSION`), verifies a sha256 sidecar, installs to `$HOME/.local/bin` (override via `UPSKILL_INSTALL_DIR`). Fails fast with a `cargo install upskill` hint on unsupported platforms. shellcheck-clean.
- **`.github/workflows/release.yml`** — tag-triggered (`v*`) + `workflow_dispatch`. 4-target matrix: Linux `x86_64`/`aarch64` (musl, fully static) + macOS `x86_64`/`aarch64`. Publishes 8 assets (4 archives + 4 `.sha256`) via `softprops/action-gh-release`.
- **CI** — new gating `ShellCheck` job; `shellcheck install.sh` added to `just lint`.
- **Docs** — README + getting-started lead with the `curl|sh` one-liner, document `UPSKILL_VERSION`/`UPSKILL_INSTALL_DIR`, and note Windows users run it under WSL.
- Native Windows is intentionally out of scope (WSL = the Linux path).

Built via spec → plan → subagent-driven TDD; every task passed independent spec + code-quality review, plus a final holistic review (READY TO MERGE, all 6 acceptance criteria PASS, no Critical/Important issues).

Design spec: `docs/superpowers/specs/2026-05-16-install-script-design.md` · Plan: `docs/superpowers/plans/2026-05-16-install-script.md`

## Test plan

- [x] `sh install.sh --help` exits 0 with usage (ATDD: `tests/cli_install.rs`)
- [x] Unsupported platform fails fast with `cargo install upskill` hint (ATDD)
- [x] `shellcheck install.sh` clean; gating CI `ShellCheck` job green
- [x] `release.yml` validated (YAML + CodeQL `Analyze (actions)`); asset/tarball/checksum contract verified byte-exact against `install.sh` for all 4 targets
- [x] CI green: Format, Clippy, Test, Conventional commits, ShellCheck, CodeQL
- [ ] Manual end-to-end: push a real `v*` tag, confirm a Release with 8 assets and that the one-liner installs a runnable `upskill` (post-merge, needs a published release)

## Known follow-up (non-blocking)

- K2/XS: with both `HOME` and `UPSKILL_INSTALL_DIR` unset, `install.sh` exits noisily under `set -u` before `--help`. Irrelevant to the `curl|sh` use case (shells export `HOME`); tracked as low-priority debt.

https://claude.ai/code/session_01XnPApyWZTHNfyp9NioeCmB