### PR TITLE
docs: ADR-0008 plugin install shellout + format-spec §3.7 plugins

### DIFF
--- a/docs/adr/0008-plugin-install-shellout.md
+++ b/docs/adr/0008-plugin-install-shellout.md
@@ -1,0 +1,241 @@
+# Plugin installation — extend Bundle, shell out to client CLIs
+
+**Status**: Proposed (2026-05-22)
+
+## Context
+
+[ADR-0001](./0001-multi-kind-compiler-architecture.md) and
+[ADR-0003](./0003-generation-pipeline.md) established the SSOT-to-files
+contract: upskill reads SSOT items, generates per-client output files,
+and never invokes the host client at runtime. That contract is the
+right shape for rules, skills, and agents — they are content that
+each client consumes by reading files from a known path.
+
+Plugins do not fit that mold. Claude Code plugins (e.g.
+`superpowers`), VS Code extensions, and opencode modules carry hooks,
+slash commands, marketplace registration, and runtime state that the
+host client owns. Re-emitting that surface from upskill SSOT
+duplicates the upstream plugin, can't capture hooks and commands
+cleanly, and would have us shipping a second-class copy of artifacts
+like `superpowers` that already exist as fully-formed Claude Code
+plugins maintained upstream.
+
+Each of the three target clients exposes a CLI for plugin/extension
+management:
+
+- `claude plugin marketplace add <source>` +
+  `claude plugin install <plugin>@<marketplace> --scope <s>`
+- `code --install-extension <ext-id>`
+- `opencode plugin <module>`
+
+These CLIs already implement the lifecycle work (marketplace
+registration, version pinning, scope semantics, idempotent updates)
+that upskill would otherwise reinvent.
+
+## Decision
+
+### Bundle gains an optional `plugins:` map
+
+[ADR-0007](./0007-bundle-yaml-format.md) defined the Bundle YAML
+schema. This ADR extends it with one new top-level key, `plugins:`, a
+map keyed by upskill-level plugin name:
+
+```yaml
+schema: 1
+name: superpowers-baseline
+description: Superpowers plugin and supporting rules
+items:
+  rules:
+    - license-awareness
+plugins:
+  superpowers:
+    claude:
+      source: anthropics/claude-plugins
+      plugin: superpowers
+      install_url: https://github.com/obra/superpowers#install
+    vscode:
+      extension: anthropic.superpowers
+      install_url: https://marketplace.visualstudio.com/items?itemName=anthropic.superpowers
+    opencode:
+      module: superpowers-opencode
+      install_url: https://opencode.ai/plugins/superpowers
+```
+
+- The map key (`superpowers`) is the upskill-level identity — used in
+  the lockfile, CLI output, and `upskill remove plugin superpowers`.
+- Per-client blocks (`claude`, `vscode`, `opencode`) are each
+  optional and typed to that client's actual install primitives. A
+  plugin that only exists for Claude Code carries only a `claude:`
+  block.
+- Each client block MAY carry `install_url:` — a URL surfaced in the
+  warn-skip message when that client's CLI is not on PATH. The field
+  is optional; if absent, the warning fires without the URL line.
+
+### Install shells out to the native CLI
+
+When `upskill add` resolves a bundle that declares plugins and the
+user has the matching client targeted, upskill shells out:
+
+| Client   | Commands                                                                                                                                                                  |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| claude   | `claude plugin marketplace add <source>` (idempotent — checked via `claude plugin marketplace list`), then `claude plugin install <plugin>@<marketplace> --scope <scope>` |
+| vscode   | `code --install-extension <extension>` (naturally idempotent)                                                                                                             |
+| opencode | `opencode plugin <module>`                                                                                                                                                |
+
+Claude's `--scope` derives from upskill's existing project/global
+flag:
+
+| upskill flag       | lockfile location          | `claude --scope` |
+| ------------------ | -------------------------- | ---------------- |
+| `--global`         | `$HOME/.upskill-lock.json` | `user`           |
+| (default, project) | `<cwd>/.upskill-lock.json` | `project`        |
+
+Claude's `local` scope (machine-local, not committed) is not exposed
+via upskill; users who want it can call `claude plugin install`
+directly.
+
+### CLI-missing policy: warn-skip
+
+If a bundle declares a plugin for client X and X's CLI is not on
+PATH, upskill prints a warning and continues with the rest of the
+install:
+
+```text
+warn: claude CLI not found; skipped plugin 'superpowers' for claude.
+      manual install: https://github.com/obra/superpowers#install
+```
+
+The rules/skills/agents portion of the bundle still installs.
+Rationale: in mixed-client teams, the bundle's primary value
+(SSOT-derived content) is independent of whether every plugin lands.
+Failing the whole install for a missing tertiary tool is hostile.
+
+### Lockfile records the resolved triple
+
+Each plugin install records `(client, marketplace, plugin-name,
+scope)` (or the client-equivalent identifier) in
+`.upskill-lock.json` so `remove` / `update` / `doctor` can invoke the
+inverse CLI command. The lockfile schema bump is documented in the
+format spec.
+
+### Implementation shape
+
+New module `src/plugin.rs`, peer to `src/fetch.rs` and `src/auth.rs`.
+Uses `std::process::Command` directly — no new dependencies, no
+async, consistent with the project's "shell out to git" stance from
+ADR-0001.
+
+The module exposes typed functions per client operation
+(`claude_marketplace_add`, `claude_plugin_install`,
+`vscode_extension_install`, `opencode_plugin_install`, plus the
+inverse uninstall calls). All return `anyhow::Result<T>` and never
+write to stdout/stderr — presentation lives in `main.rs` per
+existing project conventions.
+
+### Platform scope
+
+Per PR #135 the supported Windows path is `install.sh` under
+WSL — `upskill` runs as a Linux ELF binary regardless of host
+OS. Inside WSL all three target CLIs are present on PATH as
+ordinary Linux executables (Claude Code, opencode, and VS Code
+each ship Linux builds; VS Code's WSL-remote workflow
+additionally injects a `code` shim that proxies to Windows-side
+`code.exe` via interop). Shellout is indistinguishable from
+native Linux — no `cfg!(windows)` branches, no `PATHEXT`
+handling, no `.cmd` argument-escaping concerns.
+
+Presence detection for the warn-skip policy uses
+`Command::spawn()` and matches `ErrorKind::NotFound`, which is
+portable across every platform Rust targets — no `which` crate
+dependency, consistent with ADR-0001 §3.
+
+Users who side-step the stance via `cargo install upskill` on
+native Windows are unsupported. Native-Windows shellout (`.cmd`
+shims, `PATHEXT`, Rust 1.77 batch-argument escaping, VS Code
+Insiders discovery) would need its own ADR if that ever moves
+in-scope.
+
+## Consequences
+
+**Positive.**
+
+- Native lifecycle (marketplace updates, version pinning, scope
+  semantics, idempotent upgrades) is delegated to each client, not
+  reinvented in upskill.
+- Consistent with the "shell out to git instead of `git2`" stance
+  from [ADR-0001](./0001-multi-kind-compiler-architecture.md) §3 — a
+  proven pattern in the codebase.
+- Bundle authors get a single SSOT entry that fans out to whichever
+  clients the consumer has installed.
+- Warn-skip keeps mixed-client teams unblocked: a Copilot-only user
+  installing a bundle that includes a `claude:` plugin block sees a
+  warning and gets the rest of the bundle.
+
+**Negative.**
+
+- Determinism loss: install outcome depends on which CLIs are
+  present, which marketplaces they have configured, and which
+  upstream plugin versions resolve at install time. Integration tests
+  must shim the client CLIs on PATH (the pattern already used by
+  `fetch.rs::tests` for `git`).
+- Bundle schema growth: `plugins:` is a non-trivial sub-shape with
+  three client-specific variants. Future clients add more variants.
+- Warn-skip can mask a real misconfiguration (user expected the
+  plugin to install but the CLI was missing). Mitigated by `doctor`,
+  which surfaces every skipped plugin during reconciliation.
+
+## Alternatives considered
+
+**(a) Patch `~/.claude/settings.json` directly.** Rejected:
+depends on undocumented internal schema, breaks across Claude Code
+versions, duplicates registration logic the CLI already implements,
+and doesn't generalise to VS Code or opencode (each has its own
+state file).
+
+**(b) Re-emit plugin contents from SSOT.** Rejected: duplicates
+upstream plugins like `superpowers`, can't represent hooks or slash
+commands in the current item model, and forces upskill to track
+upstream plugin updates instead of letting each client's CLI do it.
+
+**(c) New top-level `Plugin` kind alongside rules/skills/agents.**
+Rejected: plugins compose with rules/skills/agents in practice — a
+bundle like `superpowers-baseline` wants to ship both the plugin and
+its supporting rules in one unit. Keeping plugins on Bundle aligns
+with how authors actually distribute them. A standalone Plugin kind
+would force users to install two artifacts to get a coherent setup.
+
+**(d) Hard-fail when the target client's CLI is missing.** Rejected:
+too hostile to mixed-client teams. A user who runs `upskill add
+some-bundle --claude --vscode` and is missing `code` would lose the
+entire install. Warn-skip lets the parts that can install proceed,
+and `doctor` reports the gap so it's not silently lost.
+
+**(e) Per-plugin `install_url` (single URL, applies to all
+clients).** Rejected: install instructions are usually
+client-specific — "how to install superpowers for Claude Code"
+differs from "how to install the VS Code extension." Per-client
+`install_url:` is the natural home.
+
+**(f) Make `install_url:` required.** Rejected: forces every bundle
+author to track three URLs even when the warn-skip path is
+unlikely. Optional, with a graceful degradation in the warning
+message when absent.
+
+## Migration
+
+None — additive. `plugins:` is optional on Bundle. Existing bundles
+without plugin entries are unaffected. v0.6 introduces the schema
+extension; v0.5 bundles parse unchanged.
+
+## References
+
+- Predecessor: [ADR-0001](./0001-multi-kind-compiler-architecture.md)
+  (SSOT-to-files contract, dependency philosophy).
+- Predecessor: [ADR-0003](./0003-generation-pipeline.md)
+  (generation pipeline this ADR explicitly _does not_ extend).
+- Predecessor: [ADR-0007](./0007-bundle-yaml-format.md)
+  (Bundle YAML schema this ADR extends with `plugins:`).
+- Authoritative spec: [`docs/format-spec.md`](../format-spec.md) §3.7
+  — to be updated with the `plugins:` sub-shape.
+- Claude Code plugin CLI: `claude plugin --help`,
+  `claude plugin marketplace --help`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@ Numbered sequentially. Status one of: Proposed | Accepted | Superseded.
 - [0005 — skills.sh ecosystem interop](0005-skills-sh-ecosystem-interop.md)
 - [0006 — Flat item layout — drop kind subdirectories](0006-flat-item-layout.md)
 - [0007 — Bundle file format — YAML, not Markdown-with-frontmatter](0007-bundle-yaml-format.md)
