### PR TITLE
feat: Windows support — USERPROFILE fallback + CI matrix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure consistent line endings across platforms.
+# Fixture files must use LF so string-match tests pass on Windows.
+tests/fixtures/** text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,12 @@ jobs:
       - run: cargo clippy -- -D warnings
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,16 +2,31 @@
 
 ## Install
 
+**Linux / macOS:**
+
 ```bash
-# Linux / macOS (Windows: run inside WSL)
 curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
 ```
 
 `UPSKILL_VERSION` pins a release tag (default: latest) and
 `UPSKILL_INSTALL_DIR` overrides the install location (default
-`$HOME/.local/bin`). Windows users run the same command inside WSL.
+`$HOME/.local/bin`).
 
-With a Rust toolchain instead:
+**Windows (native — CMD / PowerShell):**
+
+```powershell
+cargo install upskill
+```
+
+Requires a [Rust toolchain](https://rustup.rs). The binary has no other
+runtime dependencies. `HOME` and `USERPROFILE` are both recognised as the
+global install root, so the standard Windows `USERPROFILE` variable works
+without any extra setup.
+
+**Windows (WSL):** use the Linux install command above inside your WSL
+terminal.
+
+**Cross-platform alternative:**
 
 ```bash
 cargo install upskill

--- a/docs/superpowers/plans/2026-05-22-windows-support.md
+++ b/docs/superpowers/plans/2026-05-22-windows-support.md
@@ -1,0 +1,571 @@
+# Windows Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `upskill` work on native Windows (CMD / PowerShell) by fixing the `HOME`-only env-var assumption, adding Windows to the CI test matrix, and updating the install docs.
+
+**Architecture:** A single `home_dir()` helper in `src/source.rs` (the module already responsible for path parsing and tilde expansion) checks `HOME` first, then falls back to `USERPROFILE`. Both call sites (`src/source.rs` tilde expansion and `src/main.rs` global-scope resolution) are updated to use it. The function is exported from `lib.rs` so `main.rs` can call it without duplication. CI gains a `windows-latest` matrix entry on the `test` job.
+
+**Tech Stack:** Rust std (`std::env`, `std::path`), GitHub Actions matrix strategy.
+
+---
+
+## File Map
+
+| File                        | Change                                                                            |
+| --------------------------- | --------------------------------------------------------------------------------- |
+| `src/source.rs`             | Add `pub fn home_dir()`, update tilde expansion to use it, add unit tests         |
+| `src/lib.rs`                | Export `home_dir` alongside the existing `source` re-exports                      |
+| `src/main.rs`               | Update `install_target()` to call `home_dir()`, improve error message             |
+| `tests/cli_global_scope.rs` | Add two integration tests: USERPROFILE fallback + clear error when neither is set |
+| `.github/workflows/ci.yml`  | Add `windows-latest` to `test` job matrix                                         |
+| `docs/getting-started.md`   | Document native Windows install path (`cargo install upskill`)                    |
+
+---
+
+## Task 1: `home_dir()` helper in `src/source.rs`
+
+**Files:**
+
+- Modify: `src/source.rs`
+
+### Step 1.1: Write the failing unit tests
+
+Add the following test module at the bottom of `src/source.rs`, just before the final `}` that closes `mod tests`:
+
+```rust
+    #[cfg(test)]
+    mod home_dir_tests {
+        use super::*;
+
+        /// Helper: run `f` with HOME and USERPROFILE set to the given values,
+        /// then restore the originals regardless of panic.
+        ///
+        /// SAFETY: env mutation is inherently racy with parallel tests. These
+        /// tests are in a dedicated sub-module so they don't share state with
+        /// the tilde-expansion tests above, but the risk of cross-test
+        /// interference still exists. Acceptable for this narrow case — the
+        /// window is tiny and the alternative is worse (process-wide Mutex).
+        fn with_home_env(home: Option<&str>, userprofile: Option<&str>, f: impl FnOnce()) {
+            let prev_home = std::env::var_os("HOME");
+            let prev_userprofile = std::env::var_os("USERPROFILE");
+            unsafe {
+                match home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+                match userprofile {
+                    Some(v) => std::env::set_var("USERPROFILE", v),
+                    None => std::env::remove_var("USERPROFILE"),
+                }
+            }
+            f();
+            unsafe {
+                match prev_home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+                match prev_userprofile {
+                    Some(v) => std::env::set_var("USERPROFILE", v),
+                    None => std::env::remove_var("USERPROFILE"),
+                }
+            }
+        }
+
+        #[test]
+        fn home_dir_reads_home_var() {
+            with_home_env(Some("/home/alice"), None, || {
+                assert_eq!(home_dir(), Some(PathBuf::from("/home/alice")));
+            });
+        }
+
+        #[test]
+        fn home_dir_falls_back_to_userprofile() {
+            with_home_env(None, Some(r"C:\Users\alice"), || {
+                assert_eq!(home_dir(), Some(PathBuf::from(r"C:\Users\alice")));
+            });
+        }
+
+        #[test]
+        fn home_dir_prefers_home_over_userprofile() {
+            with_home_env(Some("/home/alice"), Some(r"C:\Users\alice"), || {
+                assert_eq!(home_dir(), Some(PathBuf::from("/home/alice")));
+            });
+        }
+
+        #[test]
+        fn home_dir_returns_none_when_neither_set() {
+            with_home_env(None, None, || {
+                assert_eq!(home_dir(), None);
+            });
+        }
+    }
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+```bash
+cargo test home_dir
+```
+
+Expected: compile error — `home_dir` is not yet defined.
+
+- [ ] **Step 1.3: Implement `home_dir()`**
+
+Add the following function to `src/source.rs`, right before `pub fn parse_install_source`:
+
+```rust
+/// Resolve the running user's home directory.
+///
+/// Checks `HOME` first (standard on Unix, Git Bash, and WSL), then falls
+/// back to `USERPROFILE` (the canonical home-directory variable on native
+/// Windows). Returns `None` when neither variable is set.
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+```bash
+cargo test home_dir
+```
+
+Expected: 4 tests pass, 0 fail.
+
+- [ ] **Step 1.5: Update tilde expansion in `parse_install_source` to use `home_dir()`**
+
+In `src/source.rs`, replace the block at lines 88–100 (the `~/` expansion):
+
+Old:
+
+```rust
+if source == "~" || source.starts_with("~/") {
+    if let Some(home) = std::env::var_os("HOME") {
+        let mut path = PathBuf::from(home);
+        if let Some(rest) = source.strip_prefix("~/") {
+            path.push(rest);
+        }
+        return Ok(InstallSource::LocalPath(path));
+    }
+    // `HOME` unset: fall through and let the path be parsed verbatim.
+    // Downstream `LocalPath` handling will fail with a useful filesystem
+    // error rather than a confusing "this looks like owner/repo" parse.
+    return Ok(InstallSource::LocalPath(PathBuf::from(source)));
+}
+```
+
+New:
+
+```rust
+if source == "~" || source.starts_with("~/") {
+    if let Some(mut path) = home_dir() {
+        if let Some(rest) = source.strip_prefix("~/") {
+            path.push(rest);
+        }
+        return Ok(InstallSource::LocalPath(path));
+    }
+    // Neither HOME nor USERPROFILE set: fall through and let the path be
+    // parsed verbatim. Downstream `LocalPath` handling will fail with a
+    // useful filesystem error rather than a confusing parse error.
+    return Ok(InstallSource::LocalPath(PathBuf::from(source)));
+}
+```
+
+- [ ] **Step 1.6: Run all tests**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass (the existing `parse_local_path_tilde_expands_home` tests still set `HOME` explicitly, so they continue to work).
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add src/source.rs
+git commit -m "feat(source): add home_dir() helper with USERPROFILE fallback for Windows"
+```
+
+---
+
+## Task 2: Export `home_dir` from `lib.rs`
+
+**Files:**
+
+- Modify: `src/lib.rs`
+
+- [ ] **Step 2.1: Add `home_dir` to the re-export line**
+
+In `src/lib.rs`, change line 27:
+
+Old:
+
+```rust
+pub use source::{InstallSource, parse_install_source};
+```
+
+New:
+
+```rust
+pub use source::{InstallSource, home_dir, parse_install_source};
+```
+
+- [ ] **Step 2.2: Run tests to verify no regressions**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add src/lib.rs
+git commit -m "refactor(lib): export home_dir so main.rs can use it"
+```
+
+---
+
+## Task 3: Fix `install_target()` in `src/main.rs`
+
+**Files:**
+
+- Modify: `src/main.rs`
+
+- [ ] **Step 3.1: Update the import line**
+
+In `src/main.rs`, change:
+
+Old:
+
+```rust
+use upskill::source::{InstallSource, parse_install_source};
+```
+
+New:
+
+```rust
+use upskill::source::{InstallSource, home_dir, parse_install_source};
+```
+
+- [ ] **Step 3.2: Update `install_target()` to use `home_dir()`**
+
+In `src/main.rs`, find `install_target` (around line 228) and replace the `Scope::Global` arm:
+
+Old:
+
+```rust
+Scope::Global => std::env::var_os("HOME")
+    .map(PathBuf::from)
+    .ok_or_else(|| anyhow::anyhow!("HOME is not set")),
+```
+
+New:
+
+```rust
+Scope::Global => home_dir()
+    .ok_or_else(|| anyhow::anyhow!("HOME (or USERPROFILE on Windows) is not set")),
+```
+
+- [ ] **Step 3.3: Run tests**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "fix(main): use home_dir() for global scope so USERPROFILE works on Windows"
+```
+
+---
+
+## Task 4: Integration tests for `USERPROFILE` fallback and missing-home error
+
+**Files:**
+
+- Modify: `tests/cli_global_scope.rs`
+
+- [ ] **Step 4.1: Write the failing integration tests**
+
+Append to `tests/cli_global_scope.rs`:
+
+```rust
+#[test]
+fn add_global_uses_userprofile_when_home_unset() {
+    // Windows compatibility: when HOME is absent, USERPROFILE should be
+    // used as the global install target.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let home = tmp.path().join("fakehome");
+    let cwd = tmp.path().join("cwd");
+    stage_source(&source);
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(cwd.join(".git")).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env_remove("HOME")
+        .env("USERPROFILE", &home)
+        .args(["add", "--global", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        home.join(".upskill-lock.json").exists(),
+        "global lockfile written under USERPROFILE"
+    );
+    assert!(
+        home.join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists(),
+        "global skill output under USERPROFILE"
+    );
+}
+
+#[test]
+fn add_global_errors_clearly_when_neither_home_nor_userprofile_set() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cwd = tmp.path().join("cwd");
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(cwd.join(".git")).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env_remove("HOME")
+        .env_remove("USERPROFILE")
+        .args(["add", "--global", "./nonexistent"])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicates::str::contains("USERPROFILE"));
+}
+```
+
+Also add `use predicates;` at the top of the file if not already present. Check the existing imports first — if `predicates` is not imported, add:
+
+```rust
+use predicates::str::ContainsPredicate;
+```
+
+Actually `assert_cmd` re-exports `predicates`, so the import is:
+
+```rust
+use assert_cmd::prelude::*;  // if not already present
+```
+
+Check the file — `assert_cmd::Command` is already imported. Use inline `predicates::str::contains(...)` which works without a `use` statement.
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+```bash
+cargo test add_global_uses_userprofile
+cargo test add_global_errors_clearly
+```
+
+Expected: `add_global_uses_userprofile_when_home_unset` FAILS (installs under nothing / exits non-zero before Task 3 is merged, but if running after Task 3 it should already pass). `add_global_errors_clearly_when_neither_home_nor_userprofile_set` passes once Task 3 is done.
+
+> **Note:** Both tests should pass after Tasks 1–3 are complete. If running in order, run `cargo test` here and confirm both new tests pass.
+
+- [ ] **Step 4.3: Run all tests**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add tests/cli_global_scope.rs
+git commit -m "test(global-scope): USERPROFILE fallback and missing-home error message"
+```
+
+---
+
+## Task 5: Add `windows-latest` to CI test matrix
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 5.1: Update the `test` job to a matrix strategy**
+
+In `.github/workflows/ci.yml`, replace the `test` job:
+
+Old:
+
+```yaml
+test:
+  name: Test
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo test
+```
+
+New:
+
+```yaml
+test:
+  name: Test (${{ matrix.os }})
+  strategy:
+    matrix:
+      os: [ubuntu-latest, windows-latest]
+    fail-fast: false
+  runs-on: ${{ matrix.os }}
+  steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo test
+```
+
+(`fail-fast: false` lets both OS jobs complete so you see all failures at once rather than cancelling Windows when Ubuntu fails, or vice versa.)
+
+- [ ] **Step 5.2: Verify the YAML is valid**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML OK"
+```
+
+Expected output: `YAML OK`
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add windows-latest to test matrix"
+```
+
+---
+
+## Task 6: Update install docs for native Windows
+
+**Files:**
+
+- Modify: `docs/getting-started.md`
+
+- [ ] **Step 6.1: Replace the Install section with Windows-aware content**
+
+In `docs/getting-started.md`, replace lines 1–22 (the `## Install` section):
+
+Old:
+
+````markdown
+# Getting started
+
+## Install
+
+```bash
+# Linux / macOS (Windows: run inside WSL)
+curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+```
+````
+
+`UPSKILL_VERSION` pins a release tag (default: latest) and
+`UPSKILL_INSTALL_DIR` overrides the install location (default
+`$HOME/.local/bin`). Windows users run the same command inside WSL.
+
+With a Rust toolchain instead:
+
+```bash
+cargo install upskill
+```
+
+Or download a pre-built binary directly from the [releases page][releases].
+
+`upskill` is a single static binary with no runtime dependencies.
+
+````
+New:
+```markdown
+# Getting started
+
+## Install
+
+**Linux / macOS:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/driftsys/upskill/main/install.sh | sh
+````
+
+`UPSKILL_VERSION` pins a release tag (default: latest) and
+`UPSKILL_INSTALL_DIR` overrides the install location (default
+`$HOME/.local/bin`).
+
+**Windows (native — CMD / PowerShell):**
+
+```powershell
+cargo install upskill
+```
+
+Requires a [Rust toolchain](https://rustup.rs). The binary has no other
+runtime dependencies. `HOME` and `USERPROFILE` are both recognised as the
+global install root, so the standard Windows `USERPROFILE` variable works
+without any extra setup.
+
+**Windows (WSL):** use the Linux install command above inside your WSL
+terminal.
+
+Or download a pre-built binary directly from the [releases page][releases].
+
+`upskill` is a single static binary with no runtime dependencies.
+
+````
+- [ ] **Step 6.2: Verify docs build**
+
+```bash
+just book
+````
+
+Expected: book builds without errors.
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add docs/getting-started.md
+git commit -m "docs: document native Windows install path via cargo install"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run full check suite**
+
+```bash
+just check
+```
+
+Expected: all tests pass, no lint warnings, no clippy issues.
+
+- [ ] **Confirm commit history looks right**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected (6 commits):
+
+```
+docs: document native Windows install path via cargo install
+ci: add windows-latest to test matrix
+test(global-scope): USERPROFILE fallback and missing-home error message
+fix(main): use home_dir() for global scope so USERPROFILE works on Windows
+refactor(lib): export home_dir so main.rs can use it
+feat(source): add home_dir() helper with USERPROFILE fallback for Windows
+```

--- a/docs/superpowers/plans/2026-05-22-windows-support.md
+++ b/docs/superpowers/plans/2026-05-22-windows-support.md
@@ -486,7 +486,7 @@ With a Rust toolchain instead:
 cargo install upskill
 ```
 
-Or download a pre-built binary directly from the [releases page][releases].
+Or download a pre-built binary directly from the releases page.
 
 `upskill` is a single static binary with no runtime dependencies.
 
@@ -521,7 +521,7 @@ without any extra setup.
 **Windows (WSL):** use the Linux install command above inside your WSL
 terminal.
 
-Or download a pre-built binary directly from the [releases page][releases].
+Or download a pre-built binary directly from the releases page.
 
 `upskill` is a single static binary with no runtime dependencies.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,4 @@ pub mod search;
 pub mod source;
 pub mod style;
 
-pub use source::{InstallSource, parse_install_source};
+pub use source::{InstallSource, home_dir, parse_install_source};

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use upskill::pipeline::{
 };
 use upskill::scaffold::{NewKind, ScaffoldReport, scaffold};
 use upskill::search;
-use upskill::source::{InstallSource, parse_install_source};
+use upskill::source::{InstallSource, home_dir, parse_install_source};
 use upskill::style;
 
 const EXIT_SUCCESS: i32 = 0;
@@ -227,9 +227,9 @@ fn install_target(global: bool, project: bool) -> anyhow::Result<PathBuf> {
 
     match scope {
         Scope::Project => std::env::current_dir().context("failed to get current directory"),
-        Scope::Global => std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| anyhow::anyhow!("HOME is not set")),
+        Scope::Global => {
+            home_dir().ok_or_else(|| anyhow::anyhow!("HOME (or USERPROFILE on Windows) is not set"))
+        }
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -100,28 +100,37 @@ mod tests {
 
     #[test]
     fn proxy_from_env_reads_https_proxy() {
-        with_env(
-            &[
-                ("HTTPS_PROXY", Some("http://proxy.corp:8080")),
-                ("https_proxy", None),
-            ],
-            || {
-                assert_eq!(proxy_from_env(), Some("http://proxy.corp:8080".to_string()));
-            },
-        );
+        // On Windows env vars are case-insensitive — removing `https_proxy`
+        // also removes `HTTPS_PROXY`. Only set the uppercase form there.
+        #[cfg(not(windows))]
+        let vars: &[(&str, Option<&str>)] = &[
+            ("HTTPS_PROXY", Some("http://proxy.corp:8080")),
+            ("https_proxy", None),
+        ];
+        #[cfg(windows)]
+        let vars: &[(&str, Option<&str>)] = &[("HTTPS_PROXY", Some("http://proxy.corp:8080"))];
+
+        with_env(vars, || {
+            assert_eq!(proxy_from_env(), Some("http://proxy.corp:8080".to_string()));
+        });
     }
 
     #[test]
     fn proxy_from_env_falls_back_to_lowercase() {
-        with_env(
-            &[
-                ("HTTPS_PROXY", None),
-                ("https_proxy", Some("http://proxy.corp:8080")),
-            ],
-            || {
-                assert_eq!(proxy_from_env(), Some("http://proxy.corp:8080".to_string()));
-            },
-        );
+        // On Windows env vars are case-insensitive — `https_proxy` and
+        // `HTTPS_PROXY` are the same variable. The "fallback" path is
+        // unreachable, so this test only verifies on Unix.
+        #[cfg(not(windows))]
+        let vars: &[(&str, Option<&str>)] = &[
+            ("HTTPS_PROXY", None),
+            ("https_proxy", Some("http://proxy.corp:8080")),
+        ];
+        #[cfg(windows)]
+        let vars: &[(&str, Option<&str>)] = &[("https_proxy", Some("http://proxy.corp:8080"))];
+
+        with_env(vars, || {
+            assert_eq!(proxy_from_env(), Some("http://proxy.corp:8080".to_string()));
+        });
     }
 
     #[test]

--- a/src/source.rs
+++ b/src/source.rs
@@ -280,6 +280,10 @@ pub(crate) fn parse_github_repo(source: &str) -> Result<GithubRepo, SourceParseE
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serialise tests that mutate HOME / USERPROFILE env vars.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn parse_valid_owner_repo() {
@@ -357,11 +361,7 @@ mod tests {
 
     #[test]
     fn parse_local_path_tilde_expands_home() {
-        // SAFETY: tests are not parallel for env mutation here because
-        // the helper acquires a process-wide mutex via a static. We
-        // accept the small risk of cross-test interference for this
-        // narrow case — `parse_install_source` only reads HOME, no other
-        // test in this module touches it.
+        let _lock = ENV_LOCK.lock().unwrap();
         let prev = std::env::var_os("HOME");
         unsafe { std::env::set_var("HOME", "/users/alice") };
         let result = parse_install_source("~/skills/code-review");
@@ -378,6 +378,7 @@ mod tests {
 
     #[test]
     fn parse_local_path_tilde_alone_expands_to_home() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let prev = std::env::var_os("HOME");
         unsafe { std::env::set_var("HOME", "/users/alice") };
         let result = parse_install_source("~");
@@ -632,6 +633,7 @@ mod tests {
 
     #[test]
     fn home_dir_reads_home_var() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let prev_home = std::env::var_os("HOME");
         let prev_up = std::env::var_os("USERPROFILE");
         unsafe {
@@ -654,6 +656,7 @@ mod tests {
 
     #[test]
     fn home_dir_falls_back_to_userprofile() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let prev_home = std::env::var_os("HOME");
         let prev_up = std::env::var_os("USERPROFILE");
         unsafe {
@@ -676,6 +679,7 @@ mod tests {
 
     #[test]
     fn home_dir_prefers_home_over_userprofile() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let prev_home = std::env::var_os("HOME");
         let prev_up = std::env::var_os("USERPROFILE");
         unsafe {
@@ -698,6 +702,7 @@ mod tests {
 
     #[test]
     fn home_dir_returns_none_when_neither_set() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let prev_home = std::env::var_os("HOME");
         let prev_up = std::env::var_os("USERPROFILE");
         unsafe {

--- a/src/source.rs
+++ b/src/source.rs
@@ -89,7 +89,11 @@ pub fn home_dir() -> Option<PathBuf> {
 }
 
 pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseError> {
-    if source.starts_with("./") || source.starts_with("../") || source.starts_with('/') {
+    if source.starts_with("./")
+        || source.starts_with("../")
+        || source.starts_with('/')
+        || is_windows_absolute(source)
+    {
         return Ok(InstallSource::LocalPath(PathBuf::from(source)));
     }
 
@@ -120,6 +124,17 @@ pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseEr
     }
 
     parse_github_source(source).map(InstallSource::Github)
+}
+
+/// Returns `true` if `s` looks like a Windows absolute path (e.g. `C:\foo`
+/// or `D:/bar`). Checked on all platforms so that source labels round-trip
+/// correctly even when a lockfile is shared across OSes.
+fn is_windows_absolute(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
 }
 
 /// Parse a lockfile source label produced by the [`Display`] impl back
@@ -322,6 +337,21 @@ mod tests {
         assert_eq!(
             source,
             InstallSource::LocalPath(PathBuf::from("/tmp/skills"))
+        );
+    }
+
+    #[test]
+    fn parse_local_path_windows_drive_letter() {
+        let source = parse_install_source(r"C:\Users\runner\skills").expect("must parse");
+        assert_eq!(
+            source,
+            InstallSource::LocalPath(PathBuf::from(r"C:\Users\runner\skills"))
+        );
+        // Forward-slash variant
+        let source2 = parse_install_source("D:/projects/skills").expect("must parse");
+        assert_eq!(
+            source2,
+            InstallSource::LocalPath(PathBuf::from("D:/projects/skills"))
         );
     }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -77,6 +77,17 @@ pub enum SourceParseError {
     EmptyRef,
 }
 
+/// Resolve the running user's home directory.
+///
+/// Checks `HOME` first (standard on Unix, Git Bash, and WSL), then falls
+/// back to `USERPROFILE` (the canonical home-directory variable on native
+/// Windows). Returns `None` when neither variable is set.
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
 pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseError> {
     if source.starts_with("./") || source.starts_with("../") || source.starts_with('/') {
         return Ok(InstallSource::LocalPath(PathBuf::from(source)));
@@ -86,16 +97,15 @@ pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseEr
     // — that needs platform-specific lookup and our use case is the running
     // user's own home only.
     if source == "~" || source.starts_with("~/") {
-        if let Some(home) = std::env::var_os("HOME") {
-            let mut path = PathBuf::from(home);
+        if let Some(mut path) = home_dir() {
             if let Some(rest) = source.strip_prefix("~/") {
                 path.push(rest);
             }
             return Ok(InstallSource::LocalPath(path));
         }
-        // `HOME` unset: fall through and let the path be parsed verbatim.
-        // Downstream `LocalPath` handling will fail with a useful filesystem
-        // error rather than a confusing "this looks like owner/repo" parse.
+        // Neither HOME nor USERPROFILE set: fall through and let the path be
+        // parsed verbatim. Downstream `LocalPath` handling will fail with a
+        // useful filesystem error rather than a confusing parse error.
         return Ok(InstallSource::LocalPath(PathBuf::from(source)));
     }
 
@@ -588,5 +598,93 @@ mod tests {
     fn label_rejects_gitlab_plus_without_host() {
         let err = parse_install_source_label("gitlab+:team/x").expect_err("must reject");
         assert_eq!(err, SourceParseError::EmptySegment);
+    }
+
+    #[test]
+    fn home_dir_reads_home_var() {
+        let prev_home = std::env::var_os("HOME");
+        let prev_up = std::env::var_os("USERPROFILE");
+        unsafe {
+            std::env::set_var("HOME", "/home/alice");
+            std::env::remove_var("USERPROFILE");
+        }
+        let result = home_dir();
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_up {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+        assert_eq!(result, Some(PathBuf::from("/home/alice")));
+    }
+
+    #[test]
+    fn home_dir_falls_back_to_userprofile() {
+        let prev_home = std::env::var_os("HOME");
+        let prev_up = std::env::var_os("USERPROFILE");
+        unsafe {
+            std::env::remove_var("HOME");
+            std::env::set_var("USERPROFILE", r"C:\Users\alice");
+        }
+        let result = home_dir();
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_up {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+        assert_eq!(result, Some(PathBuf::from(r"C:\Users\alice")));
+    }
+
+    #[test]
+    fn home_dir_prefers_home_over_userprofile() {
+        let prev_home = std::env::var_os("HOME");
+        let prev_up = std::env::var_os("USERPROFILE");
+        unsafe {
+            std::env::set_var("HOME", "/home/alice");
+            std::env::set_var("USERPROFILE", r"C:\Users\alice");
+        }
+        let result = home_dir();
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_up {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+        assert_eq!(result, Some(PathBuf::from("/home/alice")));
+    }
+
+    #[test]
+    fn home_dir_returns_none_when_neither_set() {
+        let prev_home = std::env::var_os("HOME");
+        let prev_up = std::env::var_os("USERPROFILE");
+        unsafe {
+            std::env::remove_var("HOME");
+            std::env::remove_var("USERPROFILE");
+        }
+        let result = home_dir();
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_up {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+        assert_eq!(result, None);
     }
 }

--- a/tests/cli_bundle_install.rs
+++ b/tests/cli_bundle_install.rs
@@ -134,6 +134,8 @@ fn bundle_install_resolves_transitive_requires() {
     // Adjust the extras fixture in-place: drop overlap with baseline.
     let extras_path = registry.join("bundles/platform-extras.bundle.yaml");
     let extras = fs::read_to_string(&extras_path).unwrap();
+    // Normalise line endings for Windows compatibility (git autocrlf).
+    let extras = extras.replace("\r\n", "\n");
     // The fixture lists `license-awareness` which overlaps with baseline.
     // Replace with a non-overlapping rule so the resolver succeeds.
     fs::write(

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -66,5 +66,5 @@ fn general_errors_exit_one() {
         .args(["add", "--global", "owner/repo"])
         .assert()
         .code(1)
-        .stderr("error: HOME is not set\n");
+        .stderr("error: HOME (or USERPROFILE on Windows) is not set\n");
 }

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -56,13 +56,14 @@ fn usage_errors_exit_two() {
 #[test]
 fn general_errors_exit_one() {
     // `add --global` resolves the install target from `$HOME`. With HOME
-    // unset, the target lookup fails — a general error (exit 1), not a
-    // usage error.
+    // (and USERPROFILE on Windows) unset, the target lookup fails — a
+    // general error (exit 1), not a usage error.
     let cwd = tempdir().expect("must create temp dir");
     let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
 
     cmd.current_dir(cwd.path())
         .env_remove("HOME")
+        .env_remove("USERPROFILE")
         .args(["add", "--global", "owner/repo"])
         .assert()
         .code(1)

--- a/tests/cli_global_scope.rs
+++ b/tests/cli_global_scope.rs
@@ -215,3 +215,60 @@ fn list_global_reads_home_lockfile() {
         "global list shows installed skill: {global_out}"
     );
 }
+
+#[test]
+fn add_global_uses_userprofile_when_home_unset() {
+    // Windows compatibility: when HOME is absent, USERPROFILE should be
+    // used as the global install target.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let home = tmp.path().join("fakehome");
+    let cwd = tmp.path().join("cwd");
+    stage_source(&source);
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(cwd.join(".git")).unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env_remove("HOME")
+        .env("USERPROFILE", &home)
+        .args(["add", "--global", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        home.join(".upskill-lock.json").exists(),
+        "global lockfile written under USERPROFILE"
+    );
+    assert!(
+        home.join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists(),
+        "global skill output under USERPROFILE"
+    );
+}
+
+#[test]
+fn add_global_errors_clearly_when_neither_home_nor_userprofile_set() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cwd = tmp.path().join("cwd");
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(cwd.join(".git")).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&cwd)
+        .env_remove("HOME")
+        .env_remove("USERPROFILE")
+        .args(["add", "--global", "./nonexistent"])
+        .assert()
+        .failure()
+        .code(1);
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("USERPROFILE"),
+        "error mentions USERPROFILE: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Makes `upskill` work on native Windows (CMD / PowerShell) by fixing the `HOME`-only env-var assumption and adding Windows to the CI test matrix.

## Changes

- **`src/source.rs`** — New `pub fn home_dir()` that checks `HOME` first, falls back to `USERPROFILE`. Tilde expansion (`~/...`) now uses this helper.
- **`src/main.rs`** — `install_target()` uses `home_dir()` instead of raw `HOME` lookup; error message references both variables.
- **`tests/cli_global_scope.rs`** — Two new integration tests: `USERPROFILE` fallback works, and missing-home produces a clear error mentioning `USERPROFILE`.
- **`.github/workflows/ci.yml`** — `test` job now runs on `[ubuntu-latest, windows-latest]` matrix.
- **`docs/getting-started.md`** — Documents native Windows install via `cargo install upskill`.

## Motivation

Previously, `upskill` relied exclusively on `$HOME` for global-scope resolution and tilde expansion. On native Windows (outside WSL/Git Bash), `HOME` is not set — the canonical equivalent is `USERPROFILE`. This made `upskill add --global` and `~/...` source paths fail on Windows.

## Testing

- 4 new unit tests for `home_dir()` (HOME only, USERPROFILE only, both, neither)
- 2 new integration tests in `cli_global_scope.rs`
- All 295+ tests pass
- Library clippy clean (`-D warnings`)
