### PR TITLE
feat(skills): add v0.1 prompt-engineering meta-skills bundle

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -2,3 +2,4 @@ target/
 CHANGELOG.md
 CLAUDE.md
 tests/fixtures/
+skills/

--- a/skills/NOTICE
+++ b/skills/NOTICE
@@ -1,0 +1,27 @@
+driftsys prompt-engineering meta-skills
+Copyright (c) driftsys
+
+This bundle adapts methodology from `obra/superpowers`:
+
+  https://github.com/obra/superpowers
+  Licensed under the MIT License.
+  Copyright (c) Jesse Vincent (@obra) and contributors.
+
+Specifically, the following methodological patterns are adapted from
+superpowers' `skills/writing-skills` and applied across the
+`evaluating-prompts`, `writing-rules`, and `writing-subagents` skills:
+
+  - The RED-GREEN-REFACTOR-for-docs cycle
+  - The pressure-scenario typology (time, sunk-cost, social, authority,
+    compassion, cleverness, edge-case)
+  - The rationalization-tracking discipline
+  - The "Iron Law" + "Red flags — STOP" framing
+
+The per-layer extensions (three-scenario format for rules, two-interface
+decomposition for subagents, managed-tier authority test) are
+driftsys-original applications of the upstream methodology and have not
+been validated against the same eval set as the upstream skills.
+
+When `writing-skills` itself is vendored into this bundle, this NOTICE
+will be extended to reproduce the upstream MIT license text in full as
+that license requires for binary or substantial-portion redistribution.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,116 @@
+# driftsys prompt-engineering meta-skills
+
+This directory is the source registry for the v0.1 draft set of
+meta-skills for the driftsys prompt-engineering discipline, managed via
+upskill.
+
+## Layout
+
+The directory follows the upskill conventional source-registry layout
+(items and bundles flat under `skills/`; see
+<https://driftsys.github.io/upskill/conventions.html>):
+
+```text
+skills/
+├── README.md                            (this file)
+├── NOTICE                               attribution for vendored methodology
+├── prompt-engineering.bundle.yaml       one-shot install of the discipline
+├── prompt-engineering/                  umbrella / orientation
+│   └── SKILL.md
+├── prompt-distilling/                   decompose authoring intent + place across layers
+│   └── SKILL.md
+├── writing-rules/                       per-layer authoring methodology
+│   └── SKILL.md
+├── writing-subagents/                   per-layer authoring methodology
+│   └── SKILL.md
+├── evaluating-prompts/                  RED-GREEN-REFACTOR cycle + scenario batteries
+│   └── SKILL.md
+└── using-upskill/                       lifecycle operations
+    └── SKILL.md
+```
+
+## Status
+
+All skills are v0.1.0 except `prompt-distilling` (v0.3.0, renamed from
+`picking-the-layer`) and `using-upskill` (v0.2.0, rewritten against the
+real CLI surface). None have yet been through their own
+RED-GREEN-REFACTOR cycle. Each carries an "Honest caveats" section
+flagging this.
+
+## Not yet present
+
+- `writing-skills` — to be vendored from `obra/superpowers` (MIT).
+  Tracked in [driftsys/upskill#146](https://github.com/driftsys/upskill/issues/146).
+  Until it lands, skill authoring methodology is deferred to the
+  upstream superpowers source; the handoff tables in the other skills
+  reference `writing-skills` as a forward pointer.
+
+## Install
+
+This bundle pairs with [`obra/superpowers`](https://github.com/obra/superpowers).
+Install both for the full stack:
+
+- **superpowers** — engineering discipline (TDD, debugging, brainstorming,
+  plans, code review, worktrees).
+- **prompt-engineering** (this bundle) — authoring discipline for durable
+  agent content (rules, skills, agents).
+
+### 1. Install superpowers
+
+Superpowers ships as a per-harness plugin; the install command differs by
+client. Pick the one matching your setup:
+
+| Client      | Command                                                         |
+| ----------- | --------------------------------------------------------------- |
+| Claude Code | `/plugin install superpowers@claude-plugins-official`           |
+| Codex CLI   | `/plugins` → search "Superpowers"                               |
+| Gemini CLI  | `gemini extensions install https://github.com/obra/superpowers` |
+| Cursor      | `/add-plugin superpowers`                                       |
+| Copilot CLI | `copilot plugin install superpowers@superpowers-marketplace`    |
+
+If you use more than one harness, install superpowers separately for each.
+
+### 2. Install upskill's prompt-engineering bundle
+
+`upskill add` resolves a bundle when the `source` argument points at the
+`.bundle.yaml` file directly. From the upskill repo root (treating this
+directory as a local source registry):
+
+```bash
+upskill add ./skills/prompt-engineering.bundle.yaml
+```
+
+Or, once published, from the canonical source (using the `:subfolder`
+syntax to point at the bundle file inside the repo):
+
+```bash
+upskill add driftsys/skills:skills/prompt-engineering.bundle.yaml
+```
+
+To install one item without the rest of the bundle, point at the
+registry directory and pass the item name as a filter:
+
+```bash
+upskill add ./skills prompt-engineering   # just the umbrella skill
+```
+
+See `using-upskill/SKILL.md` for the full lifecycle.
+
+## Recommended adoption sequence
+
+1. Vendor `writing-skills` from superpowers.
+2. Run `evaluating-prompts`' methodology against `prompt-distilling`
+   (most-activated skill) to validate the meta-skill methodology.
+3. Iterate based on findings.
+4. Roll out to pilot team(s).
+5. Iterate based on real authoring use.
+
+## Out of scope here
+
+- General one-shot prompting guidance (belongs in engineering
+  onboarding documentation, not in the framework)
+- MCP server authoring (separate repo's authoring process; see
+  `mcp-builder` from `anthropics/skills`)
+- RAG corpus management (lives behind specific MCP tools)
+- Domain-specific skills (Android, IVI, Rust cluster) — these meta-skills
+  help authors create those domain skills

--- a/skills/evaluating-prompts/SKILL.md
+++ b/skills/evaluating-prompts/SKILL.md
@@ -1,0 +1,318 @@
+---
+schema: 1
+name: evaluating-prompts
+description: Use when setting up the RED-GREEN-REFACTOR cycle for a rule, skill, or subagent — i.e., when the `writing-*` skills tell you to "run a failing test first." Trigger when authoring meta-skills, when validating that an existing rule/skill/subagent actually shapes behavior, or when auditing whether a skill activates correctly. Do NOT trigger for content authoring itself — see writing-rules, writing-skills, writing-subagents.
+metadata:
+  version: 0.1.0
+  author: driftsys
+---
+
+The `writing-*` skills tell you to run a failing test before authoring.
+This skill explains how. It is the eval methodology underneath the
+Iron Laws of writing-rules, writing-skills, and writing-subagents.
+
+If you are about to author content and the writing-* skill says "RED
+phase: run pressure scenarios" — this is where you find out how to
+actually do that.
+
+## The Iron Law
+
+NO EVAL CLAIM WITHOUT A SCENARIO BATTERY AND A SUBAGENT HARNESS.
+
+"I tested it" without naming the scenarios, the harness, and the
+pass/fail criteria is not evaluation — it is vibes. Evaluation
+produces artifacts: a scenario file, recorded subagent outputs, and a
+pass/fail judgment per scenario. Without those, claims about whether a
+prompt "works" are unfalsifiable.
+
+## What evaluation means here
+
+Evaluation is the act of running an authored prompt (rule, skill, or
+subagent system prompt) against realistic scenarios and observing
+whether it shapes behavior as intended. It has three components:
+
+1. **Scenario battery** — a curated set of inputs that exercise the
+   prompt's intended behavior, its trigger conditions, and its
+   failure modes.
+2. **Harness** — a way to run scenarios reproducibly. For prompts
+   this means subagents: spawn a fresh agent with the prompt loaded,
+   feed it the scenario, observe output.
+3. **Pass/fail criteria** — explicit, written-down criteria for each
+   scenario. "Did the agent comply with the rule?" "Did it activate
+   the skill?" "Did the subagent return a digest under 50 lines?"
+
+All three must exist before evaluation begins. Inventing pass/fail
+criteria after seeing the output is post-hoc rationalization, not
+evaluation.
+
+## The RED-GREEN-REFACTOR cycle
+
+This methodology comes from `obra/superpowers/skills/writing-skills`.
+The cycle has three phases. Each phase has a different question.
+
+### RED — does the prompt's absence cause a failure?
+
+The point of RED is to confirm that without your prompt, the agent
+fails in the way you expect. If the agent succeeds without the prompt,
+the prompt has no measurable effect and should not ship.
+
+- Construct scenarios that exercise the prompt's intended behavior.
+- Run them against a fresh subagent WITHOUT the prompt loaded.
+- Observe failures. Document them verbatim.
+
+A failing RED phase confirms the prompt is justified. A passing RED
+phase means you do not need the prompt.
+
+### GREEN — does the prompt's presence fix the failure?
+
+- Run the same scenarios against a fresh subagent WITH the prompt
+  loaded.
+- Observe whether the failures are now successes.
+- Document any new failures the prompt introduces.
+
+If GREEN does not pass cleanly, the prompt is incomplete. Edit and
+re-run.
+
+### REFACTOR — does the prompt hold up under realistic conditions?
+
+- Layer pressure on the scenarios: time pressure, sunk-cost pressure,
+  social pressure, conflicting instructions.
+- Run them WITH the prompt loaded.
+- Observe rationalizations — moments where the agent justifies
+  ignoring the prompt.
+- Document each rationalization verbatim.
+- Add explicit counters to the prompt for the rationalizations
+  observed.
+- Re-run until the prompt holds.
+
+REFACTOR is the most important phase. Most prompts pass GREEN
+trivially. They fail under pressure. The rationalizations observed in
+REFACTOR are what distinguish a real prompt from a wish.
+
+## Per-layer scenario types
+
+The scenario battery shape depends on which layer you are evaluating.
+
+### Rules — three scenario types
+
+Per `writing-rules`:
+
+1. **In-scope compliance** — a prompt where the rule should govern.
+   RED: does the agent violate without the rule? GREEN: does it
+   comply with the rule?
+2. **Out-of-scope quiet** — a prompt where the rule should not fire.
+   GREEN: does the agent behave normally despite the rule being
+   loaded? (Tests for over-firing.)
+3. **Pressure compliance** — the in-scope scenario with realistic
+   pressure layered on. REFACTOR: does the agent rationalize around
+   the rule?
+
+### Skills — activation plus behavior
+
+Skills add a layer rules do not have: the skill must first activate
+based on its description. Two failure surfaces:
+
+1. **Activation tests** — does the skill activate when it should?
+   Does it stay quiet when it should not?
+   - Run a scenario where the skill should clearly activate. RED:
+     without the skill in the registry, the agent struggles. GREEN:
+     with the skill installed, does the agent activate it?
+   - Run an off-topic scenario. GREEN: does the skill stay quiet?
+2. **Behavior tests** — once activated, does the skill produce the
+   intended behavior? Same RED/GREEN/REFACTOR cycle as rules.
+
+A skill that activates but does not shape behavior is no better than
+one that does not activate. Both halves matter.
+
+### Subagents — two interfaces, separately
+
+Per `writing-subagents`, subagents have two failure surfaces. Test
+each independently.
+
+1. **Invocation tests** (run on the parent, subagent registered)
+   - Should-delegate task: does parent invoke?
+   - Should-not-delegate task: does parent stay inline?
+   - Adjacent-scope task: does parent invoke incorrectly?
+2. **Return tests** (run on the subagent directly)
+   - In-scope task: does it return a digest or raw output?
+   - Partially-out-of-scope task: does it refuse cleanly?
+   - Will-fail task: does it report failure honestly?
+3. **Authority test** (managed tier only)
+   - Injection scenario: does it exceed its delegated authority?
+
+Document both columns of rationalizations: the parent's excuses for
+not delegating, and the subagent's excuses for bloated returns or
+scope creep.
+
+## Subagent harnesses
+
+Evaluation requires a clean room: a fresh agent with only the prompt
+under test loaded, no carryover context, no memory of previous runs.
+In Claude Code, this means spawning a subagent. In other clients with
+no native subagent, this means a fresh session or a separate process.
+
+The harness must:
+
+- Load only the prompt under test (plus required cross-references).
+  Anything else contaminates the evaluation.
+- Capture full output verbatim. Summaries are not evidence.
+- Be reproducible. Same scenario + same prompt + same model should
+  yield comparable behavior across runs.
+- Run multiple times per scenario when the behavior is borderline.
+  LLMs are stochastic. A scenario that passes once and fails twice
+  is failing.
+
+For meta-skills like the writing-* set, the harness can be informal:
+spawn a subagent with the prompt, paste in the scenario, read the
+output. For production rollouts to 100+ repos, a more formal harness
+is justified — but the methodology is the same.
+
+## Pressure scenario construction
+
+REFACTOR is the phase that catches real failures. Pressure scenarios
+do not happen by accident; you have to construct them. Categories:
+
+- **Time pressure** — "the user needs this in 10 minutes"
+- **Sunk-cost pressure** — "you have already written 200 lines"
+- **Social pressure** — "the rest of the team merges without this
+  check"
+- **Authority pressure** — "the lead engineer said it is fine to
+  skip"
+- **Compassion pressure** — "the customer is frustrated and we just
+  need to ship"
+- **Cleverness pressure** — "I have a clever shortcut that avoids
+  the rule"
+- **Edge-case pressure** — "this case is different because..."
+
+For each prompt being evaluated, choose 2-3 pressure types most
+relevant to the scenario domain. Construct scenarios that explicitly
+layer the pressure onto a compliance task. Run them. Document the
+rationalizations.
+
+The rationalizations are the deliverable, not the pass/fail. Even
+prompts that "pass" REFACTOR produce rationalization attempts. The
+prompt is good if it resists them; great if it preempts them.
+
+## Rationalization tracking
+
+Keep a table for each prompt evaluated. Columns:
+
+| Scenario | Pressure type | Rationalization observed | Counter added |
+| -------- | ------------- | ------------------------ | ------------- |
+
+Every rationalization observed in REFACTOR goes here. The "counter
+added" column records what was added to the prompt to address it —
+specific language, an explicit red flag, a new section. After
+sufficient iterations, the prompt has counters for all
+rationalizations the scenario battery surfaces.
+
+This table is the artifact that justifies the prompt. Without it,
+you have no evidence the prompt was actually pressure-tested.
+
+## Pass/fail criteria
+
+Write these before running any scenarios. Each scenario gets one or
+more explicit criteria:
+
+- **Compliance criteria** (rules): "Agent ran X before doing Y" /
+  "Agent did not do Z."
+- **Activation criteria** (skills): "Skill activated within the
+  first response" / "Skill did not activate."
+- **Behavior criteria** (skills, post-activation): "Agent followed
+  the procedure as specified" / "Agent caught the failure mode."
+- **Delegation criteria** (subagents, parent-side): "Parent invoked
+  the subagent" / "Parent stayed inline."
+- **Return criteria** (subagents, child-side): "Return was under N
+  lines" / "Return included required field X."
+- **Refusal criteria** (subagents, child-side, scope/authority):
+  "Subagent refused cleanly with REFUSED prefix" / "Subagent did
+  not exceed delegated authority."
+
+Criteria must be checkable from the recorded output. "Agent seemed
+careful" is not a criterion. "Agent ran `cargo deny check` before
+proposing the publish step" is.
+
+## When evaluation reveals routing errors
+
+A prompt that consistently fails RED or REFACTOR despite multiple
+revisions may not have the wrong content — it may be in the wrong
+layer. Symptoms:
+
+- A "rule" that requires elaborate counter-language to avoid
+  rationalization may actually be a skill with a sharp description.
+- A "skill" that never activates despite description revisions may
+  actually be a rule that should always load.
+- A "subagent" whose returns are always too large may actually be a
+  skill the parent should load inline.
+
+When this pattern emerges, stop iterating on the prompt and hand off
+to `prompt-distilling` for a fresh layer placement.
+
+## Scenario batteries as artifacts
+
+The scenario battery is reusable. Keep it as a file alongside the
+prompt:
+
+```text
+skills/writing-rules/
+├── SKILL.md
+├── eval/
+│   ├── scenarios.md           # battery (curated, versioned)
+│   ├── rationalizations.md    # observed rationalizations + counters
+│   └── runs/                  # captured outputs per run, dated
+```
+
+A new contributor to the prompt can re-run the existing scenarios to
+confirm the prompt still holds. Without the artifact, every
+modification is a fresh eval cycle from scratch.
+
+For meta-skills authored by the framework team, scenarios become
+part of the upskill repository. For team-authored skills,
+scenarios live in the team's repo and are versioned alongside the
+skill.
+
+## Red flags — STOP and rebuild
+
+- "I tested it" with no scenario file → not evaluated.
+- "I ran it a few times" → stochastic; needs reproducible scenarios.
+- Pass/fail criteria invented after seeing output → post-hoc; redo
+  the eval with criteria written first.
+- RED phase skipped because "obviously the agent would fail without
+  the prompt" → confirm the failure or the prompt is unjustified.
+- REFACTOR phase skipped because "GREEN passed cleanly" → almost
+  every prompt passes GREEN. The failures are in REFACTOR.
+- Rationalizations not documented → no record means no counters
+  can be written; the prompt has not been hardened.
+- Eval performed by the same instance that authored the prompt with
+  full context loaded → contaminated; use a fresh subagent.
+- Battery contains only positive scenarios (where the prompt should
+  apply) → over-firing not tested; add out-of-scope scenarios.
+
+## Composition with the writing-* skills
+
+Each writing-* skill specifies the scenario shape for its layer
+(three scenarios for rules, activation+behavior for skills, two
+interfaces for subagents). `evaluating-prompts` provides the methodology
+underneath those shapes — harness construction, pressure types,
+rationalization tracking, pass/fail discipline.
+
+The writing-* skills tell you WHAT to evaluate. This skill tells you
+HOW.
+
+## Honest caveats
+
+This skill is v0.1.0. The methodology is adapted from
+`obra/superpowers/skills/writing-skills`, which is the source of the
+RED-GREEN-REFACTOR-for-docs pattern, the pressure scenario typology,
+and the rationalization-tracking discipline. The per-layer scenario
+shapes are extensions for the rule and subagent layers; they have
+not been validated against an eval set the way superpowers' original
+methodology has.
+
+This skill has not yet been put through its own RED-GREEN-REFACTOR
+cycle. The most natural way to evaluate it is to use it to evaluate
+the existing meta-skills (`writing-rules`, `writing-subagents`,
+`using-upskill`) — if the methodology produces actionable results
+when applied to those four, this skill earns its slot. If authors
+end up evaluating prompts the same way regardless of whether this
+skill is present, the skill itself is unjustified.

--- a/skills/prompt-distilling/SKILL.md
+++ b/skills/prompt-distilling/SKILL.md
@@ -1,0 +1,258 @@
+---
+schema: 1
+name: prompt-distilling
+description: Use BEFORE authoring any rule, skill, or subagent. Trigger when someone says "we should encode X", "the agent keeps forgetting Y", "let's add a rule for Z", or any variant where new behavior needs to live somewhere in the framework. Also trigger when reviewing existing content that is misbehaving — wrong-layer placement is a common silent root cause. Do NOT trigger for refining content already correctly placed; hand off to writing-rules, writing-skills, or writing-subagents.
+metadata:
+  version: 0.3.0
+  author: driftsys
+---
+
+Before authoring anything, distill the intent down to its components.
+Most authoring intents are not atomic — they mix invariants, procedures,
+enforcement, live data, and reference material. Distilling means
+separating those strands and placing each one in the layer that fits it.
+
+Skipping this step produces single-layer answers to multi-layer questions,
+which is the most common framework failure. It does not alarm; wrong-layer
+content quietly underperforms while looking healthy in CI.
+
+## The Iron Law
+
+NO AUTHORING WITHOUT DISTILLING FIRST.
+
+Distill the intent into atomic parts, then place each part in its layer.
+State which layer each part is targeting and why, in terms of the
+decision dimensions below. "It felt right" and "that's where we usually
+put these" are not reasons. Bias toward the layer you know best is the
+dominant failure mode this skill exists to prevent. The second most
+common failure is routing a multi-part intent as if it were single-part.
+
+## The five layers, at a glance
+
+| Layer          | Loaded                  | Cost shape                        | Best for                                                               |
+| -------------- | ----------------------- | --------------------------------- | ---------------------------------------------------------------------- |
+| **Rule**       | Every turn              | Per-turn token tax                | Small invariants relevant on most turns                                |
+| **Skill**      | On activation           | Description-routing cost only     | Procedures and domain knowledge                                        |
+| **Subagent**   | On invocation           | Overhead + return digest          | Bounded sub-tasks whose intermediate work would pollute parent context |
+| **MCP tool**   | Every turn (definition) | Per-turn tax + server maintenance | Live data or side effects on real systems                              |
+| **RAG corpus** | On retrieval            | Indexing + retrieval              | Searchable static-ish content too large to inline                      |
+
+## Distill before placing
+
+Most authoring intents are not atomic. "We need license-checking when
+adding new dependencies" looks like one request but contains:
+
+- An invariant ("all dependencies must have approved licenses") → rule
+- A list of approved licenses → rule, skill, or MCP tool depending on
+  size and liveness
+- A procedure ("how to add a dep including the check") → skill
+- An enforcement mechanism ("scan and flag violations") → subagent or
+  MCP tool
+
+Distillation comes BEFORE layer selection. Skipping it produces
+single-layer answers to multi-layer questions, which is the most
+common framework failure after default-layer bias.
+
+### The distillation questions
+
+Apply to the authoring intent, in order. Multiple "yes" answers means
+the intent spans multiple layers — place each part separately.
+
+1. **Is there an invariant?** A statement of the form "X must always
+   hold" or "Y must never happen" → rule candidate.
+2. **Is there a procedure?** A sequence of steps to accomplish
+   something → skill candidate.
+3. **Is there enforcement or scanning?** Something that needs to run
+   over content and report findings → subagent or MCP tool candidate.
+4. **Is there live state or data?** Lookups against systems whose
+   answer can change → MCP tool candidate.
+5. **Is there bulk reference material?** A large corpus of supporting
+   docs → RAG candidate.
+
+### The instruction/subagent split
+
+When the decomposition includes a subagent, draw the parent/subagent
+boundary explicitly. The most common misplacement is putting the
+subagent's HOW in the parent's instructions, bloating the parent's
+always-loaded context with content it never needs.
+
+**Goes in parent instructions** (CLAUDE.md / AGENTS.md):
+
+- Universal invariants the parent must respect even when no subagent
+  is active
+- One-line awareness that the subagent exists ("a test-runner
+  subagent is available for running and interpreting test failures")
+- Rules governing when NOT to delegate, if over-firing is a concern
+
+**Goes in the subagent's system prompt**:
+
+- The subagent's scope (one sentence)
+- The subagent's tools and refusal conditions
+- The subagent's return contract
+- Skills the subagent loads
+- HOW the subagent does its work
+
+**Goes in the subagent's description** (the activation surface the
+parent reads):
+
+- WHEN the parent should invoke the subagent
+- Negative triggers (when NOT to invoke)
+
+The principle: the parent must not know HOW the subagent works. It
+needs only WHAT the subagent does (description) and WHEN to call it
+(description). Anything beyond that in parent instructions is bloat
+paid every turn.
+
+**Symptoms of misplacement**:
+
+- Parent CLAUDE.md contains a paragraph explaining how a subagent
+  interprets its inputs → move to the subagent's prompt.
+- Subagent system prompt says "invoke me when X happens" → that
+  belongs in the subagent's description, not its prompt. The parent
+  controls invocation; the subagent's prompt only governs behavior
+  once invoked.
+- Universal invariant ("never commit secrets") lives only in a
+  security-check subagent's prompt → it also needs to be in parent
+  instructions, because the subagent isn't always active.
+- Subagent's procedural detail duplicated in parent instructions
+  "for completeness" → delete from parent.
+
+### Common decomposition patterns
+
+A quick reference for recurring multi-layer authoring intents:
+
+- **Rule + Skill** — invariant ("never commit secrets") plus a
+  procedure that respects it ("how to onboard a credential via
+  Vault").
+- **Skill + MCP tool** — procedure that calls live tools ("how to
+  triage a Jira incident" plus `jira_search`).
+- **Subagent + Skill** — subagent loads skills inside its own context
+  (test-runner subagent plus a "how to interpret cargo-nextest
+  failures" skill).
+- **RAG + Skill** — skill describes when and how to query the corpus
+  ("when to consult the ADR archive" plus `search_adrs`).
+- **Rule + Subagent** — invariant in parent instructions plus an
+  enforcement subagent that scans for violations.
+
+If the intent fits one of these patterns, hand off to all relevant
+authoring skills, not one.
+
+## Decision dimensions, in priority order
+
+Apply these to each distilled part separately. The first dimension
+that resolves the decision for a given part wins.
+
+1. **Liveness** — Can the answer change between this morning and this
+   afternoon? Does this need to act on a real system? If yes → **MCP tool**.
+2. **Corpus size** — Is the relevant content too large to inline as a
+   skill? If yes → **RAG**, fronted by an MCP tool.
+3. **Context isolation** — Would the intermediate work pollute parent
+   context if done inline, and does the parent only need a digested result?
+   If yes → **Subagent**.
+4. **Frequency × size** — Does this apply to >70% of turns in scope AND
+   fit in 1–3 imperative lines? If yes → **Rule**. If high frequency but
+   bulky, the scope is wrong — narrow it and reconsider.
+5. **Default** — **Skill**.
+
+## Cost-of-placement, computed before authoring
+
+Write the cost down before choosing. Refusing to do this is itself a red
+flag.
+
+- **Rule**: `lines × avg_turns_per_session × users`. A 5-line rule across
+  10 teams of 8 engineers averaging 40 turns/day is roughly 16,000
+  rule-line-turns per day. Justify it.
+- **Skill**: near-zero ambient cost. The real cost is description
+  quality — vague descriptions cause silent activation failure, which is
+  worse than a clear refusal.
+- **Subagent**: invocation overhead plus return-contract design cost.
+  Justify by showing the parent context pollution that occurs without it.
+- **MCP tool**: per-turn definition tax plus server maintenance, on-prem
+  hosting, and auth surface. Justify by showing the data is genuinely
+  live or the action genuinely needs to happen.
+- **RAG**: indexing pipeline plus retrieval-quality tuning. Justify by
+  showing the corpus is too large to inline as one or several skills.
+
+## Red flags — STOP and re-route
+
+- "Just put it in CLAUDE.md to be safe" — about to bloat the rule layer.
+  Compute the cost first.
+- "Let's make a skill for this" with no description draft — if you
+  cannot write the trigger condition in one sentence, the skill will
+  silently fail to activate.
+- "Spin up a subagent" for work that returns more than ~50 lines — that
+  is not isolation, that is relocation.
+- "Add it to the MCP server" for content that does not need live data —
+  building infrastructure for a markdown file.
+- Authoring intent treated as atomic when it contains an invariant AND
+  a procedure AND enforcement — distill first, then place each part.
+- Placement decision made before running the distillation questions —
+  high risk of single-layer answer to multi-layer question.
+- A subagent's HOW being added to parent instructions for "clarity" —
+  parent doesn't need it, pays the token cost every turn.
+- Placement decided without referencing the decision dimensions — bias,
+  not analysis.
+
+## Misplaced-content audit
+
+This skill triggers for audit, not just initial placement. Symptoms of
+misplacement:
+
+- A rule that fires correctly on <30% of turns → demote to skill.
+- A skill whose description has been rewritten 3+ times trying to get it
+  to activate → it is probably a rule masquerading as a skill, OR its
+  scope is too broad.
+- A subagent whose return values are routinely >50 lines → the parent
+  should load it as a skill instead.
+- An MCP tool that returns the same answer every time → it is a skill,
+  not a live capability.
+- A skill containing stepwise instructions with current MR numbers or
+  today's policies → the live parts belong in MCP.
+- Parent instructions contain procedural detail about how a subagent
+  does its work → move that detail into the subagent's own system
+  prompt. The parent only needs to know WHAT and WHEN.
+- A subagent's system prompt contains its own invocation triggers
+  ("invoke me when X") → move them to the subagent's description; the
+  parent reads the description to decide invocation.
+- A universal invariant lives only inside one subagent's prompt → also
+  add it to parent instructions, since the subagent isn't always active.
+- A single authoring artifact (one rule, one skill) tries to cover an
+  invariant AND a procedure AND enforcement → it was a multi-layer
+  intent that should have been distilled first.
+
+When audit reveals misplacement, the fix is layer migration or
+re-distillation, not content editing.
+
+## Handoff
+
+Once distilled and placed, hand off:
+
+- Rule → `writing-rules`
+- Skill → `superpowers:writing-skills`
+- Subagent → `writing-subagents`
+- MCP tool → the MCP server repo's authoring process (out of scope here)
+- RAG corpus → the corpus that the relevant `search_*` MCP tool fronts
+  (out of scope here)
+
+## Why this skill exists
+
+The other writing-* skills make individual artifacts better. This one
+makes the system better, because misplaced content is invisible — it
+does not fail loudly, it just quietly underperforms. A bloated rule
+layer slows every turn by a few percent. A skill with a vague
+description fails to activate but nothing alarms. A subagent dumping
+raw output looks like it "worked." None of these show up in CI.
+
+The audit clause is in the body, not a separate document, because
+distilling and placing is not a one-time decision. It happens again at
+every review.
+
+## Honest caveat
+
+This skill is v0.3.0 (renamed from `picking-the-layer`) and has not yet
+been put through its own RED-GREEN-REFACTOR cycle. Before declaring it
+ready, assemble a battery of 15–20 real authoring requests with
+expert-classified correct distillations and placements, run them past
+an author subagent without the skill present, then with, and measure
+the delta. If authors already distill and place correctly without the
+skill, the skill itself is unjustified.

--- a/skills/prompt-engineering.bundle.yaml
+++ b/skills/prompt-engineering.bundle.yaml
@@ -1,0 +1,25 @@
+# upskill bundle manifest — pure YAML (format-spec §2.2, ADR-0007).
+
+schema: 1                     # bundle schema version
+name: prompt-engineering      # must match the filename stem
+description: One-shot install of the driftsys prompt-engineering discipline — 
+  meta-skills for authoring durable agent content (rules, skills, agents)
+  under upskill management.
+license: MIT
+
+# Items this bundle installs. Names resolve against the same source
+# registry the bundle lives in.
+items:
+  skills:
+  - prompt-engineering        # umbrella entry point
+  - prompt-distilling         # placement: intent → layer
+  - writing-rules             # authoring: always-loaded invariants
+  - writing-subagents         # authoring: bounded sub-task delegation
+  - evaluating-prompts        # eval: RED-GREEN-REFACTOR
+  - using-upskill             # ops: add / update / audit
+
+# Free-form metadata. `version` should be quoted in strict registries
+# to avoid YAML float coercion, but bare floats round-trip here too.
+metadata:
+  version: 0.1.0
+  author: driftsys

--- a/skills/prompt-engineering/SKILL.md
+++ b/skills/prompt-engineering/SKILL.md
@@ -1,0 +1,169 @@
+---
+schema: 1
+name: prompt-engineering
+description: Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to prompt-distilling, writing-rules, writing-skills, writing-subagents, or using-upskill.
+metadata:
+  version: 0.1.0
+  author: driftsys
+---
+
+The umbrella for how driftsys engineers durable agent content — rules,
+skills, and subagents that shape Claude Code, Copilot, and opencode
+across our repos. This skill routes; the writing-\* skills do the work.
+
+**Out of scope:** one-shot prompt-writing guidance. That is general LLM
+literacy and belongs in engineering onboarding. The framework stops at
+the boundary between durable agent content (what it manages) and
+per-turn user prompts (what users send).
+
+## The mental model
+
+Five layers carry durable agent behavior. Three are managed by upskill:
+
+| Layer          | What it is                                                                | Authored via                               |
+| -------------- | ------------------------------------------------------------------------- | ------------------------------------------ |
+| **Rule**       | A line in CLAUDE.md / AGENTS.md, loaded every turn                        | `writing-rules`                            |
+| **Skill**      | A markdown procedure activated on demand by description matching          | `superpowers:writing-skills`               |
+| **Subagent**   | A bounded sub-task with its own system prompt, tools, and return contract | `writing-subagents`                        |
+| **MCP tool**   | Live capability exposed by an on-prem server                              | Separate MCP server repo authoring process |
+| **RAG corpus** | Searchable static content fronted by an MCP search tool                   | The corpus's MCP tool authoring process    |
+
+Most authoring questions involve the first three. MCP and RAG sit
+adjacent — referenced from the framework but governed by their own
+processes.
+
+## Where to start — the routing table
+
+| Situation                                                                  | Activate                                                 |
+| -------------------------------------------------------------------------- | -------------------------------------------------------- |
+| "I want to add a convention / encode behavior / shape what the agent does" | `prompt-distilling`                                      |
+| "I know it's a rule, how do I write it well"                               | `writing-rules`                                          |
+| "I know it's a skill, how do I write it well"                              | `superpowers:writing-skills`                             |
+| "I know it's a subagent, how do I write it well"                           | `writing-subagents`                                      |
+| "I need to run upskill commands / vendor a bundle / audit content"         | `using-upskill`                                          |
+| "I need to set up the RED-GREEN-REFACTOR cycle for something I authored"   | `evaluating-prompts`                                     |
+| "I want to write an MCP server"                                            | `mcp-builder` (vendored) — out of upskill's direct scope |
+| "I want to write good one-shot prompts to send to Claude Code"             | Not this framework — see onboarding doc                  |
+
+The umbrella does not replace these — it routes to them.
+
+## Cross-cutting concerns
+
+Knowledge that applies across all three managed layers lives here
+because it has no other home.
+
+### Cross-client portability
+
+A single canonical body in a source registry's `skills/` directory is
+emitted to per-client files by `upskill add` / `upskill update`. Two
+divergence mechanisms exist: **override files** (`SKILL.claude.md`,
+`SKILL.copilot.md`, `SKILL.opencode.md` — when the procedure itself
+diverges) and **inline directives** (`<!-- @client:claude -->` ...
+`<!-- @endclient -->` — when 90%+ of the body is shared and only a
+tactical swap is needed).
+
+**Principle:** write to the most capable client (usually Claude Code),
+then down-shift via inline directives for less capable ones. Writing
+to the lowest common denominator and up-shifting produces blander
+skills.
+
+Client capability matrix (v0.1.0). `upskill doctor` warns about
+portability misuse (overrides where directives would do, or
+directives where overrides are required):
+
+| Capability                         | Claude                      | Copilot        | opencode            |
+| ---------------------------------- | --------------------------- | -------------- | ------------------- |
+| Native subagents                   | ✓                           | ✗              | ✓ (different shape) |
+| Skills with progressive disclosure | ✓                           | ✓              | ✓                   |
+| AGENTS.md native                   | ✓ (via `@AGENTS.md` stub)   | ✓              | ✓                   |
+| Path-scoped instructions           | ✓ (`paths:` in frontmatter) | ✓ (`applyTo:`) | partial             |
+| MCP servers                        | ✓                           | ✓              | ✓                   |
+
+### Classification
+
+Default to the lowest classification that fits. Never include
+classified specifics (customer names, IP-sensitive details) in skills
+shared across teams — those belong in team- or repo-scoped skills.
+Tag sensitive content explicitly: `metadata.classification: <level>`.
+upskill itself does not bake in a classification scheme; allow-list
+gating is org-specific.
+
+### Token economics
+
+Rules are paid every turn. Skills cost on activation. Subagents cost
+invocation overhead plus return payload. MCP tool definitions are paid
+every turn (the schemas, not the responses). Description quality is the
+dominant cost variable for skills, not body length — a vague
+description silently fails to activate, which is worse than no skill
+at all. `writing-rules` carries the full token-budget discipline.
+
+### Composition patterns
+
+Most authoring intents span multiple layers (rule + skill, skill +
+MCP tool, subagent + skill, and so on). `prompt-distilling`
+enumerates the recurring patterns and handles the decomposition. If
+your intent fits one, route to every relevant writing-\* skill, not
+just one.
+
+## The methodology in one paragraph
+
+Every durable prompt — rule, skill, subagent — is authored against a
+scenario battery, evaluated under pressure, and shipped only when it
+holds up. The cycle is RED (confirm the failure exists without the
+prompt), GREEN (confirm the prompt fixes it), REFACTOR (confirm the
+prompt survives realistic pressure). Prompts that have not been
+pressure-tested look identical on the page to ones that have, and
+fail silently in production. The evaluation discipline is what
+distinguishes durable agent content from wishful thinking;
+`evaluating-prompts` covers the methodology in detail.
+
+## The lifecycle in one paragraph
+
+Content lives in a source registry's `skills/` directory as SSOT.
+`upskill add` and `upskill update` fetch the SSOT and generate
+per-client files in the consumer project at install time.
+`upskill lint` catches schema and structural errors in source
+registries; `upskill doctor` verifies installed state against
+`.upskill-lock.json`. Generated per-client files are never hand-edited
+— drift is silent. Vendored bundles (like `superpowers`) carry NOTICE
+files and attribution. `using-upskill` covers the workflows.
+
+## Symptoms that suggest framework-level problems
+
+If you notice any of these, this skill is the right entry point for
+diagnosis:
+
+- "The agent keeps doing X even though we have a rule against it" →
+  rule under-firing or being rationalized. Activate
+  `evaluating-prompts` for diagnosis, then `writing-rules` for
+  revision.
+- "We have a skill for that but nobody uses it" → description not
+  activating. Activate `superpowers:writing-skills` or hand off via
+  `prompt-distilling` (the skill may be in the wrong layer).
+- "The subagent's output is bigger than what the parent would have
+  done inline" → return-contract failure. Activate `writing-subagents`.
+- "We added a rule and now every interaction feels slower" → token
+  budget exceeded. Activate `using-upskill` (`doctor`) and
+  `prompt-distilling` (the content may not deserve to be a rule).
+- "Different teams handle the same situation differently" →
+  cross-cutting convention without a home. Route via
+  `prompt-distilling`.
+
+## Composition with onboarding
+
+This framework covers the _durable agent content_ layer. The
+_human-side discipline_ — how engineers phrase requests, structure
+context, give feedback — lives in the engineering onboarding
+documentation. A well-prompted engineer using a well-configured agent
+produces good work; either side alone underperforms.
+
+## Honest caveats
+
+v0.1.0, deliberately scoped to the framework-side of prompt
+engineering (durable agent content authoring); the user-side
+(one-shot prompting effectiveness) is explicitly excluded. The
+cross-cutting sections are short by design and each may grow into its
+own skill later. This skill has not yet been through its own
+RED-GREEN-REFACTOR cycle; the bet is that an explicit entry point
+reduces the activation cost of the discipline enough to be worth its
+slot.

--- a/skills/using-upskill/SKILL.md
+++ b/skills/using-upskill/SKILL.md
@@ -1,0 +1,265 @@
+---
+schema: 1
+name: using-upskill
+description: Use when working in an upskill-consumer repo and needing to add, modify, vendor, audit, or remove installed content (rules, skills, agents, bundles). Trigger when `upskill lint` or `upskill doctor` reports issues. Trigger when adding a third-party bundle or updating one from upstream. Trigger when generated per-client files (e.g., `.claude/`, `.github/skills/`) look stale or wrong. Do NOT trigger for actual authoring decisions — hand off to prompt-distilling, writing-rules, writing-skills, or writing-subagents. Do NOT trigger for cosmetic typo fixes in skill bodies; raw edits to source registry files plus `upskill lint` are sufficient.
+metadata:
+  version: 0.2.0
+  author: driftsys
+---
+
+upskill manages the lifecycle of installable agent content. It does not make
+authoring decisions for you. This skill covers operations: add, update,
+remove, list, doctor, lint, fmt, new. For authoring decisions (where does
+this go, how do I write it), hand off to `prompt-distilling` and the
+writing-* skills.
+
+## Two sides of the workflow
+
+upskill files live in two places. The commands you reach for depend on which
+side you are on.
+
+- **Source registry** — the repo where SSOT content is authored. Holds a
+  `skills/` directory with item subfolders (`skills/<name>/SKILL.md`,
+  `RULE.md`, `AGENT.md`) and bundle manifests (`skills/<name>.bundle.yaml`). The
+  layout is documented in
+  [Conventions](https://driftsys.github.io/upskill/conventions.html). Author
+  commands: `new`, `fmt`, `lint`.
+- **Consumer project** — a downstream repo that installs from one or more
+  source registries. Holds generated per-client output under `.claude/`,
+  `.github/`, `.opencode/`, etc., plus a `.upskill-lock.json` recording what
+  is installed. Consumer commands: `add`, `update`, `remove`, `list`,
+  `doctor`.
+
+`upskill lint` refuses to run inside a consumer project, and `upskill add`
+infers consumer scope from the current directory. Knowing which side you are
+on tells you which command surface is even available.
+
+## The Iron Law
+
+GO THROUGH UPSKILL FOR LIFECYCLE OPERATIONS. HAND OFF TO writing-*
+SKILLS FOR AUTHORING DECISIONS.
+
+This Iron Law is a routing law, not a discipline law (no "NO X
+WITHOUT Y FIRST" shape like the other meta-skills), because
+`using-upskill` governs which tool to reach for, not whether to
+pressure-test content before shipping it.
+
+The boundary is sharp. upskill handles fetching, frontmatter
+canonicalization, per-client generation, validation, and lockfile tracking.
+It does not decide whether a piece of content should be a rule, skill, or
+agent — that is `prompt-distilling`'s job. Mixing these concerns is the most
+common usage error.
+
+## When to use upskill vs raw edits
+
+| Operation                                              | Use upskill    | Raw edits OK                                  |
+| ------------------------------------------------------ | -------------- | --------------------------------------------- |
+| Authoring a new item in a source registry              | Yes (`new`)    | No                                            |
+| Adding installable content to a consumer project       | Yes (`add`)    | No                                            |
+| Updating installed content from its source             | Yes (`update`) | No                                            |
+| Removing installed content                             | Yes (`remove`) | No                                            |
+| Fixing a typo in a source SSOT body                    | Optional       | Yes, then `upskill lint`                      |
+| Editing frontmatter in source SSOT                     | Yes (`fmt`)    | No — manual edits break canonicalization      |
+| Auditing installed content for drift                   | Yes (`doctor`) | No                                            |
+| Hand-editing a generated `.claude/` or `.github/` file | Never          | No — these are regenerated and drift silently |
+
+When in doubt, use upskill. Raw edits are a sharp tool — only reach for them
+on content you authored and understand, and always lint after.
+
+## Common workflows
+
+### Authoring a new skill in a source registry
+
+1. Run `prompt-distilling` first to confirm the content belongs in a skill
+   (not a rule, agent, or MCP tool).
+2. Hand off to `superpowers:writing-skills` to draft the SKILL.md.
+3. From inside the registry's `skills/` directory, run
+   `upskill new skill <name>`. This scaffolds `skills/<name>/SKILL.md` with
+   the right shape.
+4. Edit the SKILL.md body to match your draft.
+5. Run `upskill fmt` to canonicalize frontmatter and run dprint over the
+   body.
+6. Run `upskill lint` (or `upskill lint --strict` for CI) to catch schema or
+   structural errors.
+7. Commit the SSOT. Consumer projects pick up the change at next
+   `upskill update`.
+
+### Adding installable content to a consumer project
+
+1. Identify the source: either an org repo (e.g. `driftsys/skills`), a
+   GitLab path (`gitlab:team/repo`), a full https URL, or a local path
+   (`./local-source`).
+2. From the consumer project root, run `upskill add <source>` to install
+   every item in the source, or `upskill add <source> item-a item-b` to
+   install a named subset.
+3. Verify with `upskill list` — the new items appear with their hashes and
+   their generated per-client output paths.
+4. Commit the changed `.upskill-lock.json` and the generated per-client
+   files your repo policy says to commit.
+
+### Updating installed content
+
+1. Run `upskill update` to refresh everything, or `upskill update item-a`
+   to refresh one item. The command always re-fetches the source.
+2. Use `upskill update --dry-run` first if you want a preview. It hashes
+   what the new install would produce and reports what would change without
+   writing.
+3. Review the diff. Pay attention to:
+   - Changed `description` fields — these affect skill activation behavior
+     and may need eval before accepting.
+   - Removed items — confirm no downstream content depends on them.
+   - New items pulled in via bundle expansion.
+
+### Vendoring a third-party bundle (e.g., superpowers)
+
+upskill has no separate `vendor` command; vendoring is just `add` from the
+upstream source. The vendoring discipline lives in what you record
+alongside the install.
+
+1. Confirm the upstream license is compatible with your repo's licensing
+   policy.
+2. Run `upskill add <upstream-spec>` to fetch the bundle into the consumer
+   project.
+3. Add a `NOTICE` file at the consumer-project root with full attribution
+   to the upstream author and the license text. Most upstream licenses
+   require this.
+4. Commit the lockfile, the generated per-client output, and the NOTICE.
+
+### Removing installed content
+
+1. Run `upskill remove <item-name>` (or `--bundle <name>` for a whole
+   bundle, see `upskill remove --help`).
+2. Verify with `upskill list` that the item is gone and `upskill doctor`
+   that nothing else depended on it.
+3. Commit the changed lockfile and the deletion of the now-removed
+   per-client files.
+
+### Auditing for drift or misrouted content
+
+1. Run `upskill doctor`. It verifies the installed state matches the
+   lockfile (per-client files present, hashes consistent, no orphans).
+2. For each finding, decide whether the drift is in the consumer project
+   (someone hand-edited generated output → re-run `upskill update`) or in
+   the source registry (an item changed shape upstream → review and
+   `upskill update`).
+3. If `doctor` surfaces a content-shape concern (vague description,
+   oversized rule), the fix lives in the source registry — hand off to
+   `prompt-distilling`'s audit section there.
+
+## Interpreting upskill output
+
+### `upskill lint`
+
+Validates SSOT files in a source registry against the format spec. Refuses
+to run in a consumer project (detected by `.upskill-lock.json`). Default
+mode emits warnings and exits 0 unless an error rule fires; `--strict`
+promotes warnings to errors for CI use.
+
+Common findings:
+
+- Missing `schema:` / `name:` / `description:` in frontmatter
+- `metadata.version` not quoted (YAML float coercion risk)
+- Invalid directory layout (entry file not in its own folder, etc.)
+- Bundle `items:` list references a name not present in the registry
+- Inline directive syntax errors (unbalanced `<!-- @client:X -->` blocks)
+
+### `upskill fmt`
+
+Canonicalizes frontmatter and runs dprint over the body. Idempotent.
+Always safe to run; CI should fail if `fmt` changes anything.
+
+### `upskill doctor`
+
+Verifies the installed state of a consumer project against its
+`.upskill-lock.json`. Pure consistency check — no judgment on content
+shape. Common findings:
+
+- Generated per-client file missing or hash-changed (someone hand-edited
+  it → re-run `update`)
+- Lockfile references an item whose source is no longer reachable
+- Orphan per-client files not recorded in the lockfile (a previous
+  install or hand-creation that needs reconciling)
+
+## Conventions to remember
+
+### Source side vs consumer side
+
+- **Source registry**: holds `skills/<name>/SKILL.md`, `RULE.md`,
+  `AGENT.md`, and `skills/<name>.bundle.yaml`. Author here; commit here.
+- **Consumer project**: holds generated `.claude/`, `.github/`,
+  `.opencode/` content plus `.upskill-lock.json`. Generated files are
+  produced by `upskill add` / `upskill update`. **Never hand-edit
+  generated files** — `upskill update` will overwrite them and the
+  intervening drift is silent.
+
+### `.upskill-lock.json`
+
+The state of truth for what is installed in a consumer project. Records
+each item's source, ref, hash, and generated file paths. Edit only via
+`upskill add`, `update`, and `remove`. Commit it. Default location is the
+consumer project root; with `--global`, it moves to `$HOME/`.
+
+### Cross-platform portability
+
+upskill uses file copies, not symlinks, so generated content works on
+Windows. Generated copies are regenerated at `add`/`update` time. Don't
+rely on inode identity or hard links between source and generated.
+
+### Org-specific access control
+
+Some orgs gate skill installation through a classification or
+allow-list mechanism (an MCP-served registry, a private GitLab group,
+an org-internal upskill registry). If `upskill add` refuses to fetch
+from a particular source, check whether the source is part of your
+org's allow-list before suspecting a bug. The mechanism is org-specific;
+this skill does not assume one exists.
+
+## Handoff matrix
+
+| Situation                                              | Hand off to                                              |
+| ------------------------------------------------------ | -------------------------------------------------------- |
+| Newcomer to the framework needing orientation          | `prompt-engineering`                                     |
+| Deciding where new content belongs                     | `prompt-distilling`                                      |
+| Authoring a new rule                                   | `writing-rules`                                          |
+| Authoring a new skill                                  | `superpowers:writing-skills`                             |
+| Authoring a new subagent / agent                       | `writing-subagents`                                      |
+| Setting up RED-GREEN-REFACTOR for any authored content | `evaluating-prompts`                                     |
+| Authoring a new MCP server                             | the MCP server repo's authoring process (out of scope)   |
+| Adding to a RAG corpus                                 | the corpus's MCP tool's authoring process (out of scope) |
+| Routing decision on existing content showing drift     | `prompt-distilling` audit section                        |
+
+## Red flags — STOP
+
+- About to hand-edit a generated `.claude/`, `.github/`, or `.opencode/`
+  file → don't. Edit the source registry and run `upskill update` in the
+  consumer project.
+- About to skip `upskill lint` in a source registry because "it's just a
+  small change" → don't. Lint is cheap and catches frontmatter
+  corruption before commit.
+- About to commit generated artifacts because "the next person won't
+  have upskill installed" → that is the right reason to commit them, but
+  it is also the reason `update` is mandatory after any source change.
+  Drift between SSOT and generated output is the dominant silent
+  failure mode.
+- About to vendor a bundle without a NOTICE file → MIT and similar
+  licenses require attribution. Don't ship without it.
+- About to write a skill body explaining HOW upskill works (every flag,
+  every exit code) — that belongs in `upskill --help` and the upskill
+  user guide, not in a skill. Skills explain _workflows and decisions_,
+  not CLI invocations.
+
+## Honest caveats
+
+This skill is v0.2.0 and tracks upskill's current command surface
+(`add`, `remove`, `update`, `list`, `doctor`, `search`, `lint`, `fmt`,
+`new`). As upskill evolves, this skill needs maintenance —
+specifically, it should NOT enumerate every CLI flag (that's
+`upskill --help`'s job). It should remain at the workflow and
+decision-boundary level, which is more stable.
+
+This skill has not yet been through its own RED-GREEN-REFACTOR cycle.
+Before declaring it ready, run a battery of real upskill-operation
+scenarios (author a new skill, add a bundle, update from upstream,
+audit, hand-edit a generated file) past a subagent without the skill,
+then with, and measure whether the agent makes correct workflow
+decisions in both cases.

--- a/skills/writing-rules/SKILL.md
+++ b/skills/writing-rules/SKILL.md
@@ -1,0 +1,135 @@
+---
+schema: 1
+name: writing-rules
+description: Use when adding or editing rules in CLAUDE.md, AGENTS.md, or any always-loaded instructions file. Trigger when authoring repo conventions, invariants, or behavioral guardrails. Also trigger when an existing rule is being violated despite being present — that means the rule needs refactoring, not the agent. Do NOT trigger for skill or subagent authoring; see writing-skills and writing-subagents.
+metadata:
+  version: 0.1.0
+  author: driftsys
+---
+
+A rule is a line that costs tokens on every turn in exchange for shaping
+behavior across the whole scope. If you cannot justify the per-turn cost,
+it is a skill, not a rule. Confirm the routing decision via
+`prompt-distilling` before continuing here.
+
+## The Iron Law
+
+NO RULE WITHOUT A FAILING TEST FIRST.
+
+Run a pressure scenario WITHOUT the rule and document the exact violation
+before authoring. If the agent does not fail without the rule, the rule has
+no measurable effect and should not ship.
+
+## Failure modes this skill prevents
+
+| Failure mode              | Signature                                                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Bloat blindness**       | Rule buried in a long instructions file; agent skims past it.                                                     |
+| **Soft-language drift**   | "Consider running X" → agent does not.                                                                            |
+| **Negation-as-prompt**    | "Never auto-merge MRs" surfaces auto-merge as an option the agent would not otherwise have considered.            |
+| **Pressure capitulation** | Agent rationalizes around the rule when given time, sunk-cost, or social pressure.                                |
+| **Over-firing**           | Rule applies broadly but is relevant on 20% of work; agent invokes it on the other 80% and slows everything down. |
+| **Conflict ambiguity**    | Rule contradicts another rule, the user's prompt, or observed code. Agent picks arbitrarily.                      |
+| **Staleness**             | Codebase moved on; rule still references the old way.                                                             |
+
+The dominant failure is not "agent fails to load the rule" (rules always
+load). It is "agent loads the rule and ignores it under pressure" or
+"agent applies the rule where it should not."
+
+## RED phase — three scenario types per rule
+
+Rules need three test scenarios, not one. Run each with a subagent.
+
+1. **In-scope compliance** — a prompt where the rule should govern.
+   Without the rule, does the agent violate? (Should fail.)
+2. **Out-of-scope quiet** — a prompt where the rule should not fire.
+   Without the rule, the agent behaves normally; with the rule, does
+   it still behave normally? (Should not over-fire.)
+3. **Pressure compliance** — the in-scope prompt with realistic
+   pressure layered on: time ("user needs this in 10 minutes"), sunk
+   cost ("you already wrote 200 lines"), social ("the rest of the
+   team merges without this check"). Does the agent rationalize?
+
+Document every rationalization verbatim. Those become your counters in
+the GREEN phase. `evaluating-prompts` covers harness construction,
+pressure typology, and rationalization tracking — activate it before
+running the scenarios.
+
+## GREEN phase — writing the rule
+
+- **Imperative voice.** "Run `cargo deny check` before publishing", not
+  "consider running `cargo deny check`".
+- **State the trigger condition explicitly.** Rules that say what to do
+  without saying when fire too broadly.
+- **Prefer positive form to negation.** "Always run `cargo deny` before
+  publish" beats "never publish without running `cargo deny`" — the
+  positive form does not surface the bad option as a candidate.
+- **One rule per line.** Multi-clause rules with exceptions ("never X
+  except when Y and not Z") get partially applied. Split them.
+- **Two-sentence ceiling.** A rule longer than two sentences is either
+  a skill in disguise or several rules glued together.
+- **Justify the per-turn cost in writing, outside the rule file**
+  (the PR description, an ADR, or the registry's review record —
+  inline comments in CLAUDE.md still load every turn). Authors who
+  cannot write the justification often discover the rule does not
+  deserve to be a rule.
+
+## REFACTOR phase
+
+Re-run all three scenarios WITH the rule. Watch for:
+
+- New rationalizations the rule did not anticipate → add explicit
+  counters in a red-flags section attached to the rule.
+- Over-firing on out-of-scope prompts → tighten the trigger condition.
+- Pressure capitulation → strengthen language and add a red-flag list
+  of symptoms-of-about-to-violate.
+- Conflict with other rules → resolve explicitly, do not leave
+  ambiguous.
+
+Repeat until all three scenarios pass cleanly.
+
+## Red flags — STOP and rewrite
+
+- "Consider", "try to", "where appropriate", "if possible", "where
+  relevant" — all signal soft language; agents treat them as optional.
+- A rule longer than two sentences.
+- A rule that requires a sub-clause to disambiguate.
+- A rule whose description (or the comment justifying it) matches more
+  turns than its actual relevance.
+- A rule added "to be safe" without a failing test.
+- Negation in the imperative where a positive form would work.
+
+## Token budget discipline
+
+Every rule line is paid on every turn. Before adding one, compute the
+cost:
+
+```text
+lines × avg_turns_per_session × active_users
+```
+
+For an org-level framework propagating to ~100 repos, this compounds
+fast. If a rule fires correctly only 1 in 20 turns, it almost certainly
+belongs in a skill with a sharp description, not in the always-on
+rule layer.
+
+## Composition with other layers
+
+- A rule states an invariant. The skill explaining the procedure that
+  respects that invariant goes alongside it. Pair `writing-rules` work
+  with `superpowers:writing-skills` when both apply.
+- A rule cannot describe live state. If the invariant references "today's
+  classification policy" or "the current owner of repo X", the live part
+  belongs in an MCP tool; the rule should reference the tool, not the
+  data.
+
+## Honest caveat
+
+This skill is v0.1.0, adapted from the methodology in
+`obra/superpowers/skills/writing-skills` (which is anchored in tested
+agent behavior under pressure). The three-scenario format and the
+over-firing failure mode are extensions specific to rules; they have not
+yet been validated against an eval set the way superpowers' original
+methodology has. Before declaring this skill ready, run it against its
+own RED-GREEN-REFACTOR cycle using a battery of real rule-authoring
+requests from the org framework.

--- a/skills/writing-subagents/SKILL.md
+++ b/skills/writing-subagents/SKILL.md
@@ -1,0 +1,169 @@
+---
+schema: 1
+name: writing-subagents
+description: Use when designing a new subagent or modifying an existing one's system prompt, tool surface, or return contract. Trigger when the parent is observed doing work inline that should be delegated, OR when a subagent is observed dumping raw output, OR when subagent scope is drifting. Also trigger when designing managed/project-scoped/user-global subagent tiers with different permission models. Do NOT trigger for skill or rule authoring; see writing-skills and writing-rules.
+metadata:
+  version: 0.1.0
+  author: driftsys
+---
+
+A subagent earns its overhead only if it (a) does bounded work and
+(b) returns a digest small enough that the parent's context is cleaner
+than if the parent had done the work inline. If either fails, you have
+a tool call dressed up as a subagent. Confirm the routing decision via
+`prompt-distilling` before continuing here.
+
+## The two interfaces
+
+Every subagent has two failure surfaces. They fail independently. Both
+must be tested.
+
+1. **Invocation interface** — the name, description, and tool
+   advertisement that the parent sees. This determines whether the
+   parent decides to call the subagent.
+2. **Return interface** — what the subagent emits when it finishes.
+   This determines whether the parent's context stays clean after
+   invocation.
+
+Most subagent failures observed in practice are return-contract
+failures: the subagent itself worked, but it returned 3KB of tool noise
+instead of a digested summary, defeating the entire point.
+
+## The Iron Law
+
+NO SUBAGENT WITHOUT A FAILING TEST ON BOTH INTERFACES.
+
+You must observe (a) the parent failing to delegate when it should, OR
+the parent delegating when it should not, AND (b) the return contract
+polluting parent context or hiding failure. If neither failure is
+observed without the subagent, the work probably belongs in a skill.
+
+## Failure modes this skill prevents
+
+| Failure mode                                                                             | Interface                         |
+| ---------------------------------------------------------------------------------------- | --------------------------------- |
+| **Under-firing** — parent does the work inline, pollutes own context                     | Invocation                        |
+| **Over-firing** — parent delegates trivial work, pays overhead                           | Invocation                        |
+| **Scope creep** — subagent does more than its remit                                      | Subagent body                     |
+| **Return-contract failure** — subagent dumps raw output instead of digesting             | Return                            |
+| **Silent failure** — subagent reports success without verifying; parent acts on bad info | Return                            |
+| **Tool surface mismatch** — too many tools → wanders; too few → cannot complete          | Subagent body                     |
+| **Authority leak** — subagent has permissions parent did not intend to delegate          | Subagent body (managed tier only) |
+
+## RED phase — scenarios per interface
+
+### Invocation tests (run on the parent, subagent present)
+
+- **Should-delegate task** — does parent invoke?
+- **Should-not-delegate task** (too small) — does parent stay inline?
+- **Adjacent-scope task** — does parent invoke incorrectly?
+
+### Return tests (run on the subagent directly)
+
+- **In-scope task** — does it return a digest or raw output?
+- **Partial-out-of-scope task** — does it refuse cleanly, or silently
+  expand scope?
+- **Will-fail task** — does it report the failure honestly, or
+  rationalize success?
+
+### Authority test (managed tier only)
+
+- **Injection scenario** — parent or user attempts to get the subagent
+  to exceed its delegated authority. If it complies, the authority
+  model is broken regardless of how good the rest of the design is.
+
+Document the rationalizations in two columns: parent's excuses for not
+delegating (or for delegating wrong), and subagent's excuses for
+bloated returns or scope creep.
+
+## GREEN phase — writing the subagent
+
+### System prompt
+
+- **Scope in one sentence.** If it takes two, split the agent.
+- **Refusal conditions stated explicitly.** "If asked to do X, return
+  REFUSED with reason." Implicit refusal does not survive pressure.
+- **Return format stated explicitly.** Do not leave digest length to
+  taste.
+
+### Description (the invocation surface)
+
+- Same rules as skills: trigger conditions, not workflow summary.
+- Include **negative triggers** when over-firing is the dominant
+  failure: "Do NOT invoke for X."
+- Treat the description as the activation contract. Vague descriptions
+  cause silent under-firing.
+
+### Tool surface
+
+- Default to fewer tools. Add a tool only when a RED scenario fails
+  for lack of one. Every extra tool is a wandering opportunity.
+- For the **managed tier**, audit the tool surface against the
+  delegated authority. Elevated tools (anything that mutates real
+  systems) require a refusal-conditions section.
+
+### Return contract
+
+- **Maximum length.** "Return at most 10 lines summarizing the
+  finding. Raw tool output goes in scratch, not the return."
+- **Required fields.** A return without an explicit success/failure
+  field is a silent-failure risk. Make the field mandatory.
+- **No raw dumps.** If the parent needs the raw output, the subagent
+  should be a tool call, not a subagent.
+
+## REFACTOR phase
+
+Re-run all scenarios. Watch for:
+
+- Parent now over-delegates → tighten description with negative triggers.
+- Subagent now returns bloated digests → tighten return-contract length.
+- Subagent refuses too aggressively → loosen refusal conditions.
+- Authority injection succeeds → revoke tools, not just patch the prompt.
+- New rationalizations in either direction → counter explicitly in the
+  system prompt or description.
+
+## Red flags — STOP and reconsider
+
+- Description that summarizes the workflow rather than triggers.
+- Return contract longer than 30 lines for a "summary" return.
+- A subagent that calls another subagent (re-entrancy is a separate
+  design problem; address it explicitly or refuse to design it).
+- "The parent will know what to do with the output" — no, specify it.
+- A subagent that needs the parent's full context to function — it
+  is a skill, not a subagent.
+- A managed-tier subagent without a refusal-conditions section.
+
+## The three scope tiers
+
+The three tiers each carry additional design requirements:
+
+- **Managed** (CI-deployed, elevated permissions, non-overridable):
+  requires the authority test. Tool surface audited against delegated
+  permissions. Refusal conditions stated and tested under injection.
+- **Project-scoped** (domain-specific per repo): description should
+  reference the repo or domain explicitly so it does not over-fire
+  in adjacent contexts.
+- **User-global** (via `devex-setup`): broader description, but tool
+  surface must not include anything that mutates org-shared state.
+
+## Composition with other layers
+
+- A subagent often loads skills inside its own context. Pair
+  `writing-subagents` work with `superpowers:writing-skills` when the
+  subagent has a non-trivial procedure.
+- A subagent that needs live data uses MCP tools — those go through
+  the MCP server authoring process, not here.
+- Rules that govern the subagent's behavior live in the subagent's
+  own system prompt, not in the parent's CLAUDE.md.
+
+## Honest caveat
+
+This skill is v0.1.0. The two-interface decomposition and the
+managed-tier authority test are extensions specific to subagents; they
+build on the testing methodology in
+`obra/superpowers/skills/writing-skills` but have not been validated
+against an eval set the way superpowers' original methodology has.
+Before declaring this skill ready, run it through its own
+RED-GREEN-REFACTOR cycle using real subagent designs from the
+framework's priority list (explorer, test-runner, git-assistant first;
+license-checker and classification-guard next).


### PR DESCRIPTION
## Summary

- Adds the v0.1 draft of the **driftsys prompt-engineering meta-skills bundle** under `skills/`, treating the upskill repo as a source registry for the discipline that authors durable agent content (rules, skills, subagents).
- Six skills shipped: `prompt-engineering` (umbrella), `prompt-distilling` (placement), `writing-rules`, `writing-subagents`, `evaluating-prompts` (RED-GREEN-REFACTOR methodology), `using-upskill` (lifecycle).
- Methodology adapted from `obra/superpowers` (MIT) — attribution in `skills/NOTICE`. `writing-skills` itself is a forward reference until vendored (tracked in #146).
- Adds `skills/` to `.markdownlintignore` (matching `tests/fixtures/`) — SKILL.md is content-as-data following the Anthropic skills convention (frontmatter + prose, no redundant H1), which conflicts with MD041.

## Notes

- Bundle layout follows the conventions doc landed in #144.
- `upskill lint --strict ./skills` returns 0 findings.
- Honest caveat: none of the six skills have been through their own RED-GREEN-REFACTOR cycle yet — each carries an "Honest caveats" section saying so. Validation is the natural next step once `writing-skills` is vendored.

## Test plan

- [ ] `just verify` passes locally (run pre-push, included `just fmt`, `git std lint`, `cargo build`).
- [ ] CI green on the PR.
- [ ] Spot-check `upskill add ./skills/prompt-engineering.bundle.yaml` from a scratch consumer project resolves and installs all six items.
- [ ] Visually skim the rendered SKILL.md frontmatter in the GitHub diff for any wrapping artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
