### PR TITLE
chore: add just recipes to build and serve the mdBook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ just check              # Run all checks (test + lint)
 just build              # Assemble + check
 just verify             # Commit check + build — run before PR
 just fmt                # Format Rust + Markdown
+just book               # Build the mdBook docs into book/
+just book-serve         # Serve the mdBook with live reload (opens in browser)
 ```
 
 After `git clone` or `git worktree add`, run `./bootstrap` once. It installs

--- a/justfile
+++ b/justfile
@@ -40,6 +40,14 @@ doc:
 man:
     cargo run --example mangen --release --quiet
 
+# Build the mdBook docs into book/
+book:
+    mdbook build
+
+# Serve the mdBook docs with live reload (opens in browser)
+book-serve:
+    mdbook serve --open
+
 # Bump version, update changelog, commit, and tag
 release:
     git std bump


### PR DESCRIPTION
## Summary

- Add `just book` — runs `mdbook build`, writing the rendered site into the gitignored `book/` directory (the same artifact the Pages workflow uploads).
- Add `just book-serve` — runs `mdbook serve --open` for local preview with live reload, so doc edits can be iterated without waiting for the deploy round-trip.
- CI (`.github/workflows/pages.yml`) is unchanged; it still installs its own mdBook and calls `mdbook build` directly. The recipes are local conveniences only.

## Test plan

- [x] `just book` smoke-tested locally; `book/404.html`, `book/ayu-highlight.css`, etc. populated as expected.
- [x] `just verify` exit 0 (unchanged scope — no Rust touched).
- [ ] On a machine without `mdbook` installed, `just book` errors out clearly (`mdbook: command not found`) — acceptable, install via `cargo install mdbook` matches CI's version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
