### PR TITLE
feat(bundle): add plugins: map to Bundle schema with typed descriptors

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -192,6 +192,7 @@ mod tests {
                     version: None,
                 })
                 .collect(),
+            plugins: Default::default(),
             metadata: None,
             extra: Default::default(),
         }

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -31,6 +31,12 @@ pub struct Bundle {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires: Vec<Requires>,
 
+    /// Client-native plugins installed via shellout (ADR-0008, §3.7).
+    /// Map key is the upskill-level plugin name; value carries per-client
+    /// install descriptors.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub plugins: BTreeMap<String, PluginEntry>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
 
@@ -71,4 +77,54 @@ pub struct Requires {
     /// the resolver to interpret in C2.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+}
+
+/// Per-plugin entry in the `plugins:` map. Contains optional descriptors
+/// for each supported client. A plugin MAY target a single client, a
+/// subset, or all three.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PluginEntry {
+    /// Claude Code plugin descriptor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<ClaudePluginDescriptor>,
+
+    /// VS Code extension descriptor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vscode: Option<VscodePluginDescriptor>,
+
+    /// opencode module descriptor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opencode: Option<OpencodePluginDescriptor>,
+}
+
+/// Install descriptor for Claude Code plugins.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClaudePluginDescriptor {
+    /// Marketplace source (passed to `claude plugin marketplace add`).
+    pub source: String,
+    /// Plugin identifier (passed to `claude plugin install`).
+    pub plugin: String,
+    /// URL shown in warn-skip message when CLI not found.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_url: Option<String>,
+}
+
+/// Install descriptor for VS Code extensions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VscodePluginDescriptor {
+    /// Extension ID (passed to `code --install-extension`).
+    pub extension: String,
+    /// URL shown in warn-skip message when CLI not found.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_url: Option<String>,
+}
+
+/// Install descriptor for opencode modules.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OpencodePluginDescriptor {
+    /// Module name (passed to `opencode plugin`).
+    pub module: String,
+    /// URL shown in warn-skip message when CLI not found.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_url: Option<String>,
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -7,7 +7,10 @@ pub mod rule;
 pub mod skill;
 
 pub use agent::{Agent, Mode, ToolCap};
-pub use bundle::{Bundle, BundleItems, Requires};
+pub use bundle::{
+    Bundle, BundleItems, ClaudePluginDescriptor, OpencodePluginDescriptor, PluginEntry, Requires,
+    VscodePluginDescriptor,
+};
 pub use common::{Audience, CURRENT_SCHEMA, License, Metadata, SchemaVersion};
 pub use rule::{Rule, Scope};
 pub use skill::Skill;

--- a/src/parse/bundle.rs
+++ b/src/parse/bundle.rs
@@ -384,4 +384,112 @@ requires:
     fn renamed(template: &str, new_name: &str) -> String {
         template.replace("name: platform-baseline", &format!("name: {new_name}"))
     }
+
+    #[test]
+    fn load_parses_plugins_with_all_clients() {
+        let content = "schema: 1
+name: with-plugins
+description: Bundle with plugins declared
+items:
+  rules:
+    - license-awareness
+plugins:
+  superpowers:
+    claude:
+      source: anthropics/claude-plugins
+      plugin: superpowers
+      install_url: https://github.com/obra/superpowers#install
+    vscode:
+      extension: anthropic.superpowers
+      install_url: https://marketplace.visualstudio.com/items?itemName=anthropic.superpowers
+    opencode:
+      module: superpowers-opencode
+      install_url: https://opencode.ai/plugins/superpowers
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "with-plugins.bundle.yaml", content);
+
+        let bundle = load(&path).expect("load");
+        assert_eq!(bundle.plugins.len(), 1);
+
+        let sp = &bundle.plugins["superpowers"];
+        let claude = sp.claude.as_ref().expect("claude block");
+        assert_eq!(claude.source, "anthropics/claude-plugins");
+        assert_eq!(claude.plugin, "superpowers");
+        assert_eq!(
+            claude.install_url.as_deref(),
+            Some("https://github.com/obra/superpowers#install")
+        );
+
+        let vscode = sp.vscode.as_ref().expect("vscode block");
+        assert_eq!(vscode.extension, "anthropic.superpowers");
+        assert_eq!(
+            vscode.install_url.as_deref(),
+            Some("https://marketplace.visualstudio.com/items?itemName=anthropic.superpowers")
+        );
+
+        let opencode = sp.opencode.as_ref().expect("opencode block");
+        assert_eq!(opencode.module, "superpowers-opencode");
+        assert_eq!(
+            opencode.install_url.as_deref(),
+            Some("https://opencode.ai/plugins/superpowers")
+        );
+    }
+
+    #[test]
+    fn load_parses_plugins_with_single_client() {
+        // A plugin that only targets one client is valid.
+        let content = "schema: 1
+name: claude-only
+description: Plugin for Claude only
+items:
+  skills: []
+plugins:
+  my-plugin:
+    claude:
+      source: my-org/marketplace
+      plugin: my-plugin
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "claude-only.bundle.yaml", content);
+
+        let bundle = load(&path).expect("load");
+        assert_eq!(bundle.plugins.len(), 1);
+
+        let plugin = &bundle.plugins["my-plugin"];
+        assert!(plugin.claude.is_some());
+        assert!(plugin.vscode.is_none());
+        assert!(plugin.opencode.is_none());
+    }
+
+    #[test]
+    fn load_accepts_bundle_without_plugins() {
+        // Bundles without plugins: are valid (existing behavior).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "platform-baseline.bundle.yaml", PLATFORM);
+
+        let bundle = load(&path).expect("load");
+        assert!(bundle.plugins.is_empty());
+    }
+
+    #[test]
+    fn plugins_round_trips_through_serialize() {
+        let content = "schema: 1
+name: roundtrip
+description: Roundtrip test
+items:
+  rules: []
+plugins:
+  example:
+    vscode:
+      extension: publisher.example
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "roundtrip.bundle.yaml", content);
+
+        let bundle = load(&path).expect("load");
+        let serialized = serde_yaml_ng::to_string(&bundle).expect("serialize");
+        let reparsed: Bundle = serde_yaml_ng::from_str(&serialized).expect("reparse");
+        assert_eq!(bundle.plugins, reparsed.plugins);
+    }
 }

