### PR TITLE
docs: drop unimplemented bundle-name source form from spec

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -77,10 +77,6 @@ upskill add <source> [items...] [--global|--project]
 - `https://github.com/owner/repo[...]` — full HTTPS URL
 - `gitlab:owner/repo[...]` or `https://gitlab.com/[...]` — GitLab
 - `./path`, `../path`, `/abs/path`, `~/path` — local paths
-- `<bundle-name>` — a bundle resolved from configured registries
-
-Source resolution order: registry index first; if no match, treat as git repo
-or local path.
 
 `upskill add <source>` installs everything the source contains. Optional
 `items...` after the source filter to a subset. There is no interactive


### PR DESCRIPTION
## Summary

Spec §2.1 listed `<bundle-name>` as an accepted source form and described a "registry index first" resolution order. Neither is implemented in 0.4.1:

- [src/source.rs:80-113](src/source.rs#L80-L113) only handles `owner/repo[@ref][:subfolder]`, `https://`, `gitlab:`, and local paths.
- The `registry` module is author-side only (`upskill registry build`); there is no `.upskill-registries.yaml` lookup or consumer-side `<bundle-name>` → registry-index resolution.

Users following the spec hit `error: source must be in owner/repo format` (exit 2), as just happened with the markspec install guide ([driftsys/markspec#402](https://github.com/driftsys/markspec/pull/402)).

This removes the two unfounded lines so [docs/specification.md](docs/specification.md) matches 0.4.1 behaviour. Consumer-side registry resolution stays tracked under epic **#62 — v0.4 — Registry standard**, story **#30 — Install from named registry**; the spec lines should come back (in a more precise form) when #30 ships.

[docs/commands.md](docs/commands.md) and [README.md](README.md) already use only the implemented forms, so no other doc changes are needed.

## Test plan

- [x] `just fmt` clean
- [x] `just verify` clean (full test + lint + build)
- [x] `git std lint` accepts commit message
- [x] Manually re-read the surrounding §2.1 prose to confirm it still reads coherently after the removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
