### PR TITLE
refactor(bundle)!: switch bundle manifest format to pure YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- **bundle format:** bundle manifests are pure YAML files named
+  `<name>.bundle.yaml` (was Markdown-with-frontmatter `<name>.bundle.md`).
+  The schema is unchanged; only the file format changes. Discovery
+  matches the `.bundle.yaml` suffix and gates on a top-level integer
+  `schema:` key — YAML files without it are silently skipped. A bundle
+  MAY have an optional sibling `<name>.bundle.md` carrying human-readable
+  documentation; the parser ignores it. See
+  [ADR-0007](docs/adr/0007-bundle-yaml-format.md).
+  Migration (pre-1.0, no back-compat): rename `<name>.bundle.md` →
+  `<name>.bundle.yaml` and strip the `---` delimiters and Markdown body.
+  Move any worth-keeping prose to a sibling `<name>.bundle.md`.
+
 ## [0.5.1] (2026-05-21)
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cargo install upskill
 upskill add driftsys/skills
 
 # Or install a curated bundle — one entry, dependency-resolved
-upskill add driftsys/bundles:platform-baseline.bundle.md
+upskill add driftsys/bundles:platform-baseline.bundle.yaml
 
 # Pull latest and regenerate
 upskill update
@@ -58,12 +58,12 @@ the same tree.
 
 ## Bundles
 
-A bundle is a flat manifest (`*.bundle.md`) that names the items it
+A bundle is a flat YAML manifest (`*.bundle.yaml`) that names the items it
 includes, and optionally other bundles it depends on. Installing a
 bundle resolves the transitive closure once and writes per-item output:
 
 ```bash
-upskill add driftsys/bundles:platform-baseline.bundle.md
+upskill add driftsys/bundles:platform-baseline.bundle.yaml
 ```
 
 The lockfile records the bundle entry alongside the items, so

--- a/docs/adr/0005-skills-sh-ecosystem-interop.md
+++ b/docs/adr/0005-skills-sh-ecosystem-interop.md
@@ -69,11 +69,12 @@ same well-known directories as skills.sh:
 
 ### Bundle format is additive
 
-The `<name>.bundle.md` manifest is an upskill-specific extension layered
+The `<name>.bundle.yaml` manifest is an upskill-specific extension layered
 on top of the open standard. It does not replace, redefine, or break
-any existing standard field. Tools that don't understand `.bundle.md`
+any existing standard field. Tools that don't understand `.bundle.yaml`
 (including `npx skills`) simply ignore them — bundles never appear in