--- a/tests/fixtures/bundles/with-plugins.bundle.yaml
+++ b/tests/fixtures/bundles/with-plugins.bundle.yaml
@@ -1,0 +1,17 @@
+schema: 1
+name: with-plugins
+description: Bundle that also declares client-native plugins
+license: proprietary
+
+items:
+  rules:
+    - license-awareness
+
+plugins:
+  superpowers:
+    claude:
+      source: anthropics/claude-plugins
+      plugin: superpowers
+      install_url: https://github.com/obra/superpowers#install
+    vscode:
+      extension: anthropic.superpowers

--- a/tests/parse_bundles.rs
+++ b/tests/parse_bundles.rs
@@ -16,8 +16,8 @@ fn discovers_every_fixture_bundle() {
     let names: Vec<&str> = bundles.iter().map(|(_, b)| b.name.as_str()).collect();
     assert_eq!(
         names,
-        vec!["platform-baseline", "platform-extras"],
-        "fixture set is two bundles, sorted by path"
+        vec!["platform-baseline", "platform-extras", "with-plugins"],
+        "fixture set is three bundles, sorted by name"
     );
 }
 
@@ -51,4 +51,30 @@ fn extras_pins_baseline_with_caret_constraint() {
     assert_eq!(extras.requires.len(), 1);
     assert_eq!(extras.requires[0].name, "platform-baseline");
     assert_eq!(extras.requires[0].version.as_deref(), Some("^1.0.0"));
+}
+
+#[test]
+fn with_plugins_declares_client_native_plugins() {
+    let bundles = discover(Path::new(FIXTURES)).expect("discover");
+    let (_, bundle) = bundles
+        .iter()
+        .find(|(_, b)| b.name == "with-plugins")
+        .expect("with-plugins present");
+
+    assert_eq!(bundle.plugins.len(), 1);
+
+    let sp = &bundle.plugins["superpowers"];
+    let claude = sp.claude.as_ref().expect("claude descriptor");
+    assert_eq!(claude.source, "anthropics/claude-plugins");
+    assert_eq!(claude.plugin, "superpowers");
+    assert_eq!(
+        claude.install_url.as_deref(),
+        Some("https://github.com/obra/superpowers#install")
+    );
+
+    let vscode = sp.vscode.as_ref().expect("vscode descriptor");
+    assert_eq!(vscode.extension, "anthropic.superpowers");
+    assert!(vscode.install_url.is_none());
+
+    assert!(sp.opencode.is_none());
 }


### PR DESCRIPTION
## Summary

Extends the Bundle model (format-spec §3.7) with the `plugins:` map per ADR-0008. This is the schema and parser layer — no runtime behavior yet (install/shellout comes in #149, pipeline wiring in #150).

### Changes

**`src/model/bundle.rs`:**
- Added `plugins: BTreeMap<String, PluginEntry>` field to `Bundle` (optional, defaults empty)
- New types: `PluginEntry`, `ClaudePluginDescriptor`, `VscodePluginDescriptor`, `OpencodePluginDescriptor`
- All with proper serde derive — no custom parser needed

**`src/model/mod.rs`:**
- Re-exports new types for downstream use

**`src/bundle.rs`:**
- Updated test helper `bundle()` to include `plugins: Default::default()`

**Tests (4 new unit + 1 new integration):**
- `load_parses_plugins_with_all_clients` — full 3-client plugin entry
- `load_parses_plugins_with_single_client` — claude-only entry
- `load_accepts_bundle_without_plugins` — backwards compat
- `plugins_round_trips_through_serialize` — serde roundtrip
- `with_plugins_declares_client_native_plugins` — integration test against fixture

**Fixture:**
- `tests/fixtures/bundles/with-plugins.bundle.yaml` — real bundle with plugins

### Backwards Compatibility

Fully additive. The `plugins:` field defaults to `BTreeMap::default()` (empty). Existing bundles parse unchanged — verified by all 177 unit tests + all integration tests passing.

Closes #148