### PR TITLE
feat(pipeline): bundle-by-name discovery for upskill add

### DIFF
--- a/docs/superpowers/plans/2026-05-22-bundle-by-name-discovery.md
+++ b/docs/superpowers/plans/2026-05-22-bundle-by-name-discovery.md
@@ -1,0 +1,687 @@
+# Bundle-by-name Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `upskill add owner/repo bundle-name` to discover and install bundles by name, not just by full file path.
+
+**Architecture:** Add a `find_bundle_by_name` helper that recursively searches a source directory for `<name>.bundle.yaml`. Wire it into `install_with_lockfile` so that when positional item names are provided and no items match, it falls back to bundle-by-name discovery. Add a lint rule that detects name collisions between bundles and items.
+
+**Tech Stack:** Rust, existing `pipeline.rs` + `lint.rs` modules, existing `parse::bundle::discover` for recursive bundle walking.
+
+---
+
+## Tasks
+
+### Task 1: Add `find_bundle_by_name` helper to pipeline.rs
+
+**Files:**
+
+- Modify: `src/pipeline.rs` (add function near `is_bundle_file`)
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/pipeline.rs` inside `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn find_bundle_by_name_finds_nested_bundle_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bundles_dir = tmp.path().join("bundles");
+    std::fs::create_dir_all(&bundles_dir).unwrap();
+    std::fs::write(
+        bundles_dir.join("baseline.bundle.yaml"),
+        "schema: 1\nname: baseline\ndescription: test\nitems:\n  rules: []\n",
+    )
+    .unwrap();
+
+    let result = find_bundle_by_name(tmp.path(), "baseline");
+    assert_eq!(
+        result,
+        Some(bundles_dir.join("baseline.bundle.yaml"))
+    );
+}
+
+#[test]
+fn find_bundle_by_name_returns_none_when_not_found() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("skills/foo")).unwrap();
+    std::fs::write(tmp.path().join("skills/foo/SKILL.md"), "---\nschema: 1\nname: foo\n---\n# body\n").unwrap();
+
+    let result = find_bundle_by_name(tmp.path(), "foo");
+    assert!(result.is_none());
+}
+
+#[test]
+fn find_bundle_by_name_skips_hidden_dirs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let hidden = tmp.path().join(".hidden");
+    std::fs::create_dir_all(&hidden).unwrap();
+    std::fs::write(hidden.join("secret.bundle.yaml"), "schema: 1\nname: secret\ndescription: x\nitems:\n  rules: []\n").unwrap();
+
+    let result = find_bundle_by_name(tmp.path(), "secret");
+    assert!(result.is_none());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib find_bundle_by_name`
+Expected: FAIL — `find_bundle_by_name` not found.
+
+- [ ] **Step 3: Implement `find_bundle_by_name`**
+
+Add to `src/pipeline.rs` near `is_bundle_file` (around line 155):
+
+```rust
+/// Search `root` recursively for a file named `<name>.bundle.yaml`.
+/// Skips hidden directories. Returns the first match or `None`.
+fn find_bundle_by_name(root: &Path, name: &str) -> Option<PathBuf> {
+    let target_filename = format!("{}{}", name, crate::parse::bundle::BUNDLE_SUFFIX);
+    find_bundle_recursive(root, &target_filename)
+}
+
+fn find_bundle_recursive(dir: &Path, target: &str) -> Option<PathBuf> {
+    let entries = fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let entry_name = entry.file_name();
+        let name_str = entry_name.to_string_lossy();
+        if name_str.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_file() && name_str == target {
+            return Some(path);
+        }
+        if path.is_dir() {
+            if let Some(found) = find_bundle_recursive(&path, target) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib find_bundle_by_name`
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "feat(pipeline): add find_bundle_by_name recursive search helper"
+```
+
+---
+
+### Task 2: Add `has_matching_items` helper to pipeline.rs
+
+**Files:**
+
+- Modify: `src/pipeline.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn has_matching_items_true_when_skill_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_dir = tmp.path().join("code-review");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(skill_dir.join("SKILL.md"), "---\nschema: 1\nname: code-review\n---\n# body\n").unwrap();
+
+    assert!(has_matching_items(tmp.path(), "code-review"));
+}
+
+#[test]
+fn has_matching_items_false_when_no_item_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("other")).unwrap();
+
+    assert!(!has_matching_items(tmp.path(), "nonexistent"));
+}
+
+#[test]
+fn has_matching_items_true_for_rules_and_agents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rule_dir = tmp.path().join("my-rule");
+    std::fs::create_dir_all(&rule_dir).unwrap();
+    std::fs::write(rule_dir.join("RULE.md"), "---\nschema: 1\nname: my-rule\n---\n# body\n").unwrap();
+
+    assert!(has_matching_items(tmp.path(), "my-rule"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib has_matching_items`
+Expected: FAIL — function not defined.
+
+- [ ] **Step 3: Implement `has_matching_items`**
+
+Add to `src/pipeline.rs`:
+
+```rust
+/// Check whether a source directory contains any item (skill, rule, or
+/// agent) with the given name. An item exists when a subdirectory named
+/// `name` contains at least one of `SKILL.md`, `RULE.md`, or `AGENT.md`.
+fn has_matching_items(source: &Path, name: &str) -> bool {
+    let item_dir = source.join(name);
+    if !item_dir.is_dir() {
+        return false;
+    }
+    item_dir.join("SKILL.md").is_file()
+        || item_dir.join("RULE.md").is_file()
+        || item_dir.join("AGENT.md").is_file()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib has_matching_items`
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "feat(pipeline): add has_matching_items existence check"
+```
+
+---
+
+### Task 3: Wire bundle-by-name into `install_with_lockfile`
+
+**Files:**
+
+- Modify: `src/pipeline.rs` (the `install_with_lockfile` function)
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `tests/pipeline_lockfile.rs`, add:
+
+```rust
+#[test]
+fn install_by_name_discovers_bundle_when_no_item_matches() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    // "with-plugins" is a bundle name, not an item name.
+    let report = install_with_lockfile(
+        &InstallSource::LocalPath(registry.clone()),
+        &target,
+        &["with-plugins".into()],
+        PluginScope::Project,
+    )
+    .expect("install");
+
+    // Bundle dispatch should have fired — items from the bundle are installed.
+    assert!(
+        !report.items.is_empty(),
+        "expected bundle items to be installed"
+    );
+    assert!(
+        !report.bundles.is_empty(),
+        "expected bundle to appear in report"
+    );
+    assert_eq!(report.bundles[0].name, "with-plugins");
+}
+
+#[test]
+fn install_by_name_errors_on_ambiguity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    // Create an item directory that collides with bundle name "with-plugins"
+    let collision_dir = registry.join("with-plugins");
+    fs::create_dir_all(&collision_dir).unwrap();
+    fs::write(
+        collision_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: with-plugins\ndescription: collision\n---\n# body\n",
+    )
+    .unwrap();
+
+    let err = install_with_lockfile(
+        &InstallSource::LocalPath(registry.clone()),
+        &target,
+        &["with-plugins".into()],
+        PluginScope::Project,
+    )
+    .expect_err("should error on ambiguity");
+
+    let msg = format!("{:#}", err);
+    assert!(msg.contains("matches both"), "error mentions ambiguity: {msg}");
+    assert!(msg.contains(".bundle.yaml"), "error shows bundle path: {msg}");
+}
+
+#[test]
+fn install_by_name_prefers_items_when_only_items_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    // "license-awareness" is a rule item, not a bundle.
+    let report = install_with_lockfile(
+        &InstallSource::LocalPath(registry.clone()),
+        &target,
+        &["license-awareness".into()],
+        PluginScope::Project,
+    )
+    .expect("install");
+
+    assert!(!report.items.is_empty());
+    assert!(report.bundles.is_empty(), "no bundle dispatch for item-only match");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test pipeline_lockfile install_by_name`
+Expected: First test FAILS with "no matching items in source for: with-plugins".
+
+- [ ] **Step 3: Implement bundle-by-name dispatch in `install_with_lockfile`**
+
+Modify the `install_with_lockfile` function in `src/pipeline.rs`. Replace the current logic between the item filter construction and the "no matching items" bail:
+
+```rust
+pub fn install_with_lockfile(
+    source: &InstallSource,
+    target: &Path,
+    items: &[String],
+    plugin_scope: crate::plugin::PluginScope,
+) -> Result<InstallReport> {
+    let mut report = if items.is_empty() {
+        // No names → install everything (existing default).
+        install_from_source(source, target, None)?
+    } else {
+        // Names provided → try item-filter first, then bundle-by-name.
+        install_with_name_resolution(source, target, items)?
+    };
+
+    // -- Plugin installation (ADR-0008) --
+    let plugin_results = install_plugins_from_bundles(&report.bundles, plugin_scope);
+    report.plugin_results = plugin_results;
+
+    // ... rest unchanged (lockfile recording, ancillary files) ...
+```
+
+Add the new helper:
+
+```rust
+/// Resolve positional names against both items and bundles.
+///
+/// For each name:
+/// - If it matches items AND a bundle → error (ambiguity).
+/// - If it matches only a bundle → install via bundle dispatch.
+/// - If it matches only items → install via item filter.
+/// - If it matches neither → error.
+///
+/// When the list contains a mix (some names are bundles, some are items),
+/// all bundle installs run first, then item installs run with the
+/// remaining names as a filter.
+fn install_with_name_resolution(
+    source: &InstallSource,
+    target: &Path,
+    names: &[String],
+) -> Result<InstallReport> {
+    // We need the source as a local path to check for bundles/items.
+    // For git sources, clone first and then inspect.
+    let (local_source, _tmp) = resolve_to_local(source)?;
+
+    let mut bundle_paths: Vec<PathBuf> = Vec::new();
+    let mut item_names: Vec<String> = Vec::new();
+
+    for name in names {
+        let has_items = has_matching_items(&local_source, name);
+        let bundle_path = find_bundle_by_name(&local_source, name);
+
+        match (has_items, bundle_path) {
+            (true, Some(bp)) => {
+                anyhow::bail!(
+                    "'{}' matches both an item and a bundle\n\n  \
+                     item:   {}/{}\n  \
+                     bundle: {}\n\n\
+                     Disambiguate with the full path:\n  \
+                     upskill add <source>:{}\n  \
+                     upskill add <source>:{}",
+                    name,
+                    name,
+                    detect_item_entrypoint(&local_source, name),
+                    bp.strip_prefix(&local_source).unwrap_or(&bp).display(),
+                    bp.strip_prefix(&local_source).unwrap_or(&bp).display(),
+                    name,
+                );
+            }
+            (false, Some(bp)) => bundle_paths.push(bp),
+            (true, None) => item_names.push(name.clone()),
+            (false, None) => {
+                anyhow::bail!("no matching items or bundles in source for: {}", name);
+            }
+        }
+    }
+
+    let mut report = InstallReport::default();
+
+    // Install bundles first.
+    for bp in &bundle_paths {
+        let bundle_report = install_bundle_file(bp, target)?;
+        report.items.extend(bundle_report.items);
+        report.bundles.extend(bundle_report.bundles);
+    }
+
+    // Install remaining items via the standard filter path.
+    if !item_names.is_empty() {
+        let filter = crate::bundle::ResolvedItems {
+            rules: item_names.clone(),
+            skills: item_names.clone(),
+            agents: item_names.clone(),
+        };
+        let item_report = install_from_local_path(&local_source, target, Some(&filter))?;
+        report.items.extend(item_report.items);
+    }
+
+    Ok(report)
+}
+
+/// Resolve an InstallSource to a local path (cloning if needed).
+/// Returns the path and an optional TempDir guard (dropped = cleaned up).
+fn resolve_to_local(source: &InstallSource) -> Result<(PathBuf, Option<tempfile::TempDir>)> {
+    match source {
+        InstallSource::LocalPath(p) => Ok((p.clone(), None)),
+        InstallSource::Github(repo) => {
+            let url = github_authenticated_url(repo)?;
+            let tmp = tempfile::tempdir().context("create temp dir for clone")?;
+            fetch::shallow_clone(&url, repo.git_ref.as_deref(), "clone", tmp.path())
+                .map_err(|e| anyhow!("git clone: {}", e))?;
+            let source = fetch::resolve_subfolder(
+                &tmp.path().join("clone"),
+                repo.subfolder.as_deref(),
+                &repo.owner,
+                &repo.name,
+            )
+            .map_err(|e| anyhow!("{}", e))?;
+            Ok((source, Some(tmp)))
+        }
+        InstallSource::Gitlab(repo) => {
+            let url = gitlab_authenticated_url(repo)?;
+            let tmp = tempfile::tempdir().context("create temp dir for clone")?;
+            fetch::shallow_clone(&url, repo.git_ref.as_deref(), "clone", tmp.path())
+                .map_err(|e| anyhow!("git clone: {}", e))?;
+            let source = fetch::resolve_subfolder(
+                &tmp.path().join("clone"),
+                repo.subfolder.as_deref(),
+                &repo.owner,
+                &repo.name,
+            )
+            .map_err(|e| anyhow!("{}", e))?;
+            Ok((source, Some(tmp)))
+        }
+    }
+}
+
+/// Detect which entrypoint file (SKILL.md, RULE.md, AGENT.md) exists for
+/// an item, for use in error messages.
+fn detect_item_entrypoint(source: &Path, name: &str) -> &'static str {
+    let dir = source.join(name);
+    if dir.join("SKILL.md").is_file() {
+        "SKILL.md"
+    } else if dir.join("RULE.md").is_file() {
+        "RULE.md"
+    } else if dir.join("AGENT.md").is_file() {
+        "AGENT.md"
+    } else {
+        "SKILL.md" // fallback for error message
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test pipeline_lockfile install_by_name`
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test`
+Expected: All existing tests still pass (the empty-items path is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipeline.rs tests/pipeline_lockfile.rs
+git commit -m "feat(pipeline): wire bundle-by-name discovery into install_with_lockfile"
+```
+
+---
+
+### Task 4: Add lint rule for bundle-item-name-collision
+
+**Files:**
+
+- Modify: `src/lint.rs`
+- Test: `tests/cli_lint.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/cli_lint.rs`, add:
+
+```rust
+#[test]
+fn lint_flags_bundle_item_name_collision() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // Create a skill named "baseline"
+    let skill_dir = root.join("baseline");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: baseline\ndescription: a skill\n---\n# body\n",
+    )
+    .unwrap();
+
+    // Create a bundle also named "baseline"
+    let bundles_dir = root.join("bundles");
+    fs::create_dir_all(&bundles_dir).unwrap();
+    fs::write(
+        bundles_dir.join("baseline.bundle.yaml"),
+        "schema: 1\nname: baseline\ndescription: a bundle\nitems:\n  skills:\n    - baseline\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(root)
+        .args(["lint"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("name-collision"))
+        .stderr(predicates::str::contains("baseline"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test cli_lint lint_flags_bundle_item_name_collision`
+Expected: FAIL — no "name-collision" in output.
+
+- [ ] **Step 3: Implement the lint rule**
+
+In `src/lint.rs`, add a new check function and wire it into `lint()`:
+
+After `check_directives`, add a new cross-file check. Modify the `lint` function to call it after per-file checks complete:
+
+```rust
+pub fn lint(paths: &[PathBuf], strict: bool) -> Result<LintReport> {
+    // ... existing code through per-file loop ...
+
+    // Cross-file checks: bundle-item name collisions.
+    for root in roots {
+        if root.is_dir() {
+            check_bundle_item_name_collisions(root, &mut report.findings)?;
+        }
+    }
+
+    if strict {
+        // ... existing strict promotion ...
+    }
+
+    Ok(report)
+}
+```
+
+Add the implementation:
+
+```rust
+/// Cross-file lint: detect when a bundle's `name:` collides with an item
+/// directory name in the same registry. This ambiguity causes
+/// `upskill add <source> <name>` to fail at install time — better to
+/// catch it during authoring.
+fn check_bundle_item_name_collisions(root: &Path, out: &mut Vec<Finding>) -> Result<()> {
+    // Collect item names (directories containing SKILL.md/RULE.md/AGENT.md).
+    let mut item_names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let dirname = entry.file_name().to_string_lossy().to_string();
+            if dirname.starts_with('.') {
+                continue;
+            }
+            if path.join("SKILL.md").is_file()
+                || path.join("RULE.md").is_file()
+                || path.join("AGENT.md").is_file()
+            {
+                item_names.insert(dirname);
+            }
+        }
+    }
+
+    // Discover bundles and check for collisions.
+    let mut bundle_files: Vec<PathBuf> = Vec::new();
+    walk_bundles(root, &mut bundle_files)?;
+
+    for bundle_path in bundle_files {
+        let raw = fs::read_to_string(&bundle_path)
+            .with_context(|| format!("read {}", bundle_path.display()))?;
+        // Quick extraction of the `name:` field without full parse.
+        let bundle_name = extract_bundle_name(&raw);
+        if let Some(name) = bundle_name {
+            if item_names.contains(&name) {
+                let item_kind = detect_item_kind_in_root(root, &name);
+                out.push(Finding {
+                    rule_id: "name-collision",
+                    severity: Severity::Error,
+                    path: bundle_path,
+                    line: None,
+                    message: format!(
+                        "bundle '{}' collides with {} '{}'",
+                        name, item_kind, name
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Extract the `name:` field from a bundle YAML without full parse.
+fn extract_bundle_name(raw: &str) -> Option<String> {
+    // Use serde for reliability — the bundle schema is known.
+    let parsed: Result<crate::model::Bundle, _> = serde_yaml_ng::from_str(raw);
+    parsed.ok().map(|b| b.name)
+}
+
+/// Detect what kind of item a name corresponds to in the root, for error messages.
+fn detect_item_kind_in_root(root: &Path, name: &str) -> &'static str {
+    let dir = root.join(name);
+    if dir.join("SKILL.md").is_file() {
+        "skill"
+    } else if dir.join("RULE.md").is_file() {
+        "rule"
+    } else if dir.join("AGENT.md").is_file() {
+        "agent"
+    } else {
+        "item"
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --test cli_lint lint_flags_bundle_item_name_collision`
+Expected: PASS.
+
+- [ ] **Step 5: Run full lint test suite**
+
+Run: `cargo test --test cli_lint`
+Expected: All lint tests pass (existing clean fixtures have no collisions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lint.rs tests/cli_lint.rs
+git commit -m "feat(lint): add name-collision rule for bundle-item name conflicts"
+```
+
+---
+
+### Task 5: Run clippy + full verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 2: Run full verification**
+
+Run: `just verify`
+Expected: All checks pass.
+
+- [ ] **Step 3: Fix any issues found**
+
+If clippy or tests fail, fix and re-run.
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address clippy/test issues from bundle-by-name"
+```
+
+---
+
+### Task 6: Create PR
+
+**Files:** None
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push origin feat/bundle-by-name-discovery
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create \
+  --title "feat(pipeline): bundle-by-name discovery for upskill add" \
+  --base main \
+  --body "..." \
+  --label "story"
+```

--- a/docs/superpowers/specs/2026-05-22-bundle-by-name-discovery-design.md
+++ b/docs/superpowers/specs/2026-05-22-bundle-by-name-discovery-design.md
@@ -1,0 +1,137 @@
+# Bundle-by-name Discovery
+
+Date: 2026-05-22
+
+## Problem
+
+`upskill add owner/repo bundle-name` only searches for items
+(skills/rules/agents). Bundle files (`.bundle.yaml`) are only installed
+when the source path literally ends in `.bundle.yaml`. There is no
+ergonomic way to install a bundle by name from a remote repo.
+
+Current workaround: specify the full path to the bundle file:
+
+```bash
+upskill add driftsys/upskill:skills/prompt-engineering.bundle.yaml
+```
+
+This is not discoverable and forces users to know the internal layout.
+
+## Design
+
+### Bundle-by-name resolution
+
+**Trigger:** `upskill add <source> <name>` (positional item-filter arg
+only). No change to the `:subfolder` colon syntax — that remains a
+literal path.
+
+**Resolution order for each positional name:**
+
+1. Search for items (skills/rules/agents) matching the name (existing
+   behavior).
+2. Search for `<name>.bundle.yaml` files anywhere in the source
+   directory (recursive walk).
+3. Dispatch based on results:
+   - **Both exist** — error listing both matches, suggest `:path`
+     disambiguation.
+   - **Only bundle** — use bundle dispatch (existing
+     `install_bundle_file` path).
+   - **Only items** — install items (existing behavior).
+   - **Neither** — error (existing "no matching items" message).
+
+**Bare `upskill add owner/repo`** (no positional names) keeps current
+behavior: install all items, ignore bundles. Bundles are opt-in by
+name.
+
+### Lint rule: bundle-item-name-collision
+
+`upskill lint` gains a new check at **error** severity. If a bundle's
+`name:` field collides with any item directory name (skill, rule, or
+agent) in the same registry root, emit an error.
+
+This is a static guardrail that prevents the ambiguity case from ever
+reaching end users. Registries that follow the convention "bundles and
+items have distinct names" will never trigger the install-time
+ambiguity error.
+
+### Convention
+
+Registries SHOULD use distinct names for bundles and items:
+
+- `prompt-engineering` — bundle (references items + plugins + deps)
+- `prompt-design` — skill (the actual SSOT content)
+
+This makes `upskill add owner/repo prompt-engineering` unambiguous.
+
+## Error messages
+
+### Install-time ambiguity
+
+```
+error: 'foo' matches both a skill and a bundle
+
+  skill:  skills/foo/SKILL.md
+  bundle: bundles/foo.bundle.yaml
+
+Disambiguate with the full path:
+  upskill add owner/repo:bundles/foo.bundle.yaml
+  upskill add owner/repo:skills/foo
+```
+
+### Lint collision
+
+```
+error[name-collision]: bundle 'foo' collides with skill 'foo'
+  --> bundles/foo.bundle.yaml
+  = help: rename the bundle or item so names are unique
+```
+
+## Implementation scope
+
+### pipeline.rs
+
+- Add `find_bundle_by_name(source_dir: &Path, name: &str) ->
+  Option<PathBuf>` — walks the source tree for
+  `<name>.bundle.yaml`.
+- In `install_with_lockfile`, when positional `items` are provided:
+  after cloning, for each name check both item existence and bundle
+  existence. Dispatch accordingly or error on ambiguity.
+- The `install_from_local_path` function's existing item-filter path
+  is unchanged; the new bundle-by-name logic sits above it at the
+  `install_with_lockfile` / `install_from_source` level.
+
+### lint.rs
+
+- Add `check_bundle_item_name_collision` — iterates discovered bundles
+  and item directories, reports collisions.
+- Severity: error (not warning). This is a hard rule for registry
+  authors.
+
+### No changes to
+
+- `source.rs` — `:subfolder` parsing untouched.
+- `fetch.rs` — `resolve_subfolder` untouched.
+- Lockfile schema — no new fields needed.
+
+## Testing
+
+### Pipeline tests
+
+- `upskill add <local-path> bundle-name` where only a bundle matches
+  → bundle dispatch fires, items from bundle are installed.
+- `upskill add <local-path> item-name` where only an item matches →
+  existing behavior preserved.
+- `upskill add <local-path> ambiguous-name` where both exist → error
+  with disambiguation message.
+- `upskill add <local-path> unknown-name` → existing "no matching
+  items" error.
+
+### Lint tests
+
+- Registry with colliding bundle/item name → error finding.
+- Registry with distinct names → clean.
+
+### Integration (CLI) tests
+
+- `upskill add owner/repo bundle-name` (via local git clone) →
+  success, lockfile records bundle.

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -16,6 +16,7 @@
 //! | `body-h1`         | warning  | §5.1               |
 //! | `fence-lang`      | warning  | §5.2               |
 //! | `directive`       | error    | §6.3 (any imbalance, unknown client, nesting) |
+//! | `name-collision`  | error    | cross-file (bundle vs item name) |
 //!
 //! Discovery: a path argument is either a file (lint that file) or a
 //! directory (walk for `<root>/<name>/{RULE,SKILL,AGENT}.md` per
@@ -106,6 +107,13 @@ pub fn lint(paths: &[PathBuf], strict: bool) -> Result<LintReport> {
         for file in discover(root)? {
             report.files_checked += 1;
             check_file(&file, &mut report.findings)?;
+        }
+    }
+
+    // Cross-file checks: bundle-item name collisions.
+    for root in roots {
+        if root.is_dir() {
+            check_bundle_item_name_collisions(root, &mut report.findings)?;
         }
     }
 
@@ -410,6 +418,81 @@ fn check_directives(file: &Path, body: &str, out: &mut Vec<Finding>) {
             line: None,
             message: format!("{:#}", err),
         });
+    }
+}
+
+/// Cross-file lint: detect when a bundle's `name:` collides with an item
+/// directory name in the same registry.
+fn check_bundle_item_name_collisions(root: &Path, out: &mut Vec<Finding>) -> Result<()> {
+    // Collect item names (directories containing SKILL.md/RULE.md/AGENT.md).
+    let mut item_names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let dirname = entry.file_name().to_string_lossy().to_string();
+            if dirname.starts_with('.') {
+                continue;
+            }
+            if path.join("SKILL.md").is_file()
+                || path.join("RULE.md").is_file()
+                || path.join("AGENT.md").is_file()
+            {
+                item_names.insert(dirname);
+            }
+        }
+    }
+
+    if item_names.is_empty() {
+        return Ok(());
+    }
+
+    // Discover bundles and check for collisions.
+    let mut bundle_files: Vec<PathBuf> = Vec::new();
+    walk_bundles(root, &mut bundle_files)?;
+
+    for bundle_path in bundle_files {
+        let raw = fs::read_to_string(&bundle_path)
+            .with_context(|| format!("read {}", bundle_path.display()))?;
+        if let Some(name) = extract_bundle_name(&raw) {
+            if item_names.contains(&name) {
+                let item_kind = detect_item_kind(root, &name);
+                out.push(Finding {
+                    rule_id: "name-collision",
+                    severity: Severity::Error,
+                    path: bundle_path,
+                    line: None,
+                    message: format!(
+                        "bundle name '{}' collides with {} '{}'",
+                        name, item_kind, name
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Extract the `name:` field from a bundle YAML without full parse.
+fn extract_bundle_name(raw: &str) -> Option<String> {
+    let parsed: Result<crate::model::Bundle, _> = serde_yaml_ng::from_str(raw);
+    parsed.ok().map(|b| b.name)
+}
+
+/// Detect what kind of item a name corresponds to, for error messages.
+fn detect_item_kind(root: &Path, name: &str) -> &'static str {
+    let dir = root.join(name);
+    if dir.join("SKILL.md").is_file() {
+        "skill"
+    } else if dir.join("RULE.md").is_file() {
+        "rule"
+    } else if dir.join("AGENT.md").is_file() {
+        "agent"
+    } else {
+        "item"
     }
 }
 

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -456,20 +456,20 @@ fn check_bundle_item_name_collisions(root: &Path, out: &mut Vec<Finding>) -> Res
     for bundle_path in bundle_files {
         let raw = fs::read_to_string(&bundle_path)
             .with_context(|| format!("read {}", bundle_path.display()))?;
-        if let Some(name) = extract_bundle_name(&raw) {
-            if item_names.contains(&name) {
-                let item_kind = detect_item_kind(root, &name);
-                out.push(Finding {
-                    rule_id: "name-collision",
-                    severity: Severity::Error,
-                    path: bundle_path,
-                    line: None,
-                    message: format!(
-                        "bundle name '{}' collides with {} '{}'",
-                        name, item_kind, name
-                    ),
-                });
-            }
+        if let Some(name) = extract_bundle_name(&raw)
+            && item_names.contains(&name)
+        {
+            let item_kind = detect_item_kind(root, &name);
+            out.push(Finding {
+                rule_id: "name-collision",
+                severity: Severity::Error,
+                path: bundle_path,
+                line: None,
+                message: format!(
+                    "bundle name '{}' collides with {} '{}'",
+                    name, item_kind, name
+                ),
+            });
         }
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -181,6 +181,19 @@ fn find_bundle_recursive(dir: &Path, target: &str) -> Option<PathBuf> {
     None
 }
 
+/// Check whether a source directory contains any item (skill, rule, or
+/// agent) with the given name. An item exists when a subdirectory named
+/// `name` contains at least one of `SKILL.md`, `RULE.md`, or `AGENT.md`.
+fn has_matching_items(source: &Path, name: &str) -> bool {
+    let item_dir = source.join(name);
+    if !item_dir.is_dir() {
+        return false;
+    }
+    item_dir.join("SKILL.md").is_file()
+        || item_dir.join("RULE.md").is_file()
+        || item_dir.join("AGENT.md").is_file()
+}
+
 /// Walk up from `bundle_path`'s parent until a directory is found that
 /// looks like an SSOT root — a directory whose direct children include
 /// at least one item directory (containing `RULE.md`, `SKILL.md`, or
@@ -1683,5 +1696,41 @@ mod tests {
 
         let result = find_bundle_by_name(tmp.path(), "secret");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn has_matching_items_true_when_skill_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("code-review");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nschema: 1\nname: code-review\n---\n# body\n",
+        )
+        .unwrap();
+
+        assert!(has_matching_items(tmp.path(), "code-review"));
+    }
+
+    #[test]
+    fn has_matching_items_false_when_no_item_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("other")).unwrap();
+
+        assert!(!has_matching_items(tmp.path(), "nonexistent"));
+    }
+
+    #[test]
+    fn has_matching_items_true_for_rules_and_agents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rule_dir = tmp.path().join("my-rule");
+        std::fs::create_dir_all(&rule_dir).unwrap();
+        std::fs::write(
+            rule_dir.join("RULE.md"),
+            "---\nschema: 1\nname: my-rule\n---\n# body\n",
+        )
+        .unwrap();
+
+        assert!(has_matching_items(tmp.path(), "my-rule"));
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -265,24 +265,13 @@ pub fn install_with_lockfile(
     items: &[String],
     plugin_scope: crate::plugin::PluginScope,
 ) -> Result<InstallReport> {
-    // Empty list means "install everything" (the historical default).
-    // Otherwise build a `ResolvedItems` filter with each name copied
-    // into all three buckets — the per-kind walks check by `(kind,
-    // name)` so unrelated kinds simply skip names that aren't theirs.
-    let resolved = if items.is_empty() {
-        None
+    let mut report = if items.is_empty() {
+        // No names → install everything (existing default).
+        install_from_source(source, target, None)?
     } else {
-        Some(crate::bundle::ResolvedItems {
-            rules: items.to_vec(),
-            skills: items.to_vec(),
-            agents: items.to_vec(),
-        })
+        // Names provided → try item-filter first, then bundle-by-name.
+        install_with_name_resolution(source, target, items)?
     };
-    let mut report = install_from_source(source, target, resolved.as_ref())?;
-
-    if !items.is_empty() && report.items.is_empty() {
-        anyhow::bail!("no matching items in source for: {}", items.join(", "));
-    }
 
     // -- Plugin installation (ADR-0008) --
     // After items are generated, iterate the resolved bundles' plugins
@@ -355,6 +344,97 @@ pub fn install_with_lockfile(
     crate::ancillary::ensure_vscode_instructions_registered(target, has_rules)?;
 
     Ok(report)
+}
+
+/// Resolve positional names against both items and bundles.
+///
+/// For each name:
+/// - If it matches items AND a bundle → error (ambiguity).
+/// - If it matches only a bundle → install via bundle dispatch.
+/// - If it matches only items → install via item filter.
+/// - If it matches neither → error.
+///
+/// When the list contains a mix (some names are bundles, some are items),
+/// all bundle installs run first, then item installs run with the
+/// remaining names as a filter.
+fn install_with_name_resolution(
+    source: &InstallSource,
+    target: &Path,
+    names: &[String],
+) -> Result<InstallReport> {
+    let (local_source, _tmp) = fetch_ssot(source)?;
+
+    let mut bundle_paths: Vec<PathBuf> = Vec::new();
+    let mut item_names: Vec<String> = Vec::new();
+
+    for name in names {
+        let has_items = has_matching_items(&local_source, name);
+        let bundle_path = find_bundle_by_name(&local_source, name);
+
+        match (has_items, bundle_path) {
+            (true, Some(bp)) => {
+                let rel = bp
+                    .strip_prefix(&local_source)
+                    .unwrap_or(&bp)
+                    .display()
+                    .to_string();
+                anyhow::bail!(
+                    "'{}' matches both an item and a bundle\n\n  \
+                     item:   {}/{}\n  \
+                     bundle: {}\n\n\
+                     Disambiguate by using the full path to the bundle:\n  \
+                     upskill add <source>:{}",
+                    name,
+                    name,
+                    detect_item_entrypoint(&local_source, name),
+                    rel,
+                    rel,
+                );
+            }
+            (false, Some(bp)) => bundle_paths.push(bp),
+            (true, None) => item_names.push(name.clone()),
+            (false, None) => {
+                anyhow::bail!("no matching items or bundles in source for: {}", name);
+            }
+        }
+    }
+
+    let mut report = InstallReport::default();
+
+    // Install bundles first.
+    for bp in &bundle_paths {
+        let bundle_report = install_bundle_file(bp, target)?;
+        report.items.extend(bundle_report.items);
+        report.bundles.extend(bundle_report.bundles);
+    }
+
+    // Install remaining items via the standard filter path.
+    if !item_names.is_empty() {
+        let filter = crate::bundle::ResolvedItems {
+            rules: item_names.clone(),
+            skills: item_names.clone(),
+            agents: item_names.clone(),
+        };
+        let item_report = install_from_local_path(&local_source, target, Some(&filter))?;
+        report.items.extend(item_report.items);
+    }
+
+    Ok(report)
+}
+
+/// Detect which entrypoint file (SKILL.md, RULE.md, AGENT.md) exists for
+/// an item, for use in error messages.
+fn detect_item_entrypoint(source: &Path, name: &str) -> &'static str {
+    let dir = source.join(name);
+    if dir.join("SKILL.md").is_file() {
+        "SKILL.md"
+    } else if dir.join("RULE.md").is_file() {
+        "RULE.md"
+    } else if dir.join("AGENT.md").is_file() {
+        "AGENT.md"
+    } else {
+        "SKILL.md" // fallback for error message
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -172,10 +172,10 @@ fn find_bundle_recursive(dir: &Path, target: &str) -> Option<PathBuf> {
         if path.is_file() && name_str == target {
             return Some(path);
         }
-        if path.is_dir() {
-            if let Some(found) = find_bundle_recursive(&path, target) {
-                return Some(found);
-            }
+        if path.is_dir()
+            && let Some(found) = find_bundle_recursive(&path, target)
+        {
+            return Some(found);
         }
     }
     None

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -153,6 +153,34 @@ fn is_bundle_file(path: &Path) -> bool {
             .is_some_and(|n| n.ends_with(crate::parse::bundle::BUNDLE_SUFFIX))
 }
 
+/// Search `root` recursively for a file named `<name>.bundle.yaml`.
+/// Skips hidden directories. Returns the first match or `None`.
+fn find_bundle_by_name(root: &Path, name: &str) -> Option<PathBuf> {
+    let target_filename = format!("{}{}", name, crate::parse::bundle::BUNDLE_SUFFIX);
+    find_bundle_recursive(root, &target_filename)
+}
+
+fn find_bundle_recursive(dir: &Path, target: &str) -> Option<PathBuf> {
+    let entries = fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let entry_name = entry.file_name();
+        let name_str = entry_name.to_string_lossy();
+        if name_str.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_file() && name_str == target {
+            return Some(path);
+        }
+        if path.is_dir() {
+            if let Some(found) = find_bundle_recursive(&path, target) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
 /// Walk up from `bundle_path`'s parent until a directory is found that
 /// looks like an SSOT root — a directory whose direct children include
 /// at least one item directory (containing `RULE.md`, `SKILL.md`, or
@@ -1611,5 +1639,49 @@ mod tests {
                 agent_output_path(client, "x")
             );
         }
+    }
+
+    #[test]
+    fn find_bundle_by_name_finds_nested_bundle_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundles_dir = tmp.path().join("bundles");
+        std::fs::create_dir_all(&bundles_dir).unwrap();
+        std::fs::write(
+            bundles_dir.join("baseline.bundle.yaml"),
+            "schema: 1\nname: baseline\ndescription: test\nitems:\n  rules: []\n",
+        )
+        .unwrap();
+
+        let result = find_bundle_by_name(tmp.path(), "baseline");
+        assert_eq!(result, Some(bundles_dir.join("baseline.bundle.yaml")));
+    }
+
+    #[test]
+    fn find_bundle_by_name_returns_none_when_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("skills/foo")).unwrap();
+        std::fs::write(
+            tmp.path().join("skills/foo/SKILL.md"),
+            "---\nschema: 1\nname: foo\n---\n# body\n",
+        )
+        .unwrap();
+
+        let result = find_bundle_by_name(tmp.path(), "foo");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_bundle_by_name_skips_hidden_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hidden = tmp.path().join(".hidden");
+        std::fs::create_dir_all(&hidden).unwrap();
+        std::fs::write(
+            hidden.join("secret.bundle.yaml"),
+            "schema: 1\nname: secret\ndescription: x\nitems:\n  rules: []\n",
+        )
+        .unwrap();
+
+        let result = find_bundle_by_name(tmp.path(), "secret");
+        assert!(result.is_none());
     }
 }

--- a/tests/cli_lint.rs
+++ b/tests/cli_lint.rs
@@ -208,6 +208,39 @@ fn lint_refuses_to_run_inside_consumer_project() {
     );
 }
 
+#[test]
+fn lint_flags_bundle_item_name_collision() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // Create a skill named "baseline"
+    let skill_dir = root.join("baseline");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: baseline\ndescription: a skill\n---\n# body\n",
+    )
+    .unwrap();
+
+    // Create a bundle also named "baseline"
+    let bundles_dir = root.join("bundles");
+    fs::create_dir_all(&bundles_dir).unwrap();
+    fs::write(
+        bundles_dir.join("baseline.bundle.yaml"),
+        "schema: 1\nname: baseline\ndescription: a bundle\nitems:\n  skills:\n    - baseline\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(root)
+        .args(["lint"])
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("name-collision"))
+        .stdout(predicates::str::contains("baseline"));
+}
+
 fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
     fs::create_dir_all(to)?;
     for entry in fs::read_dir(from)? {

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -391,3 +391,92 @@ fn plugin_results_carry_correct_metadata() {
     assert_eq!(vscode_result.identifier, "anthropic.superpowers");
     assert_eq!(vscode_result.bundle, "with-plugins");
 }
+
+// ---------------------------------------------------------------------------
+// Bundle-by-name discovery tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn install_by_name_discovers_bundle_when_no_item_matches() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    // "with-plugins" is a bundle name, not an item name.
+    let report = install_with_lockfile(
+        &InstallSource::LocalPath(registry.clone()),
+        &target,
+        &["with-plugins".into()],
+        PluginScope::Project,
+    )
+    .expect("install");
+
+    // Bundle dispatch should have fired — items from the bundle are installed.
+    assert!(
+        !report.items.is_empty(),
+        "expected bundle items to be installed"
+    );
+    assert!(
+        !report.bundles.is_empty(),
+        "expected bundle to appear in report"
+    );
+    assert_eq!(report.bundles[0].name, "with-plugins");
+}
+
+#[test]
+fn install_by_name_errors_on_ambiguity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    // Create an item directory that collides with bundle name "with-plugins"
+    let collision_dir = registry.join("with-plugins");
+    fs::create_dir_all(&collision_dir).unwrap();
+    fs::write(
+        collision_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: with-plugins\ndescription: collision\n---\n# body\n",
+    )
+    .unwrap();
+
+    let err = install_with_lockfile(
+        &InstallSource::LocalPath(registry.clone()),
+        &target,
+        &["with-plugins".into()],
+        PluginScope::Project,
+    )
+    .expect_err("should error on ambiguity");
+
+    let msg = format!("{:#}", err);
+    assert!(
+        msg.contains("matches both"),
+        "error mentions ambiguity: {msg}"
+    );
+}
+
+#[test]
+fn install_by_name_prefers_items_when_only_items_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let target = tmp.path().join("target");
+    stage_registry(&registry);
+    fs::create_dir_all(&target).unwrap();
+
+    // "license-awareness" is a rule item, not a bundle.
+    let report = install_with_lockfile(
+        &InstallSource::LocalPath(registry.clone()),
+        &target,
+        &["license-awareness".into()],
+        PluginScope::Project,
+    )
+    .expect("install");
+
+    assert!(!report.items.is_empty());
+    assert!(
+        report.bundles.is_empty(),
+        "no bundle dispatch for item-only match"
+    );
+}


### PR DESCRIPTION
## Summary

Allow `upskill add owner/repo bundle-name` to discover and install bundles by name, not just by full file path.

### Changes

- **`find_bundle_by_name`** — recursively searches a source directory for `<name>.bundle.yaml`, skipping hidden dirs
- **`has_matching_items`** — checks if a source contains an item (skill/rule/agent) with a given name
- **`install_with_name_resolution`** — new dispatch logic in `install_with_lockfile` that resolves positional names against both items and bundles
- **`name-collision` lint rule** — error-severity cross-file lint that catches bundle-item name collisions at authoring time

### Resolution order

For each positional name:
1. If it matches both an item AND a bundle → error (ambiguity with disambiguation hint)
2. If it matches only a bundle → install via bundle dispatch
3. If it matches only items → install via item filter
4. If it matches neither → error

### Test plan

- 6 new unit tests (`find_bundle_by_name` × 3, `has_matching_items` × 3)
- 3 new integration tests (bundle discovery, ambiguity error, item-only match)
- 1 new CLI lint test (`name-collision` rule)
- All 342 tests pass, clippy clean, `just verify` green

Design spec: `docs/superpowers/specs/2026-05-22-bundle-by-name-discovery-design.md`
Implementation plan: `docs/superpowers/plans/2026-05-22-bundle-by-name-discovery.md`