-their output, and nothing else degrades.
+their output, and nothing else degrades. The bundle file format itself
+is settled in [ADR-0007](./0007-bundle-yaml-format.md).
 
 Bundle authors who want their bundles consumable by skills.sh need a
 separate publishing path (skills.sh doesn't currently understand the

--- a/docs/adr/0007-bundle-yaml-format.md
+++ b/docs/adr/0007-bundle-yaml-format.md
@@ -1,0 +1,169 @@
+# Bundle file format — YAML, not Markdown-with-frontmatter
+
+**Status**: Proposed (2026-05-21)
+
+## Context
+
+[ADR-0002](./0002-portable-content-format.md) established the SSOT
+on-disk contract, including bundle files as
+[Markdown-with-frontmatter](../format-spec.md) named `<name>.bundle.md`.
+The frontmatter carried the manifest (`schema`, `name`, `description`,
+`items`, `requires`, `metadata`); the body carried human-readable
+documentation (install examples, adoption path, caveats).
+
+That shape mirrored `SKILL.md` / `RULE.md` / `AGENT.md` and gave bundle
+authors one file to point at. In practice, the body never carried
+information that influenced installation behavior — the parser reads
+the frontmatter and discards the body. The Markdown body is purely
+documentation.
+
+[ADR-0006](./0006-flat-item-layout.md) tightened the item layout. This
+ADR tightens the bundle layout for the same reason: keep the SSOT
+contract as small as it needs to be, drop redundancy.
+
+## Decision
+
+### Manifest is a pure YAML file
+
+Bundle manifests are pure YAML, with the filename suffix
+`.bundle.yaml`:
+
+```text
+<bundle-root>/
+├── platform-baseline.bundle.yaml
+├── android.bundle.yaml
+└── rust-embedded.bundle.yaml
+```
+
+The file body is the YAML manifest verbatim — no `---` delimiters, no
+trailing Markdown. The schema is unchanged from ADR-0002 §3.7
+(`schema`, `name`, `description`, `license`, `items`, `requires`,
+`metadata`); only the file format changes.
+
+```yaml
+schema: 1
+name: platform-baseline
+description: Baseline rules, skills, and agents for all repositories
+license: proprietary
+
+items:
+  rules:
+    - license-awareness
+    - security-baseline
+  skills:
+    - pr-summary
+  agents:
+    - security-reviewer
+
+metadata:
+  version: "1.2.0"
+  author: platform-dx
+```
+
+### Optional sibling README
+
+A bundle MAY have a sibling Markdown file at `<name>.bundle.md` (same
+stem, `.md` suffix) carrying human-readable documentation — install
+examples, adoption path, exclusions, maintenance notes. The parser
+ignores `.bundle.md` files entirely; they exist for humans browsing the
+registry.
+
+### Discovery is suffix + schema-field gate
+
+Discovery walks for `*.bundle.yaml`. The parser does a cheap
+`schema:` field check first: if the top-level `schema:` key is absent
+or not an integer, the file is silently skipped (it's not a bundle,
+just a YAML file that happens to share the suffix).
+
+Explicit-path operations (`upskill add ./foo.bundle.yaml`) are strict:
+a file that doesn't parse as a valid bundle is a hard error. The user
+pointed at it; silence would hide bugs.
+
+## Consequences
+
+**Positive.**
+
+- One parser path for bundles, one for items. No frontmatter-extraction
+  step on bundle files — direct `serde_yaml_ng::from_str`.
+- Manifest validation is stricter — no Markdown body that can drift
+  away from the frontmatter, no risk of an author editing the body and
+  accidentally changing what looks like manifest text.
+- Conventional shape — `Cargo.toml`, `package.json`, `action.yml`, and
+  most other manifest files in the wider ecosystem are pure
+  data-language files, not data-plus-prose.
+- The README sibling is optional. Bundles that need no narrative
+  documentation ship as one file. Bundles that benefit from narrative
+  put it in a sibling, freely editable without touching the manifest.
+
+**Negative.**
+
+- Shape consistency with `SKILL.md` is lost. Items use
+  frontmatter+body; bundles do not. The trade-off is judged worthwhile:
+  bundles are mostly manifests, items are mostly content, and the
+  current shared shape was forcing a body on a file that doesn't need
+  one.
+- One-time fixture migration in `tests/fixtures/bundles/` and the
+  in-repo `skills/prompt-engineering.bundle.md`.
+- Tutorials and existing registries authored against v0.5 (`.bundle.md`)
+  must rename and strip the body. Per
+  [no back-compat until 1.0](../../AGENTS.md), this is a hard cut.
+
+## Alternatives considered
+
+**(a) Keep `.bundle.md` with frontmatter+body.** Rejected: the body
+adds no parser semantics and creates two places where an author can
+write contradictory information about the same bundle.
+
+**(b) TOML instead of YAML.** Rejected: every other SSOT file in this
+project is YAML-frontmatter; introducing TOML for one file kind adds a
+second config language without solving any problem the current YAML
+shape has. TOML's strengths (flat key-value, strict scalar parsing) do
+not match the bundle's structured `items.*` and `requires[]` shape.
+
+**(c) Filename namespace — `<name>.upskill-bundle.yaml`.** Rejected:
+bundle files live in tool-owned locations and are installed via
+`upskill add` explicitly. The `schema:` field check is a stronger gate
+than a filename prefix — random `.bundle.yaml` files outside our schema
+are skipped silently in discovery.
+
+**(d) Directory form `<name>.bundle/{bundle.yaml, README.md}`.**
+Rejected: bundles do not carry sidecar assets the way items do. A
+directory per bundle is overhead for nothing.
+
+**(e) Allow qualified item names (`owner/repo:skill-name`) in
+`items.*`.** Deferred. The simple shape — bare names resolving from
+the bundle's host registry — covers every current use case. Adding
+cross-registry composition at the bundle-file level adds resolver
+complexity (multi-source cloning, name collisions, lockfile shape)
+without a real consumer asking for it. Cross-registry composition
+remains available at the `upskill add` level by installing multiple
+bundles or sources.
+
+## Migration
+
+Per [no back-compat until 1.0](../../AGENTS.md), the format change is
+a hard cut. v0.6 reads `.bundle.yaml` only; `.bundle.md` is removed
+from spec and parser in one release. No translator, no fallback
+discovery.
+
+Registries authored against v0.5 (`.bundle.md`) must:
+
+1. Rename `<name>.bundle.md` → `<name>.bundle.yaml`.
+2. Strip the `---` delimiters and the Markdown body. If the body
+   contained documentation worth keeping, move it to a sibling
+   `<name>.bundle.md`. The new `.bundle.md` is documentation only —
+   the parser ignores it.
+
+A simple shell rename + body-strip script suffices; no schema changes
+to the manifest itself.
+
+## References
+
+- Predecessor: [ADR-0002](./0002-portable-content-format.md) §
+  "Bundle file shape" — superseded by this ADR for the file format;
+  the bundle schema (fields, semantics, transitive resolution) is
+  unchanged.
+- Authoritative spec: [`docs/format-spec.md`](../format-spec.md) §2.2,
+  §3.7.
+- Related: [ADR-0006](./0006-flat-item-layout.md) (same "drop
+  redundancy in the SSOT contract" rationale, applied to items).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,3 +9,4 @@ Numbered sequentially. Status one of: Proposed | Accepted | Superseded.
 - [0004 — upskill CLI surface](0004-cli-surface.md)
 - [0005 — skills.sh ecosystem interop](0005-skills-sh-ecosystem-interop.md)
 - [0006 — Flat item layout — drop kind subdirectories](0006-flat-item-layout.md)
+- [0007 — Bundle file format — YAML, not Markdown-with-frontmatter](0007-bundle-yaml-format.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -42,7 +42,7 @@ upskill add owner/repo@abc123                       # pin to commit SHA
 upskill add gitlab:owner/repo                       # GitLab.com
 upskill add https://gitlab.example.com/owner/repo   # self-hosted GitLab
 upskill add ./path/to/local                         # local directory
-upskill add owner/repo:platform.bundle.md           # bundle file
+upskill add owner/repo:platform.bundle.yaml         # bundle file
 ```
 
 `upskill add <source>` installs **everything** the source contains.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -25,8 +25,8 @@ bundle files sit together under it, flat:
 ```text
 <source-registry-root>/
 └── skills/
-    ├── platform-baseline.bundle.md     # bundles
-    ├── android.bundle.md
+    ├── platform-baseline.bundle.yaml     # bundles
+    ├── android.bundle.yaml
     ├── license-awareness/               # rule item
     │   └── RULE.md
     ├── code-review/                     # skill item
@@ -55,7 +55,7 @@ Why this shape:
 
 ### When bundles outgrow the flat layout
 
-Once a registry holds enough bundles that `*.bundle.md` files start to
+Once a registry holds enough bundles that `*.bundle.yaml` files start to
 drown out the item directories in a single `ls`, move the bundles into a
 sibling `bundles/` subdirectory:
 
@@ -63,9 +63,9 @@ sibling `bundles/` subdirectory:
 <source-registry-root>/
 └── skills/
     ├── bundles/
-    │   ├── platform-baseline.bundle.md
-    │   ├── android.bundle.md
-    │   └── rust-embedded.bundle.md
+    │   ├── platform-baseline.bundle.yaml
+    │   ├── android.bundle.yaml
+    │   └── rust-embedded.bundle.yaml
     ├── license-awareness/
     │   └── RULE.md
     ├── code-review/
@@ -79,7 +79,7 @@ a clean separation between manifests and content. Rough heuristic: stick
 with the flat layout until scanning `skills/` for an item becomes harder
 than scanning it for a bundle.
 
-`upskill` discovers bundles by scanning for the `.bundle.md` suffix
+`upskill` discovers bundles by scanning for the `.bundle.yaml` suffix
 ([format-spec §2.2](./format-spec.md#22-bundle-files)) and is indifferent
 to which of these two sub-layouts the registry uses.
 
@@ -92,7 +92,7 @@ upskill new rule license-checks   # → skills/license-checks/RULE.md
 upskill new agent security-review # → skills/security-review/AGENT.md
 ```
 
-Bundles are plain `*.bundle.md` files you create alongside the items —
+Bundles are plain `*.bundle.yaml` files you create alongside the items —
 there is no scaffolder for them; copy the
 [format-spec §3.7](./format-spec.md#37-bundle-schema) example as a
 starting point.

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -130,21 +130,29 @@ additional content and is ignored by agentskills.io-only tooling.
 
 ### 2.2 Bundle files
 
-Bundles are flat manifest files, not directories:
+Bundles are flat YAML manifest files, not directories:
 
 ```text
 <bundle-root>/
-├── platform-baseline.bundle.md
-├── android.bundle.md
-└── rust-embedded.bundle.md
+├── platform-baseline.bundle.yaml
+├── android.bundle.yaml
+└── rust-embedded.bundle.yaml
 ```
 
-- The filename stem (before `.bundle.md`) MUST match the `name` field in the bundle's frontmatter.
+- A bundle manifest is a pure YAML file (no `---` delimiters, no markdown body).
+- The filename stem (before `.bundle.yaml`) MUST match the `name` field in the manifest.
 - Bundle files MAY live anywhere within a source registry — alongside item directories under
   `<item-root>` (§2.1), in a sibling directory, or in a dedicated `bundles/` directory.
-  Implementations discover bundles by scanning for the `.bundle.md` suffix and MUST NOT depend
-  on a specific bundle-root path. The upskill project recommends placing bundles alongside item
-  directories under `skills/`; see [Conventions](./conventions.md).
+  Implementations discover bundles by scanning for the `.bundle.yaml` suffix and MUST NOT depend
+  on a specific bundle-root path. A YAML file matching the suffix but lacking a top-level integer
+  `schema:` key is silently skipped in discovery (the schema field is the bundle contract gate);
+  explicit-path operations against such a file MUST surface a parse error. The upskill project
+  recommends placing bundles alongside item directories under `skills/`; see
+  [Conventions](./conventions.md).
+- A bundle MAY have an optional sibling Markdown file `<name>.bundle.md` carrying
+  human-readable documentation (install examples, adoption path, caveats). Implementations
+  ignore `<name>.bundle.md`; it exists for humans browsing the registry. See
+  [ADR-0007](./adr/0007-bundle-yaml-format.md).
 
 ### 2.3 Per-client override files
 
@@ -206,8 +214,10 @@ Items MAY contain supporting files in their directory:
 
 ## 3. Frontmatter schema
 
-All entrypoint files (RULE.md, SKILL.md, AGENT.md, *.bundle.md) begin with YAML frontmatter delimited
-by `---` markers. Frontmatter is followed by a blank line and then markdown body content.
+Item entrypoint files (RULE.md, SKILL.md, AGENT.md) begin with YAML frontmatter delimited by
+`---` markers, followed by a blank line and then markdown body content. Bundle manifests
+(`*.bundle.yaml`, §2.2) are pure YAML — the same schema, but the file content IS the YAML, with no
+`---` wrapping and no body.
 
 ### 3.1 Common fields (all kinds and bundles)
 
@@ -403,8 +413,9 @@ live in source registries (potentially the same repo, potentially others). Consu
 not contain bundle files — an implementation records which bundles a consumer project has
 installed in its own state file (e.g. `.upskill-lock.json` for the upskill CLI).
 
+`<bundle-root>/platform-baseline.bundle.yaml`:
+
 ```yaml
----
 schema: 1
 name: platform-baseline
 description: Baseline rules, skills, and agents for all repositories
@@ -425,12 +436,10 @@ requires: []
 metadata:
   version: "1.2.0"
   author: platform-dx
----
-
-# Platform baseline
-
-What this bundle provides, who it targets, changelog...
 ```
+
+An optional sibling `<bundle-root>/platform-baseline.bundle.md` MAY carry human-readable
+documentation; the parser ignores it (§2.2).
 
 | Field          | Type     | Required | Description                          |
 | -------------- | -------- | -------- | ------------------------------------ |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ agents:
 upskill add driftsys/skills
 
 # Or install a curated bundle
-upskill add driftsys/bundles:platform-baseline.bundle.md
+upskill add driftsys/bundles:platform-baseline.bundle.yaml
 
 # Pin to a tag, branch, or commit
 upskill add driftsys/skills@v1.2.0
@@ -72,7 +72,7 @@ upskill fmt             # canonicalise YAML frontmatter
 ```
 
 You can also scaffold rules (`upskill new rule <name>`) and agents
-(`upskill new agent <name>`). Bundles are plain `*.bundle.md` files that
+(`upskill new agent <name>`). Bundles are plain `*.bundle.yaml` files that
 sit alongside the items they reference, also under `skills/`.
 
 ## Man pages

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -22,7 +22,7 @@ upskill new skill code-review        # scaffold a new SSOT skill (in a registry)
 
 Consumer projects only ever contain **generated** per-client files.
 Source registries hold the canonical SSOT items (`RULE.md`,
-`SKILL.md`, `AGENT.md`, `*.bundle.md`). The same repo can play both
+`SKILL.md`, `AGENT.md`, `*.bundle.yaml`). The same repo can play both
 roles; SSOT and generated outputs do not mix in the same tree.
 
 ## Where to next

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -47,10 +47,10 @@ re-fetches from the same ref unless you bump it explicitly.
 ## Install a curated bundle
 
 ```bash
-upskill add owner/bundles:platform-baseline.bundle.md
+upskill add owner/bundles:platform-baseline.bundle.yaml
 ```
 
-A bundle is a manifest (`*.bundle.md`) that names the items it
+A bundle is a YAML manifest (`*.bundle.yaml`) that names the items it
 includes plus any other bundles it depends on. The dependency closure
 is resolved transitively before any items are written.
 
@@ -58,7 +58,7 @@ The lockfile records the bundle entry alongside the items, so you can
 later remove everything that came from it:
 
 ```bash
-upskill remove --source github:owner/bundles:platform-baseline.bundle.md
+upskill remove --source github:owner/bundles:platform-baseline.bundle.yaml
 ```
 
 ## Bisect drift
@@ -79,7 +79,7 @@ diffs the second time.
 
 ```bash
 # Inside a source-registry repo, under the recommended skills/ root
-# (see docs/conventions.md — items and *.bundle.md both live here).
+# (see docs/conventions.md — items and *.bundle.yaml both live here).
 cd skills/
 upskill new skill my-skill
 $EDITOR my-skill/SKILL.md

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -34,7 +34,7 @@ This document describes upskill's behaviour against that contract.
 ### 1.3 Two roles
 
 - **Source registry** — repository where SSOT items are authored. Holds the
-  canonical `RULE.md` / `SKILL.md` / `AGENT.md` files and `*.bundle.md`
+  canonical `RULE.md` / `SKILL.md` / `AGENT.md` files and `*.bundle.yaml`
   manifests. Author commands (`new`, `lint`, `fmt`) operate here.
 - **Consumer project** — repository where generated outputs are installed
   for use by AI clients. Holds only generated per-client files. Consumer
@@ -71,7 +71,7 @@ upskill add <source> [items...] [--global|--project]
 - `owner/repo` — GitHub shorthand
 - `owner/repo@ref` — pinned ref (branch, tag, or commit SHA)
 - `owner/repo:path/to/item` — subfolder
-- `owner/repo:path/to/name.bundle.md` — bundle file (resolves transitively, see §2.6)
+- `owner/repo:path/to/name.bundle.yaml` — bundle file (resolves transitively, see §2.6)
 - `owner/repo@ref:path` — combined
 - `https://github.com/owner/repo[...]` — full HTTPS URL
 - `gitlab:owner/repo[...]` or `https://gitlab.com/[...]` — GitLab
@@ -139,12 +139,12 @@ Author commands. Run inside a source-registry working tree.
 
 ### 2.6 Bundles
 
-A **bundle** is a `*.bundle.md` manifest that names a curated set of items
+A **bundle** is a `*.bundle.yaml` manifest that names a curated set of items
 and (optionally) other bundles to install together. Bundles contain no
 content of their own; they reference items by `name`. Frontmatter shape is
 defined in [format-spec §3.7](./format-spec.md#37-bundle-schema).
 
-`upskill add <source>:path/to/foo.bundle.md` installs a bundle.
+`upskill add <source>:path/to/foo.bundle.yaml` installs a bundle.
 Implementation behaviour:
 
 - **Items.** Every entry in `items.rules`, `items.skills`, `items.agents` is

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -65,7 +65,7 @@ pub(crate) fn resolve_subfolder(
     if let Some(sub) = subfolder {
         let sub_path = clone_dir.join(sub);
         // Subfolders are usually directories (item-root paths) but bundle
-        // sources point at a `<name>.bundle.md` file directly. Accept
+        // sources point at a `<name>.bundle.yaml` file directly. Accept
         // both — the install layer dispatches on file vs dir.
         if !sub_path.exists() {
             return Err(format!(

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -89,9 +89,19 @@ fn format_file(path: &Path) -> Result<bool> {
 
 /// Produce the canonical form of `raw` for the kind inferred from
 /// `path`'s filename. Pure function — no I/O, no mutation.
+///
+/// Items (Skill/Rule/Agent) are frontmatter+body — body is preserved
+/// byte-for-byte. Bundles are pure YAML (§2.2, ADR-0007), so the file
+/// content is the canonical YAML verbatim, no `---` wrapping.
 fn canonicalise(raw: &str, path: &Path) -> Result<String> {
     let kind = file_kind(path)
         .ok_or_else(|| anyhow!("{}: unknown entrypoint filename", path.display()))?;
+
+    if let EntryKind::Bundle = kind {
+        let bundle: Bundle = serde_yaml_ng::from_str(raw)
+            .with_context(|| format!("parse bundle {}", path.display()))?;
+        return serde_yaml_ng::to_string(&bundle).context("serialise canonical bundle");
+    }
 
     let body = frontmatter::split(raw)
         .map(|(_, body)| body)
@@ -101,7 +111,7 @@ fn canonicalise(raw: &str, path: &Path) -> Result<String> {
         EntryKind::Skill => roundtrip::<Skill>(raw)?,
         EntryKind::Rule => roundtrip::<Rule>(raw)?,
         EntryKind::Agent => roundtrip::<Agent>(raw)?,
-        EntryKind::Bundle => roundtrip::<Bundle>(raw)?,
+        EntryKind::Bundle => unreachable!("bundle handled above"),
     };
 
     Ok(format!("---\n{yaml}---\n{body}"))
@@ -260,24 +270,28 @@ mod tests {
 
     #[test]
     fn fmt_handles_bundle() {
+        // Bundles are pure YAML (§2.2, ADR-0007). fmt reorders keys and
+        // strips the file down to canonical YAML — no `---` wrapping.
         let tmp = tempfile::tempdir().unwrap();
-        let item = tmp.path().join("bundles/baseline.bundle.md");
+        let item = tmp.path().join("bundles/baseline.bundle.yaml");
         write(
             &item,
             concat!(
-                "---\n",
                 "name: baseline\n",
                 "schema: 1\n",
                 "description: a bundle.\n",
                 "items:\n",
                 "  rules: [api]\n",
-                "---\n",
-                "## body\n",
             ),
         );
         let report = fmt(&[tmp.path().to_path_buf()]).unwrap();
         assert_eq!(report.files_changed.len(), 1);
         let after = fs::read_to_string(&item).unwrap();
         assert!(after.contains("- api"), "items.rules lost:\n{after}");
+        assert!(
+            !after.starts_with("---"),
+            "bundle file must not be wrapped in `---`:\n{after}"
+        );
+        assert!(after.starts_with("schema:"), "key order:\n{after}");
     }
 }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -19,7 +19,7 @@
 //!
 //! Discovery: a path argument is either a file (lint that file) or a
 //! directory (walk for `<root>/<name>/{RULE,SKILL,AGENT}.md` per
-//! format-spec §2.1, plus any `*.bundle.md`). With no paths, the
+//! format-spec §2.1, plus any `*.bundle.yaml`). With no paths, the
 //! current directory is used.
 
 use anyhow::{Context, Result, anyhow};
@@ -150,7 +150,7 @@ impl FileKind {
             "SKILL.md" => Some(Self::Skill),
             "RULE.md" => Some(Self::Rule),
             "AGENT.md" => Some(Self::Agent),
-            n if n.ends_with(".bundle.md") => Some(Self::Bundle),
+            n if n.ends_with(crate::parse::bundle::BUNDLE_SUFFIX) => Some(Self::Bundle),
             _ => None,
         }
     }
@@ -159,7 +159,7 @@ impl FileKind {
 /// Walk `root` (file or directory) and return every entrypoint file
 /// the lint should inspect. SSOT items are detected by the
 /// `<root>/<name>/<KIND>.md` layout per format-spec §2.1; bundles by
-/// the `*.bundle.md` suffix. Shared with `crate::fmt`.
+/// the `*.bundle.yaml` suffix. Shared with `crate::fmt`.
 pub(crate) fn discover(root: &Path) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
     if root.is_file() {
@@ -214,7 +214,7 @@ fn discover_items(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     Ok(())
 }
 
-/// Recurse into `root` looking for `*.bundle.md` files. Skips hidden
+/// Recurse into `root` looking for `*.bundle.yaml` files. Skips hidden
 /// directories (`.git`, `.upskill-…`, etc.) so the scan stays cheap.
 fn walk_bundles(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     let entries = fs::read_dir(root).with_context(|| format!("read {}", root.display()))?;
@@ -272,7 +272,10 @@ fn check_file(file: &Path, out: &mut Vec<Finding>) -> Result<()> {
     Ok(())
 }
 
-/// Parse frontmatter for the kind, returning `(name, body)`.
+/// Parse the entrypoint for the kind, returning `(name, body)`. Items
+/// are frontmatter+body; bundles are pure YAML with no body (§2.2,
+/// ADR-0007), so the bundle arm returns an empty body so the
+/// body-rules become no-ops.
 fn parse_kind(raw: &str, kind: FileKind) -> Result<(String, &str)> {
     match kind {
         FileKind::Skill => {
@@ -288,14 +291,14 @@ fn parse_kind(raw: &str, kind: FileKind) -> Result<(String, &str)> {
             Ok((item.name, body))
         }
         FileKind::Bundle => {
-            let (item, body) = frontmatter::parse::<crate::model::Bundle>(raw)?;
-            Ok((item.name, body))
+            let bundle: crate::model::Bundle = serde_yaml_ng::from_str(raw)?;
+            Ok((bundle.name, ""))
         }
     }
 }
 
 fn check_name_matches_dir(file: &Path, name: &str, kind: FileKind, out: &mut Vec<Finding>) {
-    // Bundles match the filename stem (`<name>.bundle.md`); items
+    // Bundles match the filename stem (`<name>.bundle.yaml`); items
     // match the parent directory name.
     match kind {
         FileKind::Bundle => {
@@ -615,7 +618,6 @@ mod tests {
     fn lint_flags_bundle_filename_mismatch() {
         let tmp = tempfile::tempdir().unwrap();
         let body = concat!(
-            "---\n",
             "schema: 1\n",
             "name: foo\n",
             "description: filename stem says baseline.\n",
@@ -623,10 +625,8 @@ mod tests {
             "  rules: []\n",
             "  skills: []\n",
             "  agents: []\n",
-            "---\n",
-            "## ok\n",
         );
-        write(&tmp.path().join("bundles/baseline.bundle.md"), body);
+        write(&tmp.path().join("bundles/baseline.bundle.yaml"), body);
         let report = lint(&[tmp.path().to_path_buf()], false).unwrap();
         let f = report
             .findings

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -51,7 +51,7 @@ pub struct LockedItem {
     pub hash: Option<String>,
 }
 
-/// Bundle entry recorded when an install resolves a `.bundle.md` file
+/// Bundle entry recorded when an install resolves a `.bundle.yaml` file
 /// (the entry bundle and every transitive `requires`). The lockfile's
 /// per-item `items` array still carries each rule/skill/agent
 /// independently — this entry is metadata that pairs each bundle name

--- a/src/parse/bundle.rs
+++ b/src/parse/bundle.rs
@@ -1,28 +1,32 @@
 //! Bundle file parsing and discovery (§2.2 + §3.7).
 //!
-//! Bundle files are flat manifests named `<name>.bundle.md`, with a YAML
-//! frontmatter block (the [`Bundle`] schema) and a free-form markdown
-//! body. They MAY live anywhere within a source registry — `load` takes
-//! a path; `discover` walks a directory tree for the `.bundle.md`
-//! suffix.
+//! Bundle manifests are pure YAML files named `<name>.bundle.yaml`. They
+//! MAY live anywhere within a source registry — [`load`] takes a path;
+//! [`discover`] walks a directory tree for the `.bundle.yaml` suffix and
+//! gates each file on the top-level `schema:` key so that unrelated YAML
+//! files sharing the suffix are silently skipped.
+//!
+//! A bundle MAY have a sibling `<name>.bundle.md` carrying human-readable
+//! documentation; the parser ignores it (the suffix walk only matches
+//! `.bundle.yaml`).
 
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::model::Bundle;
-use crate::parse::frontmatter;
 
 /// Filename suffix every bundle manifest carries (§2.2).
-pub const BUNDLE_SUFFIX: &str = ".bundle.md";
+pub const BUNDLE_SUFFIX: &str = ".bundle.yaml";
 
 /// Read and parse a single bundle file.
 ///
-/// Validates that the filename stem (before `.bundle.md`) matches the
-/// `name` field in the frontmatter, per §2.2.
+/// Validates that the filename stem (before `.bundle.yaml`) matches the
+/// `name` field, per §2.2. Strict: any parse error is surfaced — callers
+/// who want forgiving discovery use [`discover`] instead.
 pub fn load(path: &Path) -> Result<Bundle> {
     let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    let (bundle, _body) = frontmatter::parse::<Bundle>(&raw)
+    let bundle: Bundle = serde_yaml_ng::from_str(&raw)
         .with_context(|| format!("parse bundle {}", path.display()))?;
 
     let stem = filename_stem(path).ok_or_else(|| {
@@ -45,14 +49,15 @@ pub fn load(path: &Path) -> Result<Bundle> {
     Ok(bundle)
 }
 
-/// Recursively walk `source_root` for `*.bundle.md` files. Returns one
+/// Recursively walk `source_root` for `*.bundle.yaml` files. Returns one
 /// `(absolute path, parsed Bundle)` per file, sorted by bundle name (the
-/// identifier users actually type on the CLI). Errors on the first parse
-/// or filename-mismatch failure.
+/// identifier users actually type on the CLI).
 ///
-/// Matches the discovery contract in §2.2: bundles MAY live anywhere in
-/// a source registry; the implementation MUST NOT depend on a specific
-/// bundle-root path.
+/// Files whose top-level `schema:` key is absent or non-integer are
+/// silently skipped — the suffix matches files that may not be upskill
+/// bundles, and the `schema:` field is the contract gate (ADR-0007). A
+/// file with `schema:` present but otherwise malformed is reported as an
+/// error: the author intended a bundle and got it wrong.
 pub fn discover(source_root: &Path) -> Result<Vec<(PathBuf, Bundle)>> {
     let mut out: Vec<(PathBuf, Bundle)> = Vec::new();
     if !source_root.exists() {
@@ -61,11 +66,54 @@ pub fn discover(source_root: &Path) -> Result<Vec<(PathBuf, Bundle)>> {
     let mut paths = Vec::new();
     walk(source_root, &mut paths)?;
     for path in paths {
-        let bundle = load(&path)?;
+        let Some(bundle) = load_if_bundle(&path)? else {
+            continue;
+        };
         out.push((path, bundle));
     }
     out.sort_by(|a, b| a.1.name.cmp(&b.1.name));
     Ok(out)
+}
+
+/// Discovery-time load: peeks the `schema:` key and returns `Ok(None)`
+/// when absent or non-integer (file is not an upskill bundle).
+fn load_if_bundle(path: &Path) -> Result<Option<Bundle>> {
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    if !has_schema_field(&raw) {
+        return Ok(None);
+    }
+    let bundle: Bundle = serde_yaml_ng::from_str(&raw)
+        .with_context(|| format!("parse bundle {}", path.display()))?;
+
+    let stem = filename_stem(path).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{}: filename must end in `{}`",
+            path.display(),
+            BUNDLE_SUFFIX
+        )
+    })?;
+    if stem != bundle.name {
+        anyhow::bail!(
+            "{}: filename stem `{}` does not match bundle.name `{}`",
+            path.display(),
+            stem,
+            bundle.name
+        );
+    }
+    Ok(Some(bundle))
+}
+
+/// Cheap pre-parse: returns true iff the YAML has a top-level integer
+/// `schema:` key. Avoids deserialising the whole `Bundle` for files that
+/// aren't bundles.
+fn has_schema_field(raw: &str) -> bool {
+    let Ok(value) = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(raw) else {
+        return false;
+    };
+    value
+        .as_mapping()
+        .and_then(|m| m.get(serde_yaml_ng::Value::String("schema".into())))
+        .is_some_and(|v| v.is_u64() || v.is_i64())
 }
 
 fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
@@ -92,7 +140,7 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     Ok(())
 }
 
-/// Returns `Some("<name>")` for `<name>.bundle.md`, `None` otherwise.
+/// Returns `Some("<name>")` for `<name>.bundle.yaml`, `None` otherwise.
 fn filename_stem(path: &Path) -> Option<&str> {
     let name = path.file_name().and_then(|n| n.to_str())?;
     name.strip_suffix(BUNDLE_SUFFIX)
@@ -112,8 +160,7 @@ mod tests {
         path
     }
 
-    const PLATFORM: &str = "---
-schema: 1
+    const PLATFORM: &str = "schema: 1
 name: platform-baseline
 description: Baseline rules, skills, and agents for all repositories
 license: proprietary
@@ -130,15 +177,12 @@ items:
 metadata:
   version: \"1.0.0\"
   author: platform-dx
----
-
-# Platform baseline
 ";
 
     #[test]
     fn load_round_trips_format_spec_example() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_file(tmp.path(), "platform-baseline.bundle.md", PLATFORM);
+        let path = write_file(tmp.path(), "platform-baseline.bundle.yaml", PLATFORM);
 
         let bundle = load(&path).expect("load");
 
@@ -156,8 +200,7 @@ metadata:
 
     #[test]
     fn load_parses_requires_with_and_without_version() {
-        let content = "---
-schema: 1
+        let content = "schema: 1
 name: rust-baseline
 description: Rust-specific baseline on top of platform
 items:
@@ -165,10 +208,9 @@ items:
 requires:
   - { name: platform-baseline, version: \"^1.0.0\" }
   - { name: shared-conventions }
----
 ";
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_file(tmp.path(), "rust-baseline.bundle.md", content);
+        let path = write_file(tmp.path(), "rust-baseline.bundle.yaml", content);
 
         let bundle = load(&path).expect("load");
         assert_eq!(bundle.requires.len(), 2);
@@ -183,18 +225,16 @@ requires:
         // Per §3.7 (post-PR #76): map-only `requires`. Bare strings must
         // fail to deserialize so a future polymorphic shape stays a
         // deliberate spec change, not a silent acceptance.
-        let content = "---
-schema: 1
+        let content = "schema: 1
 name: bare
 description: Should fail
 items:
   rules: []
 requires:
   - just-a-string
----
 ";
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_file(tmp.path(), "bare.bundle.md", content);
+        let path = write_file(tmp.path(), "bare.bundle.yaml", content);
 
         let err = load(&path).expect_err("string-form requires must be rejected");
         let msg = format!("{:#}", err);
@@ -206,16 +246,14 @@ requires:
 
     #[test]
     fn load_rejects_filename_stem_mismatch() {
-        let content = "---
-schema: 1
+        let content = "schema: 1
 name: platform-baseline
 description: filename mismatch
 items:
   rules: []
----
 ";
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_file(tmp.path(), "wrong-name.bundle.md", content);
+        let path = write_file(tmp.path(), "wrong-name.bundle.yaml", content);
 
         let err = load(&path).expect_err("must reject filename mismatch");
         let msg = format!("{:#}", err);
@@ -228,17 +266,15 @@ items:
     #[test]
     fn load_accepts_empty_items_when_only_requires() {
         // A meta-bundle that just composes other bundles is valid.
-        let content = "---
-schema: 1
+        let content = "schema: 1
 name: meta
 description: Composes other bundles
 items: {}
 requires:
   - { name: platform-baseline }
----
 ";
         let tmp = tempfile::tempdir().unwrap();
-        let path = write_file(tmp.path(), "meta.bundle.md", content);
+        let path = write_file(tmp.path(), "meta.bundle.yaml", content);
         let bundle = load(&path).expect("load");
         assert!(bundle.items.is_empty());
         assert_eq!(bundle.requires.len(), 1);
@@ -252,34 +288,82 @@ requires:
 
         write_file(
             tmp.path(),
-            "root-only.bundle.md",
+            "root-only.bundle.yaml",
             &renamed(PLATFORM, "root-only"),
         );
         write_file(
             tmp.path(),
-            "bundles/in-bundles-dir.bundle.md",
+            "bundles/in-bundles-dir.bundle.yaml",
             &renamed(PLATFORM, "in-bundles-dir"),
         );
         write_file(
             tmp.path(),
-            "nested/alongside.bundle.md",
+            "nested/alongside.bundle.yaml",
             &renamed(PLATFORM, "alongside"),
         );
         // Dot-directory contents should be skipped.
         write_file(
             tmp.path(),
-            ".git/skipped.bundle.md",
-            "---\nschema: 1\nname: skipped\ndescription: nope\nitems: {}\n---\n",
+            ".git/skipped.bundle.yaml",
+            "schema: 1\nname: skipped\ndescription: nope\nitems: {}\n",
         );
         // Non-bundle file should be ignored.
         write_file(tmp.path(), "x/SKILL.md", "---\nname: x\n---\nbody");
+        // Sibling `<name>.bundle.md` README must not be parsed as a bundle.
+        write_file(
+            tmp.path(),
+            "root-only.bundle.md",
+            "# Root only — human docs\n",
+        );
 
         let found = discover(tmp.path()).expect("discover");
         let names: Vec<&str> = found.iter().map(|(_, b)| b.name.as_str()).collect();
         assert_eq!(
             names,
             vec!["alongside", "in-bundles-dir", "root-only"],
-            "deterministic sort by bundle name"
+            "deterministic sort by bundle name; sibling .bundle.md ignored"
+        );
+    }
+
+    #[test]
+    fn discover_skips_yaml_files_without_schema_field() {
+        // A `.bundle.yaml` file without a top-level `schema:` key is not
+        // an upskill bundle (ADR-0007). Discovery silently skips it; only
+        // an explicit `load()` against it would error.
+        let tmp = tempfile::tempdir().unwrap();
+
+        write_file(tmp.path(), "real.bundle.yaml", &renamed(PLATFORM, "real"));
+        write_file(
+            tmp.path(),
+            "unrelated.bundle.yaml",
+            "foo: bar\nbaz:\n  - 1\n  - 2\n",
+        );
+
+        let found = discover(tmp.path()).expect("discover");
+        let names: Vec<&str> = found.iter().map(|(_, b)| b.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["real"],
+            "schema-less file silently skipped in discovery"
+        );
+    }
+
+    #[test]
+    fn discover_errors_when_schema_present_but_otherwise_malformed() {
+        // `schema:` present signals "author intended a bundle here".
+        // Subsequent parse failures must surface, not be skipped.
+        let tmp = tempfile::tempdir().unwrap();
+        write_file(
+            tmp.path(),
+            "broken.bundle.yaml",
+            "schema: 1\nname: broken\n# missing required `description` and `items`\n",
+        );
+
+        let err = discover(tmp.path()).expect_err("malformed bundle must surface");
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("parse bundle") || msg.contains("description") || msg.contains("items"),
+            "expected parse error, got: {msg}"
         );
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -57,7 +57,7 @@ pub struct InstalledItem {
 pub struct InstallReport {
     pub items: Vec<InstalledItem>,
     /// When the install resolved a bundle (entry `source` was a
-    /// `.bundle.md` file), every reached bundle in dependency order. The
+    /// `.bundle.yaml` file), every reached bundle in dependency order. The
     /// last entry is the bundle the user named. Empty for non-bundle
     /// installs.
     pub bundles: Vec<crate::model::Bundle>,
@@ -68,7 +68,7 @@ const ALL_CLIENTS: [Client; 3] = [Client::Claude, Client::Copilot, Client::OpenC
 /// Install every item under `source` into `target`, generating per-client
 /// output for each client unless filtered by the item's `audience` field.
 ///
-/// Bundle dispatch: when `source` is a `*.bundle.md` file (not a
+/// Bundle dispatch: when `source` is a `*.bundle.yaml` file (not a
 /// directory), discovers sibling bundles in the registry root walked up
 /// from the file, resolves transitively (per [`crate::bundle::resolve`]),
 /// and installs only the resolved items. The reached bundles are

--- a/tests/cli_bundle_install.rs
+++ b/tests/cli_bundle_install.rs
@@ -1,7 +1,7 @@
 //! ATDD tests for `upskill add <bundle-file>` (bundle install path).
 //!
 //! `install_with_lockfile` detects when its source resolves to a
-//! `.bundle.md` file, walks up to the registry root, discovers sibling
+//! `.bundle.yaml` file, walks up to the registry root, discovers sibling
 //! bundles, resolves transitively, and installs only the items the
 //! resolution names. The lockfile records the entry bundle and every
 //! transitive dependency.
@@ -41,7 +41,7 @@ fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
 
 #[test]
 fn bundle_install_writes_only_referenced_items() {
-    // `platform-baseline.bundle.md` references every fixture item, so a
+    // `platform-baseline.bundle.yaml` references every fixture item, so a
     // bundle install renders the same files as a directory install.
     let tmp = tempfile::tempdir().unwrap();
     let registry = tmp.path().join("registry");
@@ -50,7 +50,7 @@ fn bundle_install_writes_only_referenced_items() {
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    let bundle = registry.join("bundles/platform-baseline.bundle.md");
+    let bundle = registry.join("bundles/platform-baseline.bundle.yaml");
     Command::cargo_bin("upskill")
         .unwrap()
         .current_dir(&target)
@@ -87,7 +87,7 @@ fn bundle_install_records_bundle_in_lockfile() {
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    let bundle = registry.join("bundles/platform-baseline.bundle.md");
+    let bundle = registry.join("bundles/platform-baseline.bundle.yaml");
     Command::cargo_bin("upskill")
         .unwrap()
         .current_dir(&target)
@@ -132,7 +132,7 @@ fn bundle_install_resolves_transitive_requires() {
     // `extras` has rule `license-awareness`; baseline has the rest.
     // Mark them disjoint so the union is exact (no conflict).
     // Adjust the extras fixture in-place: drop overlap with baseline.
-    let extras_path = registry.join("bundles/platform-extras.bundle.md");
+    let extras_path = registry.join("bundles/platform-extras.bundle.yaml");
     let extras = fs::read_to_string(&extras_path).unwrap();
     // The fixture lists `license-awareness` which overlaps with baseline.
     // Replace with a non-overlapping rule so the resolver succeeds.
@@ -185,7 +185,7 @@ fn bundle_install_errors_on_item_conflict() {
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    let extras = registry.join("bundles/platform-extras.bundle.md");
+    let extras = registry.join("bundles/platform-extras.bundle.yaml");
     let assert = Command::cargo_bin("upskill")
         .unwrap()
         .current_dir(&target)

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -116,8 +116,8 @@ fn list_bundle_install_surfaces_bundles_section() {
     stage_source(&source);
     fs::create_dir_all(source.join("bundles")).unwrap();
     fs::copy(
-        format!("{FIXTURES}/bundles/platform-baseline.bundle.md"),
-        source.join("bundles/platform-baseline.bundle.md"),
+        format!("{FIXTURES}/bundles/platform-baseline.bundle.yaml"),
+        source.join("bundles/platform-baseline.bundle.yaml"),
     )
     .unwrap();
 
@@ -127,7 +127,7 @@ fn list_bundle_install_surfaces_bundles_section() {
         .args([
             "add",
             source
-                .join("bundles/platform-baseline.bundle.md")
+                .join("bundles/platform-baseline.bundle.yaml")
                 .to_str()
                 .unwrap(),
         ])

--- a/tests/fixtures/bundles/platform-baseline.bundle.yaml
+++ b/tests/fixtures/bundles/platform-baseline.bundle.yaml
@@ -1,4 +1,3 @@
----
 schema: 1
 name: platform-baseline
 description: Baseline rules, skills, and agents for all repositories
@@ -16,9 +15,3 @@ items:
 metadata:
   version: "1.0.0"
   author: platform-dx
----
-
-# Platform baseline
-
-Bundles every fixture item under `tests/fixtures/`. Used by parse and
-(eventually) install ATDD tests.

--- a/tests/fixtures/bundles/platform-extras.bundle.yaml
+++ b/tests/fixtures/bundles/platform-extras.bundle.yaml
@@ -1,4 +1,3 @@
----
 schema: 1
 name: platform-extras
 description: Extras layered on top of platform-baseline
@@ -10,8 +9,3 @@ items:
 
 requires:
   - { name: platform-baseline, version: "^1.0.0" }
----
-
-# Platform extras
-
-Demonstrates the `requires` map shape and a partial item set.


### PR DESCRIPTION
## Summary

Bundle manifests are now pure YAML files named `<name>.bundle.yaml` (was Markdown-with-frontmatter `<name>.bundle.md`). The schema itself is unchanged; only the file format changes.

- **Parser** (`src/parse/bundle.rs`): reads YAML via `serde_yaml_ng::from_str` directly. Discovery gates each `*.bundle.yaml` file on a top-level integer `schema:` key — unrelated YAML files sharing the suffix are silently skipped. Explicit `load()` is strict and surfaces any parse error.
- **`fmt`** (`src/fmt.rs`): bundle canonicalisation drops the `---` wrapping and emits bare YAML; key order still enforced by struct field order.
- **`lint`** (`src/lint.rs`): parses bundles directly as YAML; body-only rules become no-ops on bundles (no body to inspect).
- **README sibling**: a bundle MAY have an optional `<name>.bundle.md` carrying human-readable documentation; the parser ignores it.

## Breaking change (pre-1.0, no back-compat)

The `.bundle.md` form is removed outright. Migration is mechanical:

1. Rename `<name>.bundle.md` → `<name>.bundle.yaml`.
2. Strip the `---` delimiters and the Markdown body.
3. Move any prose worth keeping to a sibling `<name>.bundle.md` (parser ignores it).

Per AGENTS.md: pre-1.0, no migration shim, no fallback discovery.

## Rationale

See [ADR-0007](docs/adr/0007-bundle-yaml-format.md) — short version: the Markdown body in `.bundle.md` carried no parser semantics, so the frontmatter+body shape was inviting drift between two places that described the same bundle. Pure YAML matches every other manifest convention (`Cargo.toml`, `package.json`, `action.yml`) and gives a stricter parse path.

## Test plan

- [x] `just verify` clean (cargo test, clippy `-D warnings`, fmt --check, dprint, markdownlint, shellcheck, build)
- [x] New unit tests in `parse::bundle`:
  - `discover_skips_yaml_files_without_schema_field`
  - `discover_errors_when_schema_present_but_otherwise_malformed`
  - `discover_finds_bundles_recursively_anywhere_in_tree` now also asserts sibling `.bundle.md` is ignored
- [x] Existing bundle integration tests (`tests/parse_bundles.rs`, `tests/cli_bundle_install.rs`, `tests/cli_list.rs`) pass against the renamed `.bundle.yaml` fixtures
- [x] `fmt_handles_bundle` updated to assert pure-YAML output (no `---` wrapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)