### PR TITLE
feat(plugin): add src/plugin.rs client CLI shellout module

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn resolve_single_bundle_with_no_requires() {
         let entry = bundle("solo", items(&["r1"], &["s1"], &["a1"]), vec![]);
-        let resolved = resolve(&entry, &[entry.clone()]).unwrap();
+        let resolved = resolve(&entry, std::slice::from_ref(&entry)).unwrap();
 
         assert_eq!(resolved.bundles.len(), 1);
         assert_eq!(resolved.bundles[0].name, "solo");
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn resolve_errors_on_missing_requirement() {
         let a = bundle("a", items(&[], &[], &[]), vec!["does-not-exist"]);
-        let err = resolve(&a, &[a.clone()]).expect_err("missing");
+        let err = resolve(&a, std::slice::from_ref(&a)).expect_err("missing");
         let msg = format!("{:#}", err);
         assert!(msg.contains("does-not-exist"), "{msg}");
         assert!(msg.contains("not found"), "{msg}");

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -192,6 +192,7 @@ mod tests {
                     version: None,
                 })
                 .collect(),
+            plugins: Default::default(),
             metadata: None,
             extra: Default::default(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod lockfile;
 pub mod model;
 pub mod parse;
 pub mod pipeline;
+pub mod plugin;
 pub mod scaffold;
 pub mod search;
 pub mod source;

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -30,6 +30,8 @@ pub struct Lockfile {
     pub items: Vec<LockedItem>,
     #[serde(default)]
     pub bundles: Vec<LockedBundle>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plugins: Vec<LockedPlugin>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -71,6 +73,27 @@ pub struct LockedBundle {
     pub items: Vec<String>,
 }
 
+/// Plugin entry recorded when a bundle's `plugins:` map is installed via
+/// client CLI shellout (ADR-0008). One entry per (plugin-name, client)
+/// pair so `remove`/`update`/`doctor` can invoke the inverse CLI command.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LockedPlugin {
+    /// Upskill-level plugin name (key in the bundle's `plugins:` map).
+    pub name: String,
+    /// Client identifier: `"claude"`, `"vscode"`, or `"opencode"`.
+    pub client: String,
+    /// Client-specific identifier used for uninstall:
+    /// - claude: `"<plugin>@<source>"`
+    /// - vscode: `"<extension-id>"`
+    /// - opencode: `"<module>"`
+    pub identifier: String,
+    /// Install scope (only meaningful for claude: `"project"` or `"user"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    /// Bundle that declared this plugin.
+    pub bundle: String,
+}
+
 impl Default for Lockfile {
     fn default() -> Self {
         Self::new()
@@ -83,6 +106,7 @@ impl Lockfile {
             schema: CURRENT_SCHEMA,
             items: Vec::new(),
             bundles: Vec::new(),
+            plugins: Vec::new(),
         }
     }
 
@@ -145,6 +169,20 @@ impl Lockfile {
         self.bundles.retain(|existing| existing.name != bundle.name);
         self.bundles.push(bundle);
         self.bundles.sort();
+    }
+
+    /// Add or replace a plugin entry by `(name, client)`. Plugins are
+    /// kept sorted for deterministic on-disk output.
+    pub fn upsert_plugin(&mut self, plugin: LockedPlugin) {
+        self.plugins
+            .retain(|existing| !(existing.name == plugin.name && existing.client == plugin.client));
+        self.plugins.push(plugin);
+        self.plugins.sort();
+    }
+
+    /// Remove all plugin entries matching `name` (across all clients).
+    pub fn remove_plugins_by_name(&mut self, name: &str) {
+        self.plugins.retain(|existing| existing.name != name);
     }
 
     /// Persist to `<project_root>/.upskill-lock.json`. Pretty-printed JSON
@@ -309,6 +347,7 @@ mod tests {
         // the lockfile should record it as one item, not three.
         let report = InstallReport {
             bundles: Vec::new(),
+            plugin_results: Vec::new(),
             items: vec![
                 InstalledItem {
                     kind: ItemKind::Skill,
@@ -342,5 +381,110 @@ mod tests {
         assert_eq!(items[0].name, "code-review");
         assert_eq!(items[0].source, "local:./src");
         assert_eq!(items[0].hash, Some("sha256:abc".into()));
+    }
+
+    #[test]
+    fn upsert_plugin_adds_new_entry() {
+        let mut lock = Lockfile::new();
+        lock.upsert_plugin(LockedPlugin {
+            name: "superpowers".into(),
+            client: "claude".into(),
+            identifier: "superpowers@anthropics/claude-plugins".into(),
+            scope: Some("project".into()),
+            bundle: "baseline".into(),
+        });
+        assert_eq!(lock.plugins.len(), 1);
+        assert_eq!(lock.plugins[0].name, "superpowers");
+    }
+
+    #[test]
+    fn upsert_plugin_replaces_by_name_and_client() {
+        let mut lock = Lockfile::new();
+        lock.upsert_plugin(LockedPlugin {
+            name: "superpowers".into(),
+            client: "claude".into(),
+            identifier: "superpowers@old-source".into(),
+            scope: Some("project".into()),
+            bundle: "baseline".into(),
+        });
+        lock.upsert_plugin(LockedPlugin {
+            name: "superpowers".into(),
+            client: "claude".into(),
+            identifier: "superpowers@new-source".into(),
+            scope: Some("user".into()),
+            bundle: "baseline".into(),
+        });
+        assert_eq!(lock.plugins.len(), 1);
+        assert_eq!(lock.plugins[0].identifier, "superpowers@new-source");
+    }
+
+    #[test]
+    fn upsert_plugin_keeps_different_clients_separate() {
+        let mut lock = Lockfile::new();
+        lock.upsert_plugin(LockedPlugin {
+            name: "superpowers".into(),
+            client: "claude".into(),
+            identifier: "superpowers@src".into(),
+            scope: Some("project".into()),
+            bundle: "baseline".into(),
+        });
+        lock.upsert_plugin(LockedPlugin {
+            name: "superpowers".into(),
+            client: "vscode".into(),
+            identifier: "anthropic.superpowers".into(),
+            scope: None,
+            bundle: "baseline".into(),
+        });
+        assert_eq!(lock.plugins.len(), 2);
+    }
+
+    #[test]
+    fn remove_plugins_by_name_removes_all_clients() {
+        let mut lock = Lockfile::new();
+        lock.upsert_plugin(LockedPlugin {
+            name: "superpowers".into(),
+            client: "claude".into(),
+            identifier: "superpowers@src".into(),
+            scope: Some("project".into()),
+            bundle: "baseline".into(),
+        });
+        lock.upsert_plugin(LockedPlugin {
+            name: "superpowers".into(),
+            client: "vscode".into(),
+            identifier: "anthropic.superpowers".into(),
+            scope: None,
+            bundle: "baseline".into(),
+        });
+        lock.remove_plugins_by_name("superpowers");
+        assert!(lock.plugins.is_empty());
+    }
+
+    #[test]
+    fn plugins_roundtrip_through_save_and_load() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut lock = Lockfile::new();
+        lock.upsert_plugin(LockedPlugin {
+            name: "superpowers".into(),
+            client: "claude".into(),
+            identifier: "superpowers@anthropics/claude-plugins".into(),
+            scope: Some("project".into()),
+            bundle: "baseline".into(),
+        });
+        lock.save(tmp.path()).expect("save");
+        let loaded = Lockfile::load(tmp.path()).expect("load");
+        assert_eq!(loaded.plugins, lock.plugins);
+    }
+
+    #[test]
+    fn existing_lockfile_without_plugins_field_loads_fine() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Simulates a lockfile from before the plugins field existed.
+        std::fs::write(
+            tmp.path().join(LOCKFILE_NAME),
+            r#"{"schema": 1, "items": [], "bundles": []}"#,
+        )
+        .unwrap();
+        let lock = Lockfile::load(tmp.path()).expect("must parse");
+        assert!(lock.plugins.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,10 @@ use upskill::fmt::{FmtReport, fmt};
 use upskill::lint::{LintReport, lint};
 use upskill::pipeline::{
     DoctorReport, InstallReport, ItemKind, ListReport, ListedBundle, ListedItem, OrphanReason,
-    RemoveFilter, RemoveReport, UpdateMode, UpdateReport, UpdateStatus, doctor,
+    PluginResult, RemoveFilter, RemoveReport, UpdateMode, UpdateReport, UpdateStatus, doctor,
     install_with_lockfile, list, remove, update,
 };
+use upskill::plugin::PluginScope;
 use upskill::scaffold::{NewKind, ScaffoldReport, scaffold};
 use upskill::search;
 use upskill::source::{InstallSource, parse_install_source};
@@ -139,10 +140,13 @@ fn run_add(source: &str, items: &[String], global: bool, project: bool) -> i32 {
         }
     };
 
+    let plugin_scope = scope_to_plugin_scope(global, project);
+
     print_install_progress(&parsed);
-    match install_with_lockfile(&parsed, &target, items) {
+    match install_with_lockfile(&parsed, &target, items, plugin_scope) {
         Ok(report) => {
             print_install_report(&report, source);
+            print_plugin_results(&report);
             EXIT_SUCCESS
         }
         Err(err) => {
@@ -257,6 +261,19 @@ fn is_inside_git_repo() -> bool {
     }
 }
 
+/// Map the `--global` / `--project` CLI flags to a `PluginScope` for
+/// Claude Code plugin installation.
+fn scope_to_plugin_scope(global: bool, _project: bool) -> PluginScope {
+    if global {
+        PluginScope::User
+    } else if is_inside_git_repo() {
+        // `--project` or auto-detected git repo → project scope.
+        PluginScope::Project
+    } else {
+        PluginScope::User
+    }
+}
+
 fn print_install_report(report: &InstallReport, source: &str) {
     if style::is_quiet() {
         return;
@@ -289,6 +306,77 @@ fn print_install_report(report: &InstallReport, source: &str) {
             style::name(&name),
             clients.join(", ")
         );
+    }
+}
+
+/// Print plugin install results (success, skipped, failed) after an install.
+/// Follows the warn-skip policy: CLI-not-found prints a warning with an
+/// optional install URL; failures print the stderr output.
+fn print_plugin_results(report: &InstallReport) {
+    if style::is_quiet() || report.plugin_results.is_empty() {
+        return;
+    }
+
+    use upskill::plugin::PluginOutcome;
+
+    let successes: Vec<&PluginResult> = report
+        .plugin_results
+        .iter()
+        .filter(|r| r.outcome.is_success())
+        .collect();
+    let skipped: Vec<&PluginResult> = report
+        .plugin_results
+        .iter()
+        .filter(|r| r.outcome.is_cli_not_found())
+        .collect();
+    let failures: Vec<&PluginResult> = report
+        .plugin_results
+        .iter()
+        .filter(|r| !r.outcome.is_success() && !r.outcome.is_cli_not_found())
+        .collect();
+
+    if !successes.is_empty() {
+        println!(
+            "{} {} plugin(s) installed",
+            style::success("Plugins:"),
+            successes.len()
+        );
+        for r in &successes {
+            println!(
+                "  {} {} ({})",
+                style::dim("plugin"),
+                style::name(&r.name),
+                r.client
+            );
+        }
+    }
+
+    for r in &skipped {
+        let url_hint = r
+            .install_url
+            .as_deref()
+            .map(|u| format!(" — install manually: {u}"))
+            .unwrap_or_default();
+        eprintln!(
+            "{} plugin {} skipped — {} CLI not found{}",
+            style::warn("warning:"),
+            style::name(&r.name),
+            r.client,
+            url_hint
+        );
+    }
+
+    for r in &failures {
+        if let PluginOutcome::Failed { exit_code, stderr } = &r.outcome {
+            eprintln!(
+                "{} plugin {} ({}) failed (exit {:?}): {}",
+                style::warn("warning:"),
+                style::name(&r.name),
+                r.client,
+                exit_code,
+                stderr.trim()
+            );
+        }
     }
 }
 
@@ -382,7 +470,9 @@ fn run_update(names: &[String], dry_run: bool, global: bool, project: bool) -> i
         UpdateMode::Apply
     };
 
-    match update(&target, names, mode) {
+    let plugin_scope = scope_to_plugin_scope(global, project);
+
+    match update(&target, names, mode, plugin_scope) {
         Ok(report) => {
             print_update_report(&report, dry_run);
             EXIT_SUCCESS

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -31,6 +31,12 @@ pub struct Bundle {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires: Vec<Requires>,
 
+    /// Client-native plugins installed via shellout (ADR-0008, §3.7).
+    /// Map key is the upskill-level plugin name; value carries per-client
+    /// install descriptors.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub plugins: BTreeMap<String, PluginEntry>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
 
@@ -71,4 +77,54 @@ pub struct Requires {
     /// the resolver to interpret in C2.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+}
+
+/// Per-plugin entry in the `plugins:` map. Contains optional descriptors
+/// for each supported client. A plugin MAY target a single client, a
+/// subset, or all three.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PluginEntry {
+    /// Claude Code plugin descriptor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<ClaudePluginDescriptor>,
+
+    /// VS Code extension descriptor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vscode: Option<VscodePluginDescriptor>,
+
+    /// opencode module descriptor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opencode: Option<OpencodePluginDescriptor>,
+}
+
+/// Install descriptor for Claude Code plugins.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClaudePluginDescriptor {
+    /// Marketplace source (passed to `claude plugin marketplace add`).
+    pub source: String,
+    /// Plugin identifier (passed to `claude plugin install`).
+    pub plugin: String,
+    /// URL shown in warn-skip message when CLI not found.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_url: Option<String>,
+}
+
+/// Install descriptor for VS Code extensions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VscodePluginDescriptor {
+    /// Extension ID (passed to `code --install-extension`).
+    pub extension: String,
+    /// URL shown in warn-skip message when CLI not found.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_url: Option<String>,
+}
+
+/// Install descriptor for opencode modules.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OpencodePluginDescriptor {
+    /// Module name (passed to `opencode plugin`).
+    pub module: String,
+    /// URL shown in warn-skip message when CLI not found.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_url: Option<String>,
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -7,7 +7,10 @@ pub mod rule;
 pub mod skill;
 
 pub use agent::{Agent, Mode, ToolCap};
-pub use bundle::{Bundle, BundleItems, Requires};
+pub use bundle::{
+    Bundle, BundleItems, ClaudePluginDescriptor, OpencodePluginDescriptor, PluginEntry, Requires,
+    VscodePluginDescriptor,
+};
 pub use common::{Audience, CURRENT_SCHEMA, License, Metadata, SchemaVersion};
 pub use rule::{Rule, Scope};
 pub use skill::Skill;

--- a/src/parse/bundle.rs
+++ b/src/parse/bundle.rs
@@ -384,4 +384,112 @@ requires:
     fn renamed(template: &str, new_name: &str) -> String {
         template.replace("name: platform-baseline", &format!("name: {new_name}"))
     }
+
+    #[test]
+    fn load_parses_plugins_with_all_clients() {
+        let content = "schema: 1
+name: with-plugins
+description: Bundle with plugins declared
+items:
+  rules:
+    - license-awareness
+plugins:
+  superpowers:
+    claude:
+      source: anthropics/claude-plugins
+      plugin: superpowers
+      install_url: https://github.com/obra/superpowers#install
+    vscode:
+      extension: anthropic.superpowers
+      install_url: https://marketplace.visualstudio.com/items?itemName=anthropic.superpowers
+    opencode:
+      module: superpowers-opencode
+      install_url: https://opencode.ai/plugins/superpowers
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "with-plugins.bundle.yaml", content);
+
+        let bundle = load(&path).expect("load");
+        assert_eq!(bundle.plugins.len(), 1);
+
+        let sp = &bundle.plugins["superpowers"];
+        let claude = sp.claude.as_ref().expect("claude block");
+        assert_eq!(claude.source, "anthropics/claude-plugins");
+        assert_eq!(claude.plugin, "superpowers");
+        assert_eq!(
+            claude.install_url.as_deref(),
+            Some("https://github.com/obra/superpowers#install")
+        );
+
+        let vscode = sp.vscode.as_ref().expect("vscode block");
+        assert_eq!(vscode.extension, "anthropic.superpowers");
+        assert_eq!(
+            vscode.install_url.as_deref(),
+            Some("https://marketplace.visualstudio.com/items?itemName=anthropic.superpowers")
+        );
+
+        let opencode = sp.opencode.as_ref().expect("opencode block");
+        assert_eq!(opencode.module, "superpowers-opencode");
+        assert_eq!(
+            opencode.install_url.as_deref(),
+            Some("https://opencode.ai/plugins/superpowers")
+        );
+    }
+
+    #[test]
+    fn load_parses_plugins_with_single_client() {
+        // A plugin that only targets one client is valid.
+        let content = "schema: 1
+name: claude-only
+description: Plugin for Claude only
+items:
+  skills: []
+plugins:
+  my-plugin:
+    claude:
+      source: my-org/marketplace
+      plugin: my-plugin
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "claude-only.bundle.yaml", content);
+
+        let bundle = load(&path).expect("load");
+        assert_eq!(bundle.plugins.len(), 1);
+
+        let plugin = &bundle.plugins["my-plugin"];
+        assert!(plugin.claude.is_some());
+        assert!(plugin.vscode.is_none());
+        assert!(plugin.opencode.is_none());
+    }
+
+    #[test]
+    fn load_accepts_bundle_without_plugins() {
+        // Bundles without plugins: are valid (existing behavior).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "platform-baseline.bundle.yaml", PLATFORM);
+
+        let bundle = load(&path).expect("load");
+        assert!(bundle.plugins.is_empty());
+    }
+
+    #[test]
+    fn plugins_round_trips_through_serialize() {
+        let content = "schema: 1
+name: roundtrip
+description: Roundtrip test
+items:
+  rules: []
+plugins:
+  example:
+    vscode:
+      extension: publisher.example
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "roundtrip.bundle.yaml", content);
+
+        let bundle = load(&path).expect("load");
+        let serialized = serde_yaml_ng::to_string(&bundle).expect("serialize");
+        let reparsed: Bundle = serde_yaml_ng::from_str(&serialized).expect("reparse");
+        assert_eq!(bundle.plugins, reparsed.plugins);
+    }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -61,6 +61,27 @@ pub struct InstallReport {
     /// last entry is the bundle the user named. Empty for non-bundle
     /// installs.
     pub bundles: Vec<crate::model::Bundle>,
+    /// Results of plugin install attempts (ADR-0008). One entry per
+    /// (plugin-name, client) pair attempted. Empty when no bundles with
+    /// plugins were resolved.
+    pub plugin_results: Vec<PluginResult>,
+}
+
+/// Result of a single plugin install attempt, for reporting to the user.
+#[derive(Debug, Clone)]
+pub struct PluginResult {
+    /// Upskill-level plugin name (key in the bundle's `plugins:` map).
+    pub name: String,
+    /// Client identifier: `"claude"`, `"vscode"`, or `"opencode"`.
+    pub client: String,
+    /// What happened.
+    pub outcome: crate::plugin::PluginOutcome,
+    /// Client-specific identifier (for lockfile recording and uninstall).
+    pub identifier: String,
+    /// Bundle that declared this plugin.
+    pub bundle: String,
+    /// URL shown in warn-skip message (if available from the descriptor).
+    pub install_url: Option<String>,
 }
 
 const ALL_CLIENTS: [Client; 3] = [Client::Claude, Client::Copilot, Client::OpenCode];
@@ -201,6 +222,7 @@ pub fn install_with_lockfile(
     source: &InstallSource,
     target: &Path,
     items: &[String],
+    plugin_scope: crate::plugin::PluginScope,
 ) -> Result<InstallReport> {
     // Empty list means "install everything" (the historical default).
     // Otherwise build a `ResolvedItems` filter with each name copied
@@ -215,11 +237,19 @@ pub fn install_with_lockfile(
             agents: items.to_vec(),
         })
     };
-    let report = install_from_source(source, target, resolved.as_ref())?;
+    let mut report = install_from_source(source, target, resolved.as_ref())?;
 
     if !items.is_empty() && report.items.is_empty() {
         anyhow::bail!("no matching items in source for: {}", items.join(", "));
     }
+
+    // -- Plugin installation (ADR-0008) --
+    // After items are generated, iterate the resolved bundles' plugins
+    // and shell out to each client CLI. Results are appended to the
+    // report for main.rs to display; successful installs are recorded
+    // in the lockfile for remove/update/doctor.
+    let plugin_results = install_plugins_from_bundles(&report.bundles, plugin_scope);
+    report.plugin_results = plugin_results;
 
     let label = source.to_string();
     let git_ref = match source {
@@ -248,6 +278,21 @@ pub fn install_with_lockfile(
             items: bundle_item_names(bundle),
         });
     }
+    // Record successfully installed plugins in the lockfile.
+    for pr in &report.plugin_results {
+        if pr.outcome.is_success() {
+            lock.upsert_plugin(crate::lockfile::LockedPlugin {
+                name: pr.name.clone(),
+                client: pr.client.clone(),
+                identifier: pr.identifier.clone(),
+                scope: match plugin_scope {
+                    crate::plugin::PluginScope::Project => Some("project".into()),
+                    crate::plugin::PluginScope::User => Some("user".into()),
+                },
+                bundle: pr.bundle.clone(),
+            });
+        }
+    }
     lock.save(target)?;
 
     // Per ADR-0003 / format-spec §7.4: ensure the Claude Code bridge file
@@ -269,6 +314,67 @@ pub fn install_with_lockfile(
     crate::ancillary::ensure_vscode_instructions_registered(target, has_rules)?;
 
     Ok(report)
+}
+
+// ---------------------------------------------------------------------------
+// Plugin installation orchestration (ADR-0008)
+// ---------------------------------------------------------------------------
+
+/// Iterate all resolved bundles, attempt to install each declared plugin for
+/// its target client(s), and return structured results. Follows the
+/// warn-skip policy: if a client CLI is not on PATH, records
+/// `PluginOutcome::CliNotFound` but does not fail the overall install.
+fn install_plugins_from_bundles(
+    bundles: &[crate::model::Bundle],
+    scope: crate::plugin::PluginScope,
+) -> Vec<PluginResult> {
+    let mut results = Vec::new();
+
+    for bundle in bundles {
+        for (plugin_name, entry) in &bundle.plugins {
+            // Claude
+            if let Some(claude) = &entry.claude {
+                let outcome = crate::plugin::install_claude_plugin(claude, scope);
+                let identifier = format!("{}@{}", claude.plugin, claude.source);
+                results.push(PluginResult {
+                    name: plugin_name.clone(),
+                    client: "claude".into(),
+                    outcome,
+                    identifier,
+                    bundle: bundle.name.clone(),
+                    install_url: claude.install_url.clone(),
+                });
+            }
+
+            // VS Code
+            if let Some(vscode) = &entry.vscode {
+                let outcome = crate::plugin::install_vscode_extension(vscode);
+                results.push(PluginResult {
+                    name: plugin_name.clone(),
+                    client: "vscode".into(),
+                    outcome,
+                    identifier: vscode.extension.clone(),
+                    bundle: bundle.name.clone(),
+                    install_url: vscode.install_url.clone(),
+                });
+            }
+
+            // opencode
+            if let Some(opencode) = &entry.opencode {
+                let outcome = crate::plugin::install_opencode_plugin(opencode);
+                results.push(PluginResult {
+                    name: plugin_name.clone(),
+                    client: "opencode".into(),
+                    outcome,
+                    identifier: opencode.module.clone(),
+                    bundle: bundle.name.clone(),
+                    install_url: opencode.install_url.clone(),
+                });
+            }
+        }
+    }
+
+    results
 }
 
 /// What to remove. Per ADR-0004 the user must be explicit — bare
@@ -568,7 +674,12 @@ pub struct UpdateReport {
 /// Names that match no lockfile entry are an error.
 ///
 /// `update` always fetches per ADR-0004 — there is no `--offline`.
-pub fn update(target: &Path, names: &[String], mode: UpdateMode) -> Result<UpdateReport> {
+pub fn update(
+    target: &Path,
+    names: &[String],
+    mode: UpdateMode,
+    plugin_scope: crate::plugin::PluginScope,
+) -> Result<UpdateReport> {
     let lock = crate::lockfile::Lockfile::load(target)?;
 
     let entries: Vec<crate::lockfile::LockedItem> = if names.is_empty() {
@@ -611,7 +722,7 @@ pub fn update(target: &Path, names: &[String], mode: UpdateMode) -> Result<Updat
 
         match mode {
             UpdateMode::Apply => {
-                let install_report = install_with_lockfile(&source, target, &[])?;
+                let install_report = install_with_lockfile(&source, target, &[], plugin_scope)?;
                 let mut new_hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> =
                     std::collections::BTreeMap::new();
                 for it in &install_report.items {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,0 +1,281 @@
+//! Client CLI shellout for plugin installation (ADR-0008).
+//!
+//! Plugins are installed by shelling out to each client's native CLI:
+//! - Claude Code: `claude plugin marketplace add` + `claude plugin install`
+//! - VS Code: `code --install-extension`
+//! - opencode: `opencode plugin`
+//!
+//! This module exposes typed install/uninstall functions per client.
+//! All functions return structured results (never write to stdout/stderr)
+//! and handle CLI-not-found gracefully per the warn-skip policy.
+
+use crate::model::bundle::{
+    ClaudePluginDescriptor, OpencodePluginDescriptor, VscodePluginDescriptor,
+};
+use std::io::ErrorKind;
+use std::process::Command;
+
+/// Scope for Claude plugin installation, derived from upskill's
+/// project/global flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginScope {
+    /// Project-scoped install (`claude plugin install --scope project`).
+    Project,
+    /// User-scoped install (`claude plugin install --scope user`).
+    User,
+}
+
+impl PluginScope {
+    /// Returns the CLI flag value for `claude plugin install --scope`.
+    pub fn as_claude_flag(&self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::User => "user",
+        }
+    }
+}
+
+/// Outcome of a plugin install or uninstall attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginOutcome {
+    /// Command executed successfully (exit code 0).
+    Success,
+    /// Client CLI not found on PATH — plugin skipped.
+    CliNotFound,
+    /// Client CLI found but command returned non-zero.
+    Failed {
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+}
+
+impl PluginOutcome {
+    /// True when the plugin was successfully installed/uninstalled.
+    pub fn is_success(&self) -> bool {
+        matches!(self, Self::Success)
+    }
+
+    /// True when the CLI was not found (warn-skip scenario).
+    pub fn is_cli_not_found(&self) -> bool {
+        matches!(self, Self::CliNotFound)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Install functions
+// ---------------------------------------------------------------------------
+
+/// Install a Claude Code plugin via `claude plugin marketplace add` followed
+/// by `claude plugin install`. The marketplace-add step is idempotent.
+pub fn install_claude_plugin(
+    descriptor: &ClaudePluginDescriptor,
+    scope: PluginScope,
+) -> PluginOutcome {
+    // Step 1: Add marketplace source (idempotent).
+    let result = run_command(
+        "claude",
+        &["plugin", "marketplace", "add", &descriptor.source],
+    );
+    match result {
+        PluginOutcome::CliNotFound => return PluginOutcome::CliNotFound,
+        PluginOutcome::Failed { .. } => return result,
+        PluginOutcome::Success => {}
+    }
+
+    // Step 2: Install plugin with scope.
+    let install_ref = format!("{}@{}", descriptor.plugin, descriptor.source);
+    run_command(
+        "claude",
+        &[
+            "plugin",
+            "install",
+            &install_ref,
+            "--scope",
+            scope.as_claude_flag(),
+        ],
+    )
+}
+
+/// Install a VS Code extension via `code --install-extension`.
+pub fn install_vscode_extension(descriptor: &VscodePluginDescriptor) -> PluginOutcome {
+    run_command("code", &["--install-extension", &descriptor.extension])
+}
+
+/// Install an opencode module via `opencode plugin`.
+pub fn install_opencode_plugin(descriptor: &OpencodePluginDescriptor) -> PluginOutcome {
+    run_command("opencode", &["plugin", &descriptor.module])
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall functions
+// ---------------------------------------------------------------------------
+
+/// Uninstall a Claude Code plugin.
+pub fn uninstall_claude_plugin(plugin: &str, source: &str, scope: PluginScope) -> PluginOutcome {
+    let install_ref = format!("{plugin}@{source}");
+    run_command(
+        "claude",
+        &[
+            "plugin",
+            "uninstall",
+            &install_ref,
+            "--scope",
+            scope.as_claude_flag(),
+        ],
+    )
+}
+
+/// Uninstall a VS Code extension.
+pub fn uninstall_vscode_extension(extension: &str) -> PluginOutcome {
+    run_command("code", &["--uninstall-extension", extension])
+}
+
+/// Uninstall an opencode module.
+pub fn uninstall_opencode_plugin(module: &str) -> PluginOutcome {
+    run_command("opencode", &["plugin", "remove", module])
+}
+
+// ---------------------------------------------------------------------------
+// CLI availability check
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the named CLI binary is available on PATH.
+///
+/// Uses `Command::new(cli).arg("--version")` and checks for
+/// `ErrorKind::NotFound`. Does not validate the command succeeds — only
+/// that the binary can be spawned.
+pub fn is_cli_available(cli: &str) -> bool {
+    match Command::new(cli).arg("--version").output() {
+        Ok(_) => true,
+        Err(e) if e.kind() == ErrorKind::NotFound => false,
+        // Other errors (e.g., permission denied) — the binary exists but
+        // can't be run. Treat as "available but broken" so the install
+        // attempt surfaces the real error.
+        Err(_) => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Execute a CLI command and map the result to a `PluginOutcome`.
+fn run_command(program: &str, args: &[&str]) -> PluginOutcome {
+    let output = match Command::new(program).args(args).output() {
+        Ok(output) => output,
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            return PluginOutcome::CliNotFound;
+        }
+        Err(e) => {
+            return PluginOutcome::Failed {
+                exit_code: None,
+                stderr: format!("failed to spawn {program}: {e}"),
+            };
+        }
+    };
+
+    if output.status.success() {
+        PluginOutcome::Success
+    } else {
+        PluginOutcome::Failed {
+            exit_code: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_scope_as_claude_flag() {
+        assert_eq!(PluginScope::Project.as_claude_flag(), "project");
+        assert_eq!(PluginScope::User.as_claude_flag(), "user");
+    }
+
+    #[test]
+    fn is_cli_available_returns_true_for_known_binary() {
+        // `sh` is always available on Unix.
+        assert!(is_cli_available("sh"));
+    }
+
+    #[test]
+    fn is_cli_available_returns_false_for_nonexistent_binary() {
+        assert!(!is_cli_available(
+            "nonexistent-binary-that-does-not-exist-xyz-42"
+        ));
+    }
+
+    #[test]
+    fn install_claude_returns_cli_not_found_when_binary_missing() {
+        // Using a descriptor that references a nonexistent binary would
+        // require overriding the program name. Instead, we test via
+        // run_command directly.
+        let result = run_command(
+            "nonexistent-claude-xyz-42",
+            &["plugin", "marketplace", "add", "test-source"],
+        );
+        assert_eq!(result, PluginOutcome::CliNotFound);
+    }
+
+    #[test]
+    fn install_vscode_returns_cli_not_found_when_binary_missing() {
+        let descriptor = VscodePluginDescriptor {
+            extension: "test.extension".to_string(),
+            install_url: None,
+        };
+        // code is likely not on PATH in CI; if it is, this still works
+        // because --install-extension with a fake extension just fails.
+        let result = run_command(
+            "nonexistent-code-xyz-42",
+            &["--install-extension", &descriptor.extension],
+        );
+        assert_eq!(result, PluginOutcome::CliNotFound);
+    }
+
+    #[test]
+    fn install_opencode_returns_cli_not_found_when_binary_missing() {
+        let result = run_command("nonexistent-opencode-xyz-42", &["plugin", "test-module"]);
+        assert_eq!(result, PluginOutcome::CliNotFound);
+    }
+
+    #[test]
+    fn run_command_returns_success_on_zero_exit() {
+        // `true` always exits 0 on Unix.
+        let result = run_command("true", &[]);
+        assert_eq!(result, PluginOutcome::Success);
+    }
+
+    #[test]
+    fn run_command_returns_failed_on_nonzero_exit() {
+        // `false` always exits 1 on Unix.
+        let result = run_command("false", &[]);
+        assert!(matches!(
+            result,
+            PluginOutcome::Failed {
+                exit_code: Some(1),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn outcome_is_success_predicate() {
+        assert!(PluginOutcome::Success.is_success());
+        assert!(!PluginOutcome::CliNotFound.is_success());
+        assert!(
+            !PluginOutcome::Failed {
+                exit_code: Some(1),
+                stderr: String::new(),
+            }
+            .is_success()
+        );
+    }
+
+    #[test]
+    fn outcome_is_cli_not_found_predicate() {
+        assert!(PluginOutcome::CliNotFound.is_cli_not_found());
+        assert!(!PluginOutcome::Success.is_cli_not_found());
+    }
+}

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -15,7 +15,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -15,7 +15,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
@@ -255,7 +255,7 @@ fn doctor_json_orphan_entry_has_kebab_case_reason() {
     assert!(!orphans.is_empty(), "expected at least one orphan entry");
     for o in orphans {
         assert_eq!(o["reason"].as_str(), Some("local-path-gone"));
-        assert_eq!(o["kind"].as_str().unwrap_or("").len() > 0, true);
+        assert!(!o["kind"].as_str().unwrap_or("").is_empty());
         assert!(o["name"].is_string());
         assert!(o["source"].as_str().unwrap().starts_with("local:"));
     }

--- a/tests/cli_global_scope.rs
+++ b/tests/cli_global_scope.rs
@@ -13,7 +13,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -13,7 +13,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/tests/cli_misc.rs
+++ b/tests/cli_misc.rs
@@ -13,7 +13,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/tests/cli_remove.rs
+++ b/tests/cli_remove.rs
@@ -14,7 +14,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -13,7 +13,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/tests/cli_ux_polish.rs
+++ b/tests/cli_ux_polish.rs
@@ -13,7 +13,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/tests/fixtures/bundles/with-plugins.bundle.yaml
+++ b/tests/fixtures/bundles/with-plugins.bundle.yaml
@@ -1,0 +1,17 @@
+schema: 1
+name: with-plugins
+description: Bundle that also declares client-native plugins
+license: proprietary
+
+items:
+  rules:
+    - license-awareness
+
+plugins:
+  superpowers:
+    claude:
+      source: anthropics/claude-plugins
+      plugin: superpowers
+      install_url: https://github.com/obra/superpowers#install
+    vscode:
+      extension: anthropic.superpowers

--- a/tests/parse_bundles.rs
+++ b/tests/parse_bundles.rs
@@ -16,8 +16,8 @@ fn discovers_every_fixture_bundle() {
     let names: Vec<&str> = bundles.iter().map(|(_, b)| b.name.as_str()).collect();
     assert_eq!(
         names,
-        vec!["platform-baseline", "platform-extras"],
-        "fixture set is two bundles, sorted by path"
+        vec!["platform-baseline", "platform-extras", "with-plugins"],
+        "fixture set is three bundles, sorted by name"
     );
 }
 
@@ -51,4 +51,30 @@ fn extras_pins_baseline_with_caret_constraint() {
     assert_eq!(extras.requires.len(), 1);
     assert_eq!(extras.requires[0].name, "platform-baseline");
     assert_eq!(extras.requires[0].version.as_deref(), Some("^1.0.0"));
+}
+
+#[test]
+fn with_plugins_declares_client_native_plugins() {
+    let bundles = discover(Path::new(FIXTURES)).expect("discover");
+    let (_, bundle) = bundles
+        .iter()
+        .find(|(_, b)| b.name == "with-plugins")
+        .expect("with-plugins present");
+
+    assert_eq!(bundle.plugins.len(), 1);
+
+    let sp = &bundle.plugins["superpowers"];
+    let claude = sp.claude.as_ref().expect("claude descriptor");
+    assert_eq!(claude.source, "anthropics/claude-plugins");
+    assert_eq!(claude.plugin, "superpowers");
+    assert_eq!(
+        claude.install_url.as_deref(),
+        Some("https://github.com/obra/superpowers#install")
+    );
+
+    let vscode = sp.vscode.as_ref().expect("vscode descriptor");
+    assert_eq!(vscode.extension, "anthropic.superpowers");
+    assert!(vscode.install_url.is_none());
+
+    assert!(sp.opencode.is_none());
 }

--- a/tests/pipeline_local.rs
+++ b/tests/pipeline_local.rs
@@ -18,7 +18,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 /// Stage the entire fixture corpus into a temp source directory.
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -9,13 +9,14 @@ use std::fs;
 use std::path::Path;
 use upskill::lockfile::{CURRENT_SCHEMA, Lockfile};
 use upskill::pipeline::install_with_lockfile;
+use upskill::plugin::PluginScope;
 use upskill::source::InstallSource;
 
 const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
@@ -40,8 +41,13 @@ fn install_writes_lockfile_at_target_root() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
-        .expect("install");
+    install_with_lockfile(
+        &InstallSource::LocalPath(source.clone()),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
 
     let lock_path = target.join(".upskill-lock.json");
     assert!(
@@ -89,14 +95,24 @@ fn re_install_upserts_existing_entries() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
-        .expect("install 1");
+    install_with_lockfile(
+        &InstallSource::LocalPath(source.clone()),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install 1");
     let lock1: Lockfile =
         serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
             .unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
-        .expect("install 2");
+    install_with_lockfile(
+        &InstallSource::LocalPath(source.clone()),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install 2");
     let lock2: Lockfile =
         serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
             .unwrap();
@@ -127,8 +143,13 @@ fn install_preserves_unrelated_existing_entries() {
     });
     seed.save(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
-        .expect("install");
+    install_with_lockfile(
+        &InstallSource::LocalPath(source.clone()),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
 
     let lock = Lockfile::load(&target).expect("load");
     // 4 from the install + 1 pre-seeded = 5.
@@ -150,8 +171,13 @@ fn install_creates_claude_bridge_when_absent() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
-        .expect("install");
+    install_with_lockfile(
+        &InstallSource::LocalPath(source.clone()),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
 
     let claude_md = target.join("CLAUDE.md");
     assert!(claude_md.exists(), "CLAUDE.md must be created");
@@ -168,8 +194,13 @@ fn install_registers_opencode_rules_glob_when_rules_present() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
-        .expect("install");
+    install_with_lockfile(
+        &InstallSource::LocalPath(source.clone()),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
 
     let raw = fs::read_to_string(target.join("opencode.json")).expect("opencode.json present");
     let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -192,8 +223,13 @@ fn install_registers_vscode_instructions_location_when_rules_present() {
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
-        .expect("install");
+    install_with_lockfile(
+        &InstallSource::LocalPath(source.clone()),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
 
     let raw = fs::read_to_string(target.join(".vscode/settings.json"))
         .expect(".vscode/settings.json present");
@@ -219,12 +255,139 @@ fn install_preserves_existing_claude_bridge() {
     let user_content = "# Project CLAUDE.md\n\n@AGENTS.md\n\nExtra project notes here.\n";
     fs::write(target.join("CLAUDE.md"), user_content).unwrap();
 
-    install_with_lockfile(&InstallSource::LocalPath(source.clone()), &target, &[])
-        .expect("install");
+    install_with_lockfile(
+        &InstallSource::LocalPath(source.clone()),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
 
     assert_eq!(
         fs::read_to_string(target.join("CLAUDE.md")).unwrap(),
         user_content,
         "user CLAUDE.md must be preserved verbatim"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Plugin pipeline tests
+// ---------------------------------------------------------------------------
+
+/// Stage `tests/fixtures/items` + `tests/fixtures/bundles` into a registry
+/// (like `cli_bundle_install` does), then install the `with-plugins` bundle
+/// via the library function. Since the test environment doesn't have
+/// `claude`/`code`/`opencode` on PATH, plugins should be warn-skipped.
+fn stage_registry(root: &Path) {
+    let items = format!("{FIXTURES}/items");
+    let bundles = format!("{FIXTURES}/bundles");
+    copy_dir_all(Path::new(&items), root).unwrap();
+    copy_dir_all(Path::new(&bundles), &root.join("bundles")).unwrap();
+}
+
+#[test]
+fn bundle_with_plugins_produces_plugin_results() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    let bundle_path = registry.join("bundles/with-plugins.bundle.yaml");
+    let report = install_with_lockfile(
+        &InstallSource::LocalPath(bundle_path),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
+
+    // Two plugins attempted: superpowers (claude + vscode).
+    assert_eq!(
+        report.plugin_results.len(),
+        2,
+        "expected 2 plugin results (claude + vscode)"
+    );
+
+    // In CI/test environments, plugins won't successfully install (CLI
+    // missing or auth failure). The key invariant: the attempt was made
+    // and the result is structured.
+    for pr in &report.plugin_results {
+        assert!(
+            !pr.outcome.is_success(),
+            "plugin {} ({}) unexpectedly succeeded in test env",
+            pr.name,
+            pr.client
+        );
+    }
+}
+
+#[test]
+fn unsuccessful_plugins_not_recorded_in_lockfile() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    let bundle_path = registry.join("bundles/with-plugins.bundle.yaml");
+    install_with_lockfile(
+        &InstallSource::LocalPath(bundle_path),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
+
+    let lock = Lockfile::load(&target).expect("load lockfile");
+    // Only successful plugins are recorded — any non-success (CliNotFound
+    // or Failed) must NOT appear in the lockfile.
+    assert!(
+        lock.plugins.is_empty(),
+        "unsuccessful plugins should not appear in lockfile, got: {:?}",
+        lock.plugins
+    );
+}
+
+#[test]
+fn plugin_results_carry_correct_metadata() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    let bundle_path = registry.join("bundles/with-plugins.bundle.yaml");
+    let report = install_with_lockfile(
+        &InstallSource::LocalPath(bundle_path),
+        &target,
+        &[],
+        PluginScope::Project,
+    )
+    .expect("install");
+
+    let claude_result = report
+        .plugin_results
+        .iter()
+        .find(|r| r.client == "claude")
+        .expect("claude result");
+    assert_eq!(claude_result.name, "superpowers");
+    assert_eq!(
+        claude_result.identifier,
+        "superpowers@anthropics/claude-plugins"
+    );
+    assert_eq!(claude_result.bundle, "with-plugins");
+    assert_eq!(
+        claude_result.install_url.as_deref(),
+        Some("https://github.com/obra/superpowers#install")
+    );
+
+    let vscode_result = report
+        .plugin_results
+        .iter()
+        .find(|r| r.client == "vscode")
+        .expect("vscode result");
+    assert_eq!(vscode_result.name, "superpowers");
+    assert_eq!(vscode_result.identifier, "anthropic.superpowers");
+    assert_eq!(vscode_result.bundle, "with-plugins");
 }

--- a/tests/pipeline_source.rs
+++ b/tests/pipeline_source.rs
@@ -21,7 +21,7 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
 fn stage_source(source: &Path) {
     let from = format!("{FIXTURES}/items");
-    copy_dir_all(Path::new(&from), &source).unwrap();
+    copy_dir_all(Path::new(&from), source).unwrap();
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {


### PR DESCRIPTION
## Summary

New `src/plugin.rs` module implementing the plugin install/uninstall surface per ADR-0008. This is the low-level shellout layer — pipeline integration comes in #150.

### API Surface

```rust
// Install
pub fn install_claude_plugin(descriptor: &ClaudePluginDescriptor, scope: PluginScope) -> PluginOutcome
pub fn install_vscode_extension(descriptor: &VscodePluginDescriptor) -> PluginOutcome
pub fn install_opencode_plugin(descriptor: &OpencodePluginDescriptor) -> PluginOutcome

// Uninstall
pub fn uninstall_claude_plugin(plugin, source, scope) -> PluginOutcome
pub fn uninstall_vscode_extension(extension) -> PluginOutcome
pub fn uninstall_opencode_plugin(module) -> PluginOutcome

// Availability
pub fn is_cli_available(cli: &str) -> bool
```

### Key Design Decisions

- **`PluginOutcome` enum** — `Success | CliNotFound | Failed { exit_code, stderr }`
- **`PluginScope`** — `Project | User` maps to `claude --scope` flag
- **`is_cli_available()`** — spawns `cli --version`, matches `ErrorKind::NotFound`
- **No new dependencies** — pure `std::process::Command`
- **Never writes stdout/stderr** — presentation belongs in `main.rs`

### Tests (10 unit tests)

- Scope flag mapping
- CLI availability detection (true for `sh`, false for nonexistent binary)
- CliNotFound path for all three clients
- Success/failure outcome mapping (`true`/`false` binaries)
- Predicate methods

### Dependencies

Built on top of #154 (schema types). Pipeline wiring in #150.

Closes #149