+- [0008 — Plugin installation — extend Bundle, shell out to client CLIs](0008-plugin-install-shellout.md)

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -433,6 +433,12 @@ items:
 
 requires: []
 
+plugins:
+  superpowers:
+    claude:
+      source: anthropics/claude-plugins
+      plugin: superpowers
+
 metadata:
   version: "1.2.0"
   author: platform-dx
@@ -452,6 +458,7 @@ documentation; the parser ignores it (§2.2).
 | `items.skills` | string[] | no       | Skill names.                         |
 | `items.agents` | string[] | no       | Agent names.                         |
 | `requires`     | array    | no       | Bundle dependencies. See below.      |
+| `plugins`      | map      | no       | Client-native plugins. See below.    |
 | `metadata`     | map      | no       | Same as §3.6.                        |
 
 `requires` entries are maps. Each entry references another bundle by `name`, optionally pinned
@@ -475,6 +482,80 @@ Implementations:
   bundles. Item-level conflicts (the same item name resolving to different sources or versions)
   MUST be reported as errors.
 - MUST reject circular `requires` chains as errors.
+
+#### `plugins` map
+
+The optional `plugins` map declares client-native plugins that accompany this bundle. Unlike
+rules, skills, and agents (which are SSOT content rendered per-client by the generation
+pipeline), plugins are installed via each client's native CLI. See
+[ADR-0008](adr/0008-plugin-install-shellout.md) for design rationale.
+
+Each entry in the `plugins` map is keyed by an upskill-level plugin name (used in the lockfile,
+CLI output, and `upskill remove`). The value is a map of per-client install descriptors:
+
+```yaml
+plugins:
+  superpowers:
+    claude:
+      source: anthropics/claude-plugins
+      plugin: superpowers
+      install_url: https://github.com/obra/superpowers#install
+    vscode:
+      extension: anthropic.superpowers
+      install_url: https://marketplace.visualstudio.com/items?itemName=anthropic.superpowers
+    opencode:
+      module: superpowers-opencode
+      install_url: https://opencode.ai/plugins/superpowers
+```
+
+**Per-client descriptor fields:**
+
+| Client     | Field         | Type   | Required | Description                                                     |
+| ---------- | ------------- | ------ | -------- | --------------------------------------------------------------- |
+| `claude`   | `source`      | string | YES      | Marketplace source (passed to `claude plugin marketplace add`). |
+| `claude`   | `plugin`      | string | YES      | Plugin identifier (passed to `claude plugin install`).          |
+| `claude`   | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.              |
+| `vscode`   | `extension`   | string | YES      | Extension ID (passed to `code --install-extension`).            |
+| `vscode`   | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.              |
+| `opencode` | `module`      | string | YES      | Module name (passed to `opencode plugin`).                      |
+| `opencode` | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.              |
+
+A plugin entry MAY declare any subset of client blocks. A plugin that only exists for Claude
+Code carries only a `claude:` block; clients without a matching block skip installation
+silently.
+
+**Install behavior:**
+
+| Client   | CLI commands                                                                                             |
+| -------- | -------------------------------------------------------------------------------------------------------- |
+| claude   | `claude plugin marketplace add <source>`, then `claude plugin install <plugin>@<source> --scope <scope>` |
+| vscode   | `code --install-extension <extension>`                                                                   |
+| opencode | `opencode plugin <module>`                                                                               |
+
+Claude's `--scope` derives from upskill's project/global context:
+
+| upskill scope | `claude --scope` |
+| ------------- | ---------------- |
+| project       | `project`        |
+| global        | `user`           |
+
+**CLI-missing policy (warn-skip):** If the target client's CLI is not on PATH, the
+implementation MUST print a warning and continue installing the rest of the bundle. If
+`install_url` is present, it MUST be included in the warning message. The rules, skills, and
+agents portion of the bundle MUST install regardless of plugin installation success.
+
+**Lockfile recording:** Each successfully installed plugin MUST be recorded in the lockfile
+with its client, identifier, and scope so that `remove`, `update`, and `doctor` can invoke the
+inverse CLI command.
+
+Implementations:
+
+- MUST shell out to the native client CLI for plugin installation — MUST NOT manipulate client
+  config files directly.
+- MUST treat plugin install as idempotent (re-running on an already-installed plugin is a
+  no-op).
+- MUST use warn-skip when the target client CLI is not found (`ErrorKind::NotFound`).
+- MUST NOT fail the entire bundle install when a single plugin install fails or is skipped.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the design documentation for the plugin install feature (epic:plugin-install).

### Changes

1. **ADR-0008** — Documents the decision to shell out to native client CLIs (claude, code, opencode) for plugin installation rather than manipulating client config files directly.

2. **format-spec.md §3.7** — Extends the Bundle schema documentation with the `plugins:` map specification:
   - Per-client descriptor fields (claude: source/plugin, vscode: extension, opencode: module)
   - Install behavior and CLI commands
   - Claude scope mapping (project → project, global → user)
   - CLI-missing warn-skip policy
   - Implementation requirements (MUST/MUST NOT)

### Design Decisions

- Plugins are delegated to each client's native lifecycle (marketplace, version pinning, scope semantics)
- Consistent with existing "shell out to git" pattern from ADR-0001
- Warn-skip keeps mixed-client teams unblocked
- No new dependencies or runtime changes

Closes #152