### PR TITLE
fix: install.sh resolves install dir without requiring HOME

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,6 @@ set -eu
 
 REPO="driftsys/upskill"
 BIN="upskill"
-INSTALL_DIR="${UPSKILL_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${UPSKILL_VERSION:-latest}"
 
 usage() {
@@ -84,6 +83,15 @@ if [ "$VERSION" = "latest" ]; then
     base="https://github.com/${REPO}/releases/latest/download"
 else
     base="https://github.com/${REPO}/releases/download/${VERSION}"
+fi
+
+INSTALL_DIR="${UPSKILL_INSTALL_DIR:-}"
+if [ -z "$INSTALL_DIR" ]; then
+    if [ -n "${HOME:-}" ]; then
+        INSTALL_DIR="$HOME/.local/bin"
+    else
+        err "set UPSKILL_INSTALL_DIR or HOME to choose an install directory"
+    fi
 fi
 
 tmp="$(mktemp -d)"

--- a/tests/cli_install.rs
+++ b/tests/cli_install.rs
@@ -23,6 +23,44 @@ fn help_flag_prints_usage_and_exits_zero() {
 }
 
 #[test]
+fn help_works_without_home_env() {
+    Command::new("sh")
+        .arg(install_sh())
+        .arg("--help")
+        .env_remove("HOME")
+        .env_remove("UPSKILL_INSTALL_DIR")
+        .assert()
+        .success()
+        .stdout(contains("Usage"));
+}
+
+#[test]
+fn unsupported_platform_without_home_still_hints() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fake_uname = tmp.path().join("uname");
+    fs::write(
+        &fake_uname,
+        "#!/bin/sh\ncase \"$1\" in\n  -s) echo Linux ;;\n  -m) echo riscv64 ;;\n  *) echo unknown ;;\nesac\n",
+    )
+    .unwrap();
+    let mut perm = fs::metadata(&fake_uname).unwrap().permissions();
+    perm.set_mode(0o755);
+    fs::set_permissions(&fake_uname, perm).unwrap();
+
+    let orig_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", tmp.path().display(), orig_path);
+
+    Command::new("sh")
+        .arg(install_sh())
+        .env("PATH", new_path)
+        .env_remove("HOME")
+        .env_remove("UPSKILL_INSTALL_DIR")
+        .assert()
+        .failure()
+        .stderr(contains("cargo install upskill"));
+}
+
+#[test]
 fn unsupported_platform_fails_with_cargo_hint() {
     let tmp = tempfile::tempdir().unwrap();
     let fake_uname = tmp.path().join("uname");


### PR DESCRIPTION
## Summary

Fixes the K2 edge from PR #135's review: `install.sh` computed `INSTALL_DIR="${UPSKILL_INSTALL_DIR:-$HOME/.local/bin}"` at top level **before** argument parsing, so under `set -u` an unset `HOME` (with `UPSKILL_INSTALL_DIR` also unset) aborted with `install.sh: 11: HOME: parameter not set` (exit 2) — even for `install.sh --help` and the unsupported-platform path.

- `INSTALL_DIR` is now resolved lazily, **after** platform detection and tool checks (right before install), so `--help`, unknown-arg, unsupported-platform, and missing-tool paths never touch `$HOME`.
- If neither `UPSKILL_INSTALL_DIR` nor `HOME` is set, it fails with a clear actionable message (`set UPSKILL_INSTALL_DIR or HOME to choose an install directory`) instead of the cryptic `set -u` abort.
- Default behavior unchanged: `UPSKILL_INSTALL_DIR` override, else `$HOME/.local/bin`.

TDD: two regression tests added to `tests/cli_install.rs` (`--help` with `HOME` unset → exit 0; unsupported platform with `HOME` unset → still emits the `cargo install upskill` hint). Red → green confirmed; `shellcheck install.sh` clean.

## Test plan

- [x] `env -u HOME sh install.sh --help` → exit 0 with usage (new test `help_works_without_home_env`)
- [x] Unsupported platform with `HOME` unset → fails with `cargo install upskill` hint (new test `unsupported_platform_without_home_still_hints`)
- [x] Original 2 ATDD tests still pass (4 passed total)
- [x] `shellcheck install.sh` clean

Note: the live `curl|sh` installer is served from `main` (`raw.githubusercontent.com/.../main/install.sh`), so merging this improves the published installer immediately; it will also ride into the next tagged release.

https://claude.ai/code/session_01XnPApyWZTHNfyp9NioeCmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnPApyWZTHNfyp9NioeCmB)_