### PR TITLE
feat(fetch): use sparse clone for subfolder installs

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -255,7 +255,9 @@ mod tests {
             ],
             Some(&work),
         );
-        git(&["push"], Some(&work));
+        // Ensure the branch is named "main" regardless of init.defaultBranch.
+        git(&["branch", "-M", "main"], Some(&work));
+        git(&["push", "-u", "origin", "main"], Some(&work));
 
         repo
     }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -230,7 +230,15 @@ mod tests {
             );
         };
 
-        git(&["init", "--bare", repo.to_str().unwrap()], None);
+        git(
+            &[
+                "init",
+                "--bare",
+                "--initial-branch=main",
+                repo.to_str().unwrap(),
+            ],
+            None,
+        );
         git(
             &["clone", repo.to_str().unwrap(), work.to_str().unwrap()],
             None,
@@ -256,7 +264,6 @@ mod tests {
             Some(&work),
         );
         // Ensure the branch is named "main" regardless of init.defaultBranch.
-        git(&["branch", "-M", "main"], Some(&work));
         git(&["push", "-u", "origin", "main"], Some(&work));
 
         repo

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -8,7 +8,13 @@ use crate::source::GithubRepo;
 /// cleaning up the returned directory.
 pub fn clone_github_repo(repo: &GithubRepo, dest: &Path) -> Result<PathBuf, String> {
     let url = format!("https://github.com/{}/{}.git", repo.owner, repo.name);
-    shallow_clone(&url, repo.git_ref.as_deref(), &repo.name, dest)?;
+    shallow_clone(
+        &url,
+        repo.git_ref.as_deref(),
+        &repo.name,
+        dest,
+        repo.subfolder.as_deref(),
+    )?;
     let clone_dir = dest.join(&repo.name);
     resolve_subfolder(
         &clone_dir,
@@ -22,17 +28,37 @@ pub fn clone_github_repo(repo: &GithubRepo, dest: &Path) -> Result<PathBuf, Stri
 /// so the v0.2 pipeline can clone from arbitrary URL forms (`file://`,
 /// GitLab self-hosted, etc.) without going through the GitHub-specific
 /// `clone_github_repo` constructor.
+///
+/// When `subfolder` is `Some`, uses partial clone (`--filter=blob:none
+/// --sparse`) followed by `git sparse-checkout set <subfolder>` to fetch
+/// only the target path. This avoids downloading blobs for the entire repo
+/// when only a single skill or bundle is needed. Falls back to a regular
+/// shallow clone if the sparse checkout step fails (e.g. older git
+/// versions that don't support `sparse-checkout set`).
 pub(crate) fn shallow_clone(
     url: &str,
     git_ref: Option<&str>,
     dir_name: &str,
     dest: &Path,
+    subfolder: Option<&str>,
 ) -> Result<(), String> {
     let clone_dir = dest.join(dir_name);
     let clone_str = clone_dir
         .to_str()
         .ok_or_else(|| "clone path is not valid UTF-8".to_string())?;
 
+    if let Some(sub) = subfolder {
+        // Try sparse clone: only fetch tree metadata, then check out the
+        // target subfolder. This is significantly faster for large repos.
+        if try_sparse_clone(url, git_ref, clone_str, sub).is_ok() {
+            return Ok(());
+        }
+        // Sparse checkout not supported — fall through to regular clone.
+        // Remove any partial clone directory before retrying.
+        let _ = std::fs::remove_dir_all(&clone_dir);
+    }
+
+    // Regular shallow clone — fetches all blobs at depth 1.
     let mut args: Vec<&str> = vec!["clone", "--depth", "1"];
     if let Some(r) = git_ref {
         args.push("--branch");
@@ -53,6 +79,54 @@ pub(crate) fn shallow_clone(
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git clone failed: {}", stderr.trim()));
     }
+    Ok(())
+}
+
+/// Attempt a sparse clone: `--depth 1 --filter=blob:none --sparse` followed
+/// by `git sparse-checkout set <subfolder>`. Returns `Ok(())` on success or
+/// an error if any step fails (caller should fall back to regular clone).
+fn try_sparse_clone(
+    url: &str,
+    git_ref: Option<&str>,
+    clone_str: &str,
+    subfolder: &str,
+) -> Result<(), String> {
+    let mut args: Vec<&str> = vec!["clone", "--depth", "1", "--filter=blob:none", "--sparse"];
+    if let Some(r) = git_ref {
+        args.push("--branch");
+        args.push(r);
+    }
+    args.push(url);
+    args.push(clone_str);
+
+    let output = Command::new("git")
+        .args(&args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .map_err(|err| format!("failed to run git clone --sparse: {}", err))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git clone --sparse failed: {}", stderr.trim()));
+    }
+
+    // Set the sparse-checkout cone to the target subfolder.
+    let output = Command::new("git")
+        .args(["sparse-checkout", "set", subfolder])
+        .current_dir(clone_str)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .map_err(|err| format!("failed to run git sparse-checkout set: {}", err))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git sparse-checkout set failed: {}", stderr.trim()));
+    }
+
     Ok(())
 }
 
@@ -194,7 +268,7 @@ mod tests {
         fs::create_dir_all(&dest).unwrap();
 
         let url = format!("file://{}", bare.display());
-        shallow_clone(&url, None, "cloned", &dest).expect("clone must succeed");
+        shallow_clone(&url, None, "cloned", &dest, None).expect("clone must succeed");
 
         assert!(dest.join("cloned/my-skill/SKILL.md").exists());
     }
@@ -207,7 +281,7 @@ mod tests {
         fs::create_dir_all(&dest).unwrap();
 
         let url = format!("file://{}", bare.display());
-        shallow_clone(&url, None, "cloned", &dest).expect("clone");
+        shallow_clone(&url, None, "cloned", &dest, None).expect("clone");
 
         let sub = resolve_subfolder(&dest.join("cloned"), Some("catalog/lint"), "test", "repo")
             .expect("subfolder must resolve");
@@ -223,7 +297,7 @@ mod tests {
         fs::create_dir_all(&dest).unwrap();
 
         let url = format!("file://{}", bare.display());
-        shallow_clone(&url, None, "cloned", &dest).expect("clone");
+        shallow_clone(&url, None, "cloned", &dest, None).expect("clone");
 
         let err = resolve_subfolder(&dest.join("cloned"), Some("nonexistent"), "test", "repo")
             .expect_err("must fail");
@@ -263,6 +337,55 @@ mod tests {
             fs::read_to_string(dest.join("a/b/c/file.txt")).unwrap(),
             "content"
         );
+    }
+
+    #[test]
+    fn sparse_clone_fetches_only_subfolder() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare = make_test_repo(tmp.path());
+        let dest = tmp.path().join("dest");
+        fs::create_dir_all(&dest).unwrap();
+
+        let url = format!("file://{}", bare.display());
+        // Clone with subfolder hint — only "catalog/lint" should be checked out
+        shallow_clone(&url, None, "cloned", &dest, Some("catalog/lint"))
+            .expect("sparse clone must succeed");
+
+        // The subfolder content must exist
+        assert!(dest.join("cloned/catalog/lint/SKILL.md").exists());
+        // Content outside the sparse cone must NOT be checked out
+        assert!(!dest.join("cloned/my-skill/SKILL.md").exists());
+    }
+
+    #[test]
+    fn sparse_clone_with_git_ref() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare = make_test_repo(tmp.path());
+        let dest = tmp.path().join("dest");
+        fs::create_dir_all(&dest).unwrap();
+
+        let url = format!("file://{}", bare.display());
+        // Sparse clone pinned to a branch (the default branch pushed by make_test_repo)
+        shallow_clone(&url, Some("main"), "cloned", &dest, Some("catalog/lint"))
+            .expect("sparse clone with ref must succeed");
+
+        assert!(dest.join("cloned/catalog/lint/SKILL.md").exists());
+        assert!(!dest.join("cloned/my-skill/SKILL.md").exists());
+    }
+
+    #[test]
+    fn shallow_clone_without_subfolder_fetches_everything() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare = make_test_repo(tmp.path());
+        let dest = tmp.path().join("dest");
+        fs::create_dir_all(&dest).unwrap();
+
+        let url = format!("file://{}", bare.display());
+        // Clone without subfolder — should get everything (backward compat)
+        shallow_clone(&url, None, "cloned", &dest, None).expect("clone must succeed");
+
+        assert!(dest.join("cloned/my-skill/SKILL.md").exists());
+        assert!(dest.join("cloned/catalog/lint/SKILL.md").exists());
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1143,7 +1143,7 @@ fn clone_to_tempdir(
     name: &str,
 ) -> Result<(PathBuf, Option<tempfile::TempDir>)> {
     let tmp = tempfile::tempdir().context("create temp dir for clone")?;
-    fetch::shallow_clone(url, git_ref, "clone", tmp.path())
+    fetch::shallow_clone(url, git_ref, "clone", tmp.path(), subfolder)
         .map_err(|e| anyhow!("git clone {}: {}", url, e))?;
     let source = fetch::resolve_subfolder(&tmp.path().join("clone"), subfolder, owner, name)
         .map_err(|e| anyhow!("{}", e))?;
@@ -1209,7 +1209,7 @@ pub fn install_from_git_url(
     filter: Option<&crate::bundle::ResolvedItems>,
 ) -> Result<InstallReport> {
     let tmp = tempfile::tempdir().context("create temp dir for clone")?;
-    fetch::shallow_clone(url, git_ref, "clone", tmp.path())
+    fetch::shallow_clone(url, git_ref, "clone", tmp.path(), subfolder)
         .map_err(|e| anyhow!("git clone {}: {}", url, e))?;
     let source = fetch::resolve_subfolder(&tmp.path().join("clone"), subfolder, owner, name)
         .map_err(|e| anyhow!("{}", e))?;


### PR DESCRIPTION
## Summary

When a subfolder is specified (e.g. `owner/repo:path/to/skill`), use partial clone (`--filter=blob:none --sparse`) followed by `git sparse-checkout set <subfolder>` to fetch only the target path. This avoids downloading blobs for the entire repo when only a single skill or bundle is needed.

## Changes

- **`src/fetch.rs`**: Added `subfolder` parameter to `shallow_clone()`. When `Some`, uses `try_sparse_clone()` (new helper) to clone with `--filter=blob:none --sparse` + `git sparse-checkout set`. Falls back to regular shallow clone if sparse checkout fails (e.g. older git versions).
- **`src/pipeline.rs`**: Updated `clone_to_tempdir()` and `install_from_git_url()` to pass `subfolder` through to `shallow_clone()`.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `upskill add owner/repo:skills/my-skill` | `git clone --depth 1` (all blobs) | `git clone --depth 1 --filter=blob:none --sparse` + `sparse-checkout set skills/my-skill` |
| `upskill add owner/repo` (no subfolder) | `git clone --depth 1` | unchanged |
| Sparse checkout unsupported | N/A | Falls back to regular `git clone --depth 1` |

## Testing

3 new unit tests added:
- `sparse_clone_fetches_only_subfolder` — verifies only the target subfolder is checked out
- `sparse_clone_with_git_ref` — verifies sparse clone works with `--branch` flag
- `shallow_clone_without_subfolder_fetches_everything` — backward compat

All 207 unit tests + 156 integration tests pass. `just verify` clean.

Closes #60