### PR TITLE
docs: fix documentation gaps from PR review (#157, #160, #166)

### DIFF
--- a/docs/adr/0008-plugin-install-shellout.md
+++ b/docs/adr/0008-plugin-install-shellout.md
@@ -147,9 +147,9 @@ existing project conventions.
 
 Per PR #135 the supported Windows path is `install.sh` under
 WSL — `upskill` runs as a Linux ELF binary regardless of host
-OS. Inside WSL all three target CLIs are present on PATH as
-ordinary Linux executables (Claude Code, opencode, and VS Code
-each ship Linux builds; VS Code's WSL-remote workflow
+OS. Inside WSL all four target CLIs are present on PATH as
+ordinary Linux executables (Claude Code, Copilot, opencode, and
+VS Code each ship Linux builds; VS Code's WSL-remote workflow
 additionally injects a `code` shim that proxies to Windows-side
 `code.exe` via interop). Shellout is indistinguishable from
 native Linux — no `cfg!(windows)` branches, no `PATHEXT`
@@ -160,11 +160,14 @@ Presence detection for the warn-skip policy uses
 portable across every platform Rust targets — no `which` crate
 dependency, consistent with ADR-0001 §3.
 
-Users who side-step the stance via `cargo install upskill` on
-native Windows are unsupported. Native-Windows shellout (`.cmd`
-shims, `PATHEXT`, Rust 1.77 batch-argument escaping, VS Code
-Insiders discovery) would need its own ADR if that ever moves
-in-scope.
+Since PR #157, `upskill` itself builds and runs on native
+Windows (`cargo install upskill`, `USERPROFILE` fallback, Windows
+CI). However, plugin CLI shellout on native Windows has known
+limitations: `.cmd`/`.bat` shim resolution via `PATHEXT`, Rust
+1.77 batch-argument escaping, and VS Code Insiders discovery are
+not yet handled. WSL remains the primary supported path for
+plugin shellout; native Windows plugin support would need its own
+ADR if demand materialises.
 
 ## Consequences
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -42,7 +42,8 @@ upskill add owner/repo@abc123                       # pin to commit SHA
 upskill add gitlab:owner/repo                       # GitLab.com
 upskill add https://gitlab.example.com/owner/repo   # self-hosted GitLab
 upskill add ./path/to/local                         # local directory
-upskill add owner/repo:platform.bundle.yaml         # bundle file
+upskill add owner/repo:platform.bundle.yaml         # bundle file (explicit path)
+upskill add owner/repo platform-baseline            # bundle by name (resolves .bundle.yaml)
 ```
 
 `upskill add <source>` installs **everything** the source contains.

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -556,6 +556,9 @@ agents portion of the bundle MUST install regardless of plugin installation succ
 with its client, identifier, and scope so that `remove`, `update`, and `doctor` can invoke the
 inverse CLI command.
 
+> **Note:** A future revision will extend lockfile recording to include warn-skipped plugins
+> (with `status: "skipped"`) so that `doctor` can surface them. See issue #151.
+
 Implementations:
 
 - MUST shell out to the native client CLI for plugin installation — MUST NOT manipulate client

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,8 +45,8 @@ agents:
 # Install everything from a source repo
 upskill add driftsys/skills
 
-# Or install a curated bundle
-upskill add driftsys/bundles:platform-baseline.bundle.yaml
+# Or install a curated bundle (by name — resolves the .bundle.yaml automatically)
+upskill add driftsys/bundles platform-baseline
 
 # Pin to a tag, branch, or commit
 upskill add driftsys/skills@v1.2.0


### PR DESCRIPTION
## Summary

Fixes documentation inconsistencies identified during review of today's merged PRs.

## Changes

### ADR-0008 Platform scope (stale after #157 + #166)
- Updated "three" → "four" target CLIs (Copilot added in #166)
- Replaced "native Windows unsupported" with acknowledgement that upskill itself runs on Windows (PR #157), while noting plugin shellout limitations remain

### User-facing docs missing bundle-by-name syntax (from #160)
- `docs/getting-started.md`: Updated example to use `upskill add owner/repo bundle-name` form
- `docs/commands.md`: Added bundle-by-name example alongside explicit path form

### format-spec.md §3.7 — forward-looking note for #151
- Added note that a future revision will extend lockfile recording to include warn-skipped plugins (`status: "skipped"`)

## Verification

- `just verify` passes (218 unit tests + all integration tests + clippy + fmt + dprint + markdownlint + shellcheck + build)