### PR TITLE
feat: upgrade UX — orphan removal, clean-and-regenerate, interactive confirm

### DIFF
--- a/docs/superpowers/plans/2026-05-24-item-conflict-resolution.md
+++ b/docs/superpowers/plans/2026-05-24-item-conflict-resolution.md
@@ -13,6 +13,7 @@
 ### Task 1: Add `source_name` field to `LockedItem`
 
 **Files:**
+
 - Modify: `src/lockfile.rs:37-54`
 - Test: `src/lockfile.rs` (inline tests)
 
@@ -58,16 +59,17 @@ Expected: FAIL — `source_name` field doesn't exist
 In `src/lockfile.rs`, add to the `LockedItem` struct after the `hash` field:
 
 ```rust
-    /// Original item name in the source registry. Only present when the
-    /// consumer installed with `--as <alias>` so `name` differs from the
-    /// SSOT name. Used by `update` to locate the correct source file.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_name: Option<String>,
+/// Original item name in the source registry. Only present when the
+/// consumer installed with `--as <alias>` so `name` differs from the
+/// SSOT name. Used by `update` to locate the correct source file.
+#[serde(skip_serializing_if = "Option::is_none")]
+pub source_name: Option<String>,
 ```
 
 - [ ] **Step 4: Fix all struct literals that construct `LockedItem`**
 
 Add `source_name: None` to:
+
 - `items_from_report` (line ~246)
 - All test helper `item()` functions in `src/lockfile.rs` and `tests/`
 
@@ -88,37 +90,38 @@ git commit -m "feat(lockfile): add source_name field for alias tracking"
 ### Task 2: Add `--force` and `--as` flags to `Add` command
 
 **Files:**
+
 - Modify: `src/cli.rs:50-64`
 
 - [ ] **Step 1: Add flags to the `Add` variant in `cli.rs`**
 
 ```rust
-    Add {
-        /// Source: `owner/repo[@ref][:subfolder]`, full https URL, or local path.
-        source: String,
-        /// Optional subset filter — only items whose name matches one of
-        /// these is installed. Empty means install everything in the
-        /// source (the default).
-        items: Vec<String>,
-        /// Install into `$HOME` instead of the current directory.
-        #[arg(short = 'g', long = "global", conflicts_with = "project")]
-        global: bool,
-        /// Force project scope (current directory). Overrides the auto-detect
-        /// fallback to global when `cwd` is not inside a git repo.
-        #[arg(short = 'p', long = "project")]
-        project: bool,
-        /// Replace existing items from a different source without error.
-        #[arg(long = "force")]
-        force: bool,
-        /// Install under an alternate name to avoid conflicts.
-        /// For direct installs: `--as alt-name`.
-        /// For bundle installs: `--as original=alias` (repeatable).
-        #[arg(long = "as", value_name = "ALIAS")]
-        alias: Vec<String>,
-        /// Skip specific items during bundle install (repeatable).
-        #[arg(long = "exclude", value_name = "NAME")]
-        exclude: Vec<String>,
-    },
+Add {
+    /// Source: `owner/repo[@ref][:subfolder]`, full https URL, or local path.
+    source: String,
+    /// Optional subset filter — only items whose name matches one of
+    /// these is installed. Empty means install everything in the
+    /// source (the default).
+    items: Vec<String>,
+    /// Install into `$HOME` instead of the current directory.
+    #[arg(short = 'g', long = "global", conflicts_with = "project")]
+    global: bool,
+    /// Force project scope (current directory). Overrides the auto-detect
+    /// fallback to global when `cwd` is not inside a git repo.
+    #[arg(short = 'p', long = "project")]
+    project: bool,
+    /// Replace existing items from a different source without error.
+    #[arg(long = "force")]
+    force: bool,
+    /// Install under an alternate name to avoid conflicts.
+    /// For direct installs: `--as alt-name`.
+    /// For bundle installs: `--as original=alias` (repeatable).
+    #[arg(long = "as", value_name = "ALIAS")]
+    alias: Vec<String>,
+    /// Skip specific items during bundle install (repeatable).
+    #[arg(long = "exclude", value_name = "NAME")]
+    exclude: Vec<String>,
+},
 ```
 
 - [ ] **Step 2: Update the `Commands::Add` match in `main.rs`**
@@ -126,15 +129,15 @@ git commit -m "feat(lockfile): add source_name field for alias tracking"
 Update the destructuring at line ~46:
 
 ```rust
-        Commands::Add {
-            source,
-            items,
-            global,
-            project,
-            force,
-            alias,
-            exclude,
-        } => run_add(&source, &items, global, project, force, &alias, &exclude),
+Commands::Add {
+    source,
+    items,
+    global,
+    project,
+    force,
+    alias,
+    exclude,
+} => run_add(&source, &items, global, project, force, &alias, &exclude),
 ```
 
 And update `run_add` signature:
@@ -160,6 +163,7 @@ git commit -m "feat(cli): add --force, --as, --exclude flags to add command"
 ### Task 3: Implement conflict detection
 
 **Files:**
+
 - Modify: `src/pipeline.rs`
 - Create: `src/conflict.rs`
 - Modify: `src/lib.rs`
@@ -315,6 +319,7 @@ git commit -m "feat(conflict): add item conflict detection module"
 ### Task 4: Wire conflict detection into `install_with_lockfile`
 
 **Files:**
+
 - Modify: `src/pipeline.rs:284-380`
 - Modify: `src/main.rs:127-158`
 
@@ -564,6 +569,7 @@ git commit -m "feat(pipeline): wire conflict detection into install_with_lockfil
 ### Task 5: Implement `--as` alias installation
 
 **Files:**
+
 - Modify: `src/pipeline.rs`
 - Modify: `src/lockfile.rs`
 
@@ -608,21 +614,21 @@ Expected: FAIL
 In `install_with_lockfile`, after conflict detection and before lockfile write, rename items that match aliases:
 
 ```rust
-    // -- Apply aliases --
-    // For direct --as (empty key): rename all items from this source
-    // For bundle --as (key=value): rename specific items
-    for item in &mut report.items {
-        let alias = options.aliases.iter().find(|(from, _)| {
-            from.is_empty() || *from == item.name
-        });
-        if let Some((original_name, alias_name)) = alias {
-            // Rename the item in the report
-            let source_name = item.name.clone();
-            item.name = alias_name.clone();
-            // Also rename the output path
-            // (regeneration with new name handled below)
-        }
+// -- Apply aliases --
+// For direct --as (empty key): rename all items from this source
+// For bundle --as (key=value): rename specific items
+for item in &mut report.items {
+    let alias = options.aliases.iter().find(|(from, _)| {
+        from.is_empty() || *from == item.name
+    });
+    if let Some((original_name, alias_name)) = alias {
+        // Rename the item in the report
+        let source_name = item.name.clone();
+        item.name = alias_name.clone();
+        // Also rename the output path
+        // (regeneration with new name handled below)
     }
+}
 ```
 
 And in the lockfile write section, set `source_name` when aliased:
@@ -667,6 +673,7 @@ git commit -m "feat(pipeline): implement --as alias installation with source_nam
 ### Task 6: Implement `--exclude` for bundle installs
 
 **Files:**
+
 - Modify: `src/pipeline.rs`
 
 - [ ] **Step 1: Write integration test**
@@ -715,14 +722,14 @@ Expected: FAIL (skill-b is installed)
 In `install_with_lockfile`, after the install but before lockfile write, filter out excluded items:
 
 ```rust
-    // -- Apply excludes --
-    if !options.excludes.is_empty() {
-        report.items.retain(|item| !options.excludes.contains(&item.name));
-        // Also remove generated output files for excluded items
-        for exclude in &options.excludes {
-            remove_generated_outputs(target, exclude);
-        }
+// -- Apply excludes --
+if !options.excludes.is_empty() {
+    report.items.retain(|item| !options.excludes.contains(&item.name));
+    // Also remove generated output files for excluded items
+    for exclude in &options.excludes {
+        remove_generated_outputs(target, exclude);
     }
+}
 ```
 
 The `remove_generated_outputs` helper deletes per-client files that were just written for excluded items. Alternatively, filter BEFORE generation by passing excludes into `install_from_source`.
@@ -749,6 +756,7 @@ git commit -m "feat(pipeline): implement --exclude flag to skip items during ins
 ### Task 7: Update `upskill update` to use `source_name`
 
 **Files:**
+
 - Modify: `src/pipeline.rs` (the `update` function)
 
 - [ ] **Step 1: Write the failing test**
@@ -809,8 +817,8 @@ Expected: FAIL — update looks for `my-alias` in source, doesn't find it
 In the `update` function in `src/pipeline.rs`, when fetching SSOT for a locked item, use `source_name` if present:
 
 ```rust
-    let ssot_name = item.source_name.as_deref().unwrap_or(&item.name);
-    // Use ssot_name to locate the item directory in the fetched source
+let ssot_name = item.source_name.as_deref().unwrap_or(&item.name);
+// Use ssot_name to locate the item directory in the fetched source
 ```
 
 And when regenerating, use `item.name` (the alias) as the output name.
@@ -837,6 +845,7 @@ git commit -m "feat(update): use source_name to fetch aliased items correctly"
 ### Task 8: Final verification and lint
 
 **Files:**
+
 - All modified files
 
 - [ ] **Step 1: Run full test suite**

--- a/docs/superpowers/plans/2026-05-24-item-conflict-resolution.md
+++ b/docs/superpowers/plans/2026-05-24-item-conflict-resolution.md
@@ -1,0 +1,866 @@
+# Item Conflict Resolution & Source Locking — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent accidental item overrides from different sources by making items locked to their source by default, with `--force` and `--as` flags to resolve conflicts.
+
+**Architecture:** Add conflict detection in `install_with_lockfile` (before writing), extend `LockedItem` with optional `source_name`, add `--force` and `--as` CLI flags, extend bundle install with `--exclude` and bundle-aware `--as`.
+
+**Tech Stack:** Rust, clap 4 (derive), anyhow, serde
+
+---
+
+### Task 1: Add `source_name` field to `LockedItem`
+
+**Files:**
+- Modify: `src/lockfile.rs:37-54`
+- Test: `src/lockfile.rs` (inline tests)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn locked_item_serializes_source_name_when_present() {
+    let item = LockedItem {
+        kind: "skill".to_string(),
+        name: "brainstorming-v2".to_string(),
+        source: "github:other-org/repo".to_string(),
+        git_ref: None,
+        hash: None,
+        source_name: Some("brainstorming".to_string()),
+    };
+    let json = serde_json::to_string(&item).unwrap();
+    assert!(json.contains("\"source_name\":\"brainstorming\""), "{json}");
+}
+
+#[test]
+fn locked_item_omits_source_name_when_none() {
+    let item = LockedItem {
+        kind: "skill".to_string(),
+        name: "brainstorming".to_string(),
+        source: "github:driftsys/superpowers".to_string(),
+        git_ref: None,
+        hash: None,
+        source_name: None,
+    };
+    let json = serde_json::to_string(&item).unwrap();
+    assert!(!json.contains("source_name"), "{json}");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test locked_item_serializes_source_name`
+Expected: FAIL — `source_name` field doesn't exist
+
+- [ ] **Step 3: Add `source_name` field to `LockedItem`**
+
+In `src/lockfile.rs`, add to the `LockedItem` struct after the `hash` field:
+
+```rust
+    /// Original item name in the source registry. Only present when the
+    /// consumer installed with `--as <alias>` so `name` differs from the
+    /// SSOT name. Used by `update` to locate the correct source file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_name: Option<String>,
+```
+
+- [ ] **Step 4: Fix all struct literals that construct `LockedItem`**
+
+Add `source_name: None` to:
+- `items_from_report` (line ~246)
+- All test helper `item()` functions in `src/lockfile.rs` and `tests/`
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lockfile.rs
+git commit -m "feat(lockfile): add source_name field for alias tracking"
+```
+
+---
+
+### Task 2: Add `--force` and `--as` flags to `Add` command
+
+**Files:**
+- Modify: `src/cli.rs:50-64`
+
+- [ ] **Step 1: Add flags to the `Add` variant in `cli.rs`**
+
+```rust
+    Add {
+        /// Source: `owner/repo[@ref][:subfolder]`, full https URL, or local path.
+        source: String,
+        /// Optional subset filter — only items whose name matches one of
+        /// these is installed. Empty means install everything in the
+        /// source (the default).
+        items: Vec<String>,
+        /// Install into `$HOME` instead of the current directory.
+        #[arg(short = 'g', long = "global", conflicts_with = "project")]
+        global: bool,
+        /// Force project scope (current directory). Overrides the auto-detect
+        /// fallback to global when `cwd` is not inside a git repo.
+        #[arg(short = 'p', long = "project")]
+        project: bool,
+        /// Replace existing items from a different source without error.
+        #[arg(long = "force")]
+        force: bool,
+        /// Install under an alternate name to avoid conflicts.
+        /// For direct installs: `--as alt-name`.
+        /// For bundle installs: `--as original=alias` (repeatable).
+        #[arg(long = "as", value_name = "ALIAS")]
+        alias: Vec<String>,
+        /// Skip specific items during bundle install (repeatable).
+        #[arg(long = "exclude", value_name = "NAME")]
+        exclude: Vec<String>,
+    },
+```
+
+- [ ] **Step 2: Update the `Commands::Add` match in `main.rs`**
+
+Update the destructuring at line ~46:
+
+```rust
+        Commands::Add {
+            source,
+            items,
+            global,
+            project,
+            force,
+            alias,
+            exclude,
+        } => run_add(&source, &items, global, project, force, &alias, &exclude),
+```
+
+And update `run_add` signature:
+
+```rust
+fn run_add(source: &str, items: &[String], global: bool, project: bool, force: bool, aliases: &[String], excludes: &[String]) -> i32 {
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo build`
+Expected: Compiles (unused params warning is fine for now)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli.rs src/main.rs
+git commit -m "feat(cli): add --force, --as, --exclude flags to add command"
+```
+
+---
+
+### Task 3: Implement conflict detection
+
+**Files:**
+- Modify: `src/pipeline.rs`
+- Create: `src/conflict.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/conflict.rs`:
+
+```rust
+//! Item conflict detection: checks whether incoming items collide with
+//! existing lockfile entries from a different source.
+
+use anyhow::{Result, bail};
+
+use crate::lockfile::{LockedItem, Lockfile};
+use crate::pipeline::ItemKind;
+
+/// A detected conflict between an incoming item and an existing lockfile entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ItemConflict {
+    pub kind: ItemKind,
+    pub name: String,
+    pub existing_source: String,
+    pub incoming_source: String,
+}
+
+/// Check incoming items against the lockfile. Returns conflicts (items from
+/// a different source that would be overwritten).
+pub fn detect_conflicts(
+    incoming: &[(ItemKind, String)],
+    lockfile: &Lockfile,
+    incoming_source: &str,
+) -> Vec<ItemConflict> {
+    let mut conflicts = Vec::new();
+    for (kind, name) in incoming {
+        let kind_str = match kind {
+            ItemKind::Rule => "rule",
+            ItemKind::Skill => "skill",
+            ItemKind::Agent => "agent",
+        };
+        if let Some(existing) = lockfile.items.iter().find(|i| i.kind == kind_str && i.name == *name) {
+            if existing.source != incoming_source {
+                conflicts.push(ItemConflict {
+                    kind: *kind,
+                    name: name.clone(),
+                    existing_source: existing.source.clone(),
+                    incoming_source: incoming_source.to_string(),
+                });
+            }
+        }
+    }
+    conflicts
+}
+
+/// Format conflicts into a user-facing error message.
+pub fn format_conflict_error(conflicts: &[ItemConflict]) -> String {
+    if conflicts.len() == 1 {
+        let c = &conflicts[0];
+        format!(
+            "{:?} `{}` is already installed from `{}`.\n\
+             Use --force to replace, or --as <alt-name> to keep both.",
+            c.kind, c.name, c.existing_source
+        )
+    } else {
+        let mut msg = format!("conflicts with {} installed items:\n", conflicts.len());
+        for c in conflicts {
+            msg.push_str(&format!("  - {:?} `{}` (from `{}`)\n", c.kind, c.name, c.existing_source));
+        }
+        msg.push_str("\nUse --force to replace all, or resolve individually with --exclude or --as.");
+        msg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lockfile::{LockedItem, Lockfile};
+
+    fn make_lockfile(items: Vec<LockedItem>) -> Lockfile {
+        Lockfile {
+            schema: 1,
+            items,
+            bundles: vec![],
+            plugins: vec![],
+        }
+    }
+
+    fn locked(kind: &str, name: &str, source: &str) -> LockedItem {
+        LockedItem {
+            kind: kind.to_string(),
+            name: name.to_string(),
+            source: source.to_string(),
+            git_ref: None,
+            hash: None,
+            source_name: None,
+        }
+    }
+
+    #[test]
+    fn no_conflict_when_same_source() {
+        let lf = make_lockfile(vec![locked("skill", "brainstorming", "github:driftsys/superpowers")]);
+        let incoming = vec![(ItemKind::Skill, "brainstorming".to_string())];
+        let conflicts = detect_conflicts(&incoming, &lf, "github:driftsys/superpowers");
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn conflict_when_different_source() {
+        let lf = make_lockfile(vec![locked("skill", "brainstorming", "github:driftsys/superpowers")]);
+        let incoming = vec![(ItemKind::Skill, "brainstorming".to_string())];
+        let conflicts = detect_conflicts(&incoming, &lf, "github:other-org/repo");
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].name, "brainstorming");
+        assert_eq!(conflicts[0].existing_source, "github:driftsys/superpowers");
+    }
+
+    #[test]
+    fn no_conflict_when_item_not_in_lockfile() {
+        let lf = make_lockfile(vec![]);
+        let incoming = vec![(ItemKind::Skill, "brainstorming".to_string())];
+        let conflicts = detect_conflicts(&incoming, &lf, "github:other-org/repo");
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn same_name_different_kind_is_not_conflict() {
+        let lf = make_lockfile(vec![locked("rule", "brainstorming", "github:driftsys/superpowers")]);
+        let incoming = vec![(ItemKind::Skill, "brainstorming".to_string())];
+        let conflicts = detect_conflicts(&incoming, &lf, "github:other-org/repo");
+        assert!(conflicts.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Register module in `lib.rs`**
+
+Add `pub mod conflict;` to `src/lib.rs`.
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cargo test conflict`
+Expected: All 4 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/conflict.rs src/lib.rs
+git commit -m "feat(conflict): add item conflict detection module"
+```
+
+---
+
+### Task 4: Wire conflict detection into `install_with_lockfile`
+
+**Files:**
+- Modify: `src/pipeline.rs:284-380`
+- Modify: `src/main.rs:127-158`
+
+- [ ] **Step 1: Write integration test**
+
+Create `tests/cli_conflict.rs`:
+
+```rust
+//! Integration tests for item conflict detection and resolution flags.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+/// Helper: set up a temp dir with a lockfile containing an item from source A.
+fn setup_with_existing_item(tmp: &TempDir) {
+    let lockfile = serde_json::json!({
+        "schema": 1,
+        "items": [{
+            "kind": "skill",
+            "name": "test-skill",
+            "source": "github:org-a/repo-a",
+            "hash": "sha256:aaa"
+        }],
+        "bundles": []
+    });
+    fs::write(tmp.path().join(".upskill-lock.json"), serde_json::to_string_pretty(&lockfile).unwrap()).unwrap();
+    // Create a minimal SSOT source with a skill named test-skill
+    let skill_dir = tmp.path().join("source/test-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "---\nname: test-skill\ndescription: A test skill\n---\nContent here.\n").unwrap();
+}
+
+#[test]
+fn add_from_different_source_errors_without_force() {
+    let tmp = TempDir::new().unwrap();
+    setup_with_existing_item(&tmp);
+
+    // Init as git repo so upskill doesn't fall back to global
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("already installed from"));
+}
+
+#[test]
+fn add_from_different_source_succeeds_with_force() {
+    let tmp = TempDir::new().unwrap();
+    setup_with_existing_item(&tmp);
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source", "--force"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn add_from_same_source_succeeds_without_force() {
+    let tmp = TempDir::new().unwrap();
+    // Lockfile with source matching what we'll install from
+    let lockfile = serde_json::json!({
+        "schema": 1,
+        "items": [{
+            "kind": "skill",
+            "name": "test-skill",
+            "source": "local:source",
+            "hash": "sha256:aaa"
+        }],
+        "bundles": []
+    });
+    fs::write(tmp.path().join(".upskill-lock.json"), serde_json::to_string_pretty(&lockfile).unwrap()).unwrap();
+
+    let skill_dir = tmp.path().join("source/test-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "---\nname: test-skill\ndescription: A test skill\n---\nContent here.\n").unwrap();
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source"])
+        .assert()
+        .success();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test cli_conflict`
+Expected: `add_from_different_source_errors_without_force` passes (currently succeeds, should fail) — actually this will PASS currently because there's no conflict detection. We need the test to assert failure. Let me correct: currently `upskill add ./source` succeeds even with a conflicting lockfile entry, so `add_from_different_source_errors_without_force` will FAIL (it expects failure but gets success).
+
+- [ ] **Step 3: Add `AddContext` struct and modify pipeline**
+
+Add to `src/pipeline.rs`:
+
+```rust
+/// Options that control conflict resolution during install.
+#[derive(Debug, Clone, Default)]
+pub struct AddOptions {
+    /// When true, replace items from different sources without error.
+    pub force: bool,
+    /// Alias mappings: `source_name -> alias`. Items matching a key are
+    /// installed under the alias instead.
+    pub aliases: Vec<(String, String)>,
+    /// Item names to skip during install.
+    pub excludes: Vec<String>,
+}
+```
+
+Change `install_with_lockfile` signature to accept `AddOptions`:
+
+```rust
+pub fn install_with_lockfile(
+    source: &InstallSource,
+    target: &Path,
+    items: &[String],
+    plugin_scope: crate::plugin::PluginScope,
+    options: &AddOptions,
+) -> Result<InstallReport> {
+```
+
+After resolving items but before writing, add conflict check:
+
+```rust
+    // -- Conflict detection --
+    let lock = crate::lockfile::Lockfile::load(target)?;
+    let label = source.to_string();
+    let incoming: Vec<(ItemKind, String)> = report
+        .items
+        .iter()
+        .map(|i| (i.kind, i.name.clone()))
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    // Filter out excluded items
+    let incoming: Vec<(ItemKind, String)> = incoming
+        .into_iter()
+        .filter(|(_, name)| !options.excludes.contains(name))
+        .collect();
+
+    let conflicts = crate::conflict::detect_conflicts(&incoming, &lock, &label);
+    if !conflicts.is_empty() && !options.force {
+        anyhow::bail!("{}", crate::conflict::format_conflict_error(&conflicts));
+    }
+```
+
+- [ ] **Step 4: Update `main.rs` to pass `AddOptions`**
+
+```rust
+fn run_add(source: &str, items: &[String], global: bool, project: bool, force: bool, aliases: &[String], excludes: &[String]) -> i32 {
+    let parsed = match parse_install_source(source) {
+        Ok(s) => s,
+        Err(err) => {
+            print_error(&err);
+            return EXIT_USAGE;
+        }
+    };
+
+    let target = match install_target(global, project) {
+        Ok(t) => t,
+        Err(err) => {
+            print_error(&err);
+            return EXIT_ERROR;
+        }
+    };
+
+    let plugin_scope = scope_to_plugin_scope(global, project);
+
+    let options = upskill::pipeline::AddOptions {
+        force,
+        aliases: parse_alias_args(aliases),
+        excludes: excludes.to_vec(),
+    };
+
+    print_install_progress(&parsed);
+    match install_with_lockfile(&parsed, &target, items, plugin_scope, &options) {
+        Ok(report) => {
+            print_install_report(&report, source);
+            print_plugin_results(&report);
+            EXIT_SUCCESS
+        }
+        Err(err) => {
+            print_error_chain(&err);
+            EXIT_ERROR
+        }
+    }
+}
+
+/// Parse `--as` arguments. Direct: `"alt-name"`. Bundle: `"original=alias"`.
+fn parse_alias_args(args: &[String]) -> Vec<(String, String)> {
+    args.iter()
+        .map(|a| {
+            if let Some((from, to)) = a.split_once('=') {
+                (from.to_string(), to.to_string())
+            } else {
+                // Direct add: alias applies to the single item being added
+                // The source name will be filled in by the pipeline
+                (String::new(), a.to_string())
+            }
+        })
+        .collect()
+}
+```
+
+- [ ] **Step 5: Run integration tests**
+
+Run: `cargo test --test cli_conflict`
+Expected: All 3 tests pass
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cargo test`
+Expected: All pass (existing tests need `AddOptions::default()` added to calls)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pipeline.rs src/main.rs src/cli.rs tests/cli_conflict.rs
+git commit -m "feat(pipeline): wire conflict detection into install_with_lockfile"
+```
+
+---
+
+### Task 5: Implement `--as` alias installation
+
+**Files:**
+- Modify: `src/pipeline.rs`
+- Modify: `src/lockfile.rs`
+
+- [ ] **Step 1: Write integration test**
+
+Add to `tests/cli_conflict.rs`:
+
+```rust
+#[test]
+fn add_with_alias_installs_under_alternate_name() {
+    let tmp = TempDir::new().unwrap();
+    setup_with_existing_item(&tmp);
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source", "--as", "test-skill-v2"])
+        .assert()
+        .success();
+
+    // Verify lockfile has the alias
+    let lock_content = fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap();
+    assert!(lock_content.contains("test-skill-v2"), "expected alias in lockfile: {lock_content}");
+    assert!(lock_content.contains("\"source_name\":\"test-skill\"") || lock_content.contains("\"source_name\": \"test-skill\""),
+        "expected source_name in lockfile: {lock_content}");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test cli_conflict add_with_alias`
+Expected: FAIL
+
+- [ ] **Step 3: Implement alias renaming in pipeline**
+
+In `install_with_lockfile`, after conflict detection and before lockfile write, rename items that match aliases:
+
+```rust
+    // -- Apply aliases --
+    // For direct --as (empty key): rename all items from this source
+    // For bundle --as (key=value): rename specific items
+    for item in &mut report.items {
+        let alias = options.aliases.iter().find(|(from, _)| {
+            from.is_empty() || *from == item.name
+        });
+        if let Some((original_name, alias_name)) = alias {
+            // Rename the item in the report
+            let source_name = item.name.clone();
+            item.name = alias_name.clone();
+            // Also rename the output path
+            // (regeneration with new name handled below)
+        }
+    }
+```
+
+And in the lockfile write section, set `source_name` when aliased:
+
+```rust
+    let new_items = crate::lockfile::items_from_report(&report, &label, git_ref, |k, n| {
+        hashes.get(&(k, n.to_string())).cloned().flatten()
+    });
+
+    // Set source_name for aliased items
+    let new_items: Vec<_> = new_items.into_iter().map(|mut item| {
+        if let Some((from, _)) = options.aliases.iter().find(|(_, to)| *to == item.name) {
+            let original = if from.is_empty() {
+                // Direct alias: the original name was whatever the source had
+                // We need to track it from the report
+                item.name.clone() // will be overridden below
+            } else {
+                from.clone()
+            };
+            item.source_name = Some(original);
+        }
+        item
+    }).collect();
+```
+
+Note: The full implementation will need to regenerate client outputs with the alias name. This requires passing the alias through to `install_from_source` or renaming output files post-generation.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test cli_conflict`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline.rs src/lockfile.rs tests/cli_conflict.rs
+git commit -m "feat(pipeline): implement --as alias installation with source_name tracking"
+```
+
+---
+
+### Task 6: Implement `--exclude` for bundle installs
+
+**Files:**
+- Modify: `src/pipeline.rs`
+
+- [ ] **Step 1: Write integration test**
+
+Add to `tests/cli_conflict.rs`:
+
+```rust
+#[test]
+fn add_with_exclude_skips_named_item() {
+    let tmp = TempDir::new().unwrap();
+
+    // Create source with two skills
+    let skill_a = tmp.path().join("source/skill-a");
+    let skill_b = tmp.path().join("source/skill-b");
+    fs::create_dir_all(&skill_a).unwrap();
+    fs::create_dir_all(&skill_b).unwrap();
+    fs::write(skill_a.join("SKILL.md"), "---\nname: skill-a\ndescription: Skill A\n---\nA\n").unwrap();
+    fs::write(skill_b.join("SKILL.md"), "---\nname: skill-b\ndescription: Skill B\n---\nB\n").unwrap();
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source", "--exclude", "skill-b"])
+        .assert()
+        .success();
+
+    let lock_content = fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap();
+    assert!(lock_content.contains("skill-a"), "expected skill-a: {lock_content}");
+    assert!(!lock_content.contains("skill-b"), "expected no skill-b: {lock_content}");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test cli_conflict add_with_exclude`
+Expected: FAIL (skill-b is installed)
+
+- [ ] **Step 3: Implement exclude filtering**
+
+In `install_with_lockfile`, after the install but before lockfile write, filter out excluded items:
+
+```rust
+    // -- Apply excludes --
+    if !options.excludes.is_empty() {
+        report.items.retain(|item| !options.excludes.contains(&item.name));
+        // Also remove generated output files for excluded items
+        for exclude in &options.excludes {
+            remove_generated_outputs(target, exclude);
+        }
+    }
+```
+
+The `remove_generated_outputs` helper deletes per-client files that were just written for excluded items. Alternatively, filter BEFORE generation by passing excludes into `install_from_source`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test cli_conflict`
+Expected: All pass
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipeline.rs tests/cli_conflict.rs
+git commit -m "feat(pipeline): implement --exclude flag to skip items during install"
+```
+
+---
+
+### Task 7: Update `upskill update` to use `source_name`
+
+**Files:**
+- Modify: `src/pipeline.rs` (the `update` function)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/cli_conflict.rs`:
+
+```rust
+#[test]
+fn update_uses_source_name_for_aliased_items() {
+    let tmp = TempDir::new().unwrap();
+
+    // Create source with a skill
+    let skill_dir = tmp.path().join("source/original-name");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "---\nname: original-name\ndescription: Original\n---\nUpdated content.\n").unwrap();
+
+    // Lockfile with an aliased item
+    let lockfile = serde_json::json!({
+        "schema": 1,
+        "items": [{
+            "kind": "skill",
+            "name": "my-alias",
+            "source": "local:source",
+            "source_name": "original-name",
+            "hash": "sha256:old"
+        }],
+        "bundles": []
+    });
+    fs::write(tmp.path().join(".upskill-lock.json"), serde_json::to_string_pretty(&lockfile).unwrap()).unwrap();
+
+    // Create generated output so update has something to compare
+    let claude_dir = tmp.path().join(".claude/skills/my-alias");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join("SKILL.md"), "old content").unwrap();
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["update"])
+        .assert()
+        .success();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test cli_conflict update_uses_source_name`
+Expected: FAIL — update looks for `my-alias` in source, doesn't find it
+
+- [ ] **Step 3: Modify `update` to use `source_name`**
+
+In the `update` function in `src/pipeline.rs`, when fetching SSOT for a locked item, use `source_name` if present:
+
+```rust
+    let ssot_name = item.source_name.as_deref().unwrap_or(&item.name);
+    // Use ssot_name to locate the item directory in the fetched source
+```
+
+And when regenerating, use `item.name` (the alias) as the output name.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test cli_conflict`
+Expected: All pass
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipeline.rs tests/cli_conflict.rs
+git commit -m "feat(update): use source_name to fetch aliased items correctly"
+```
+
+---
+
+### Task 8: Final verification and lint
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `just test`
+Expected: All pass
+
+- [ ] **Step 2: Run lints**
+
+Run: `just lint`
+Expected: No warnings
+
+- [ ] **Step 3: Format**
+
+Run: `just fmt`
+
+- [ ] **Step 4: Run full verify**
+
+Run: `just verify`
+Expected: Clean
+
+- [ ] **Step 5: Final commit (if fmt changed anything)**
+
+```bash
+git add -A
+git commit -m "chore: format"
+```

--- a/docs/superpowers/plans/2026-05-24-multi-registry-search.md
+++ b/docs/superpowers/plans/2026-05-24-multi-registry-search.md
@@ -1,0 +1,1430 @@
+# Multi-Registry Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `upskill search` to query configured git-based registries via
+a local index with HEAD-based cache invalidation.
+
+**Architecture:** New `config.rs` module loads `~/.config/upskill/config.yaml`
+(+ project `.upskill/config.yaml`), new `index.rs` module handles
+clone→scan→index and freshness checks, `search.rs` is extended to aggregate
+results from skills.sh + local indexes, CLI gains `index` subcommand and
+`--registry`/`--kind` flags on `search`.
+
+**Tech Stack:** Rust, serde\_yaml\_ng (config), serde\_json (index), git CLI
+(ls-remote/clone), existing frontmatter parser.
+
+---
+
+## Task 1: Config Module — Model and Parsing
+
+**Files:**
+
+- Create: `src/config.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Write the failing test for config parsing**
+
+```rust
+// src/config.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_config_with_registries() {
+        let yaml = r#"
+registries:
+  - name: corp
+    source: gitlab:mycompany/ai-skills
+  - name: anthropic
+    source: anthropics/skills
+"#;
+        let config = parse_config(yaml).unwrap();
+        assert_eq!(config.registries.len(), 2);
+        assert_eq!(config.registries[0].name, "corp");
+        assert_eq!(config.registries[0].source, "gitlab:mycompany/ai-skills");
+        assert_eq!(config.registries[1].name, "anthropic");
+        assert_eq!(config.registries[1].source, "anthropics/skills");
+    }
+
+    #[test]
+    fn parse_empty_config() {
+        let yaml = "";
+        let config = parse_config(yaml).unwrap();
+        assert!(config.registries.is_empty());
+    }
+
+    #[test]
+    fn parse_config_no_registries_key() {
+        let yaml = "other_key: value\n";
+        let config = parse_config(yaml).unwrap();
+        assert!(config.registries.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test config::tests --lib`
+Expected: FAIL — module doesn't exist
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+// src/config.rs
+//! User configuration: `~/.config/upskill/config.yaml` (global) and
+//! `.upskill/config.yaml` (project). Layers are merged with project
+//! taking precedence over global.
+
+use serde::Deserialize;
+
+/// Top-level config structure. Extensible for future settings.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub registries: Vec<RegistryEntry>,
+}
+
+/// A configured registry source.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistryEntry {
+    pub name: String,
+    pub source: String,
+}
+
+/// Parse a config YAML string into a `Config`. Empty or missing keys
+/// produce defaults (empty registries list).
+pub fn parse_config(yaml: &str) -> anyhow::Result<Config> {
+    if yaml.trim().is_empty() {
+        return Ok(Config::default());
+    }
+    let config: Config = serde_yaml_ng::from_str(yaml)?;
+    Ok(config)
+}
+```
+
+- [ ] **Step 4: Register module in lib.rs**
+
+Add to `src/lib.rs`:
+
+```rust
+pub mod config;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test config::tests --lib`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.rs src/lib.rs
+git commit -m "feat(config): add config model and YAML parsing"
+```
+
+---
+
+## Task 2: Config Module — Load and Merge Layers
+
+**Files:**
+
+- Modify: `src/config.rs`
+
+- [ ] **Step 1: Write the failing test for layer merging**
+
+```rust
+#[test]
+fn merge_layers_project_overrides_global() {
+    let global = Config {
+        registries: vec![
+            RegistryEntry { name: "corp".into(), source: "owner/repo-old".into() },
+            RegistryEntry { name: "public".into(), source: "other/repo".into() },
+        ],
+    };
+    let project = Config {
+        registries: vec![
+            RegistryEntry { name: "corp".into(), source: "owner/repo-new".into() },
+        ],
+    };
+    let merged = merge_configs(global, project);
+    assert_eq!(merged.registries.len(), 2);
+    // corp from project overrides global
+    let corp = merged.registries.iter().find(|r| r.name == "corp").unwrap();
+    assert_eq!(corp.source, "owner/repo-new");
+    // public from global is preserved
+    assert!(merged.registries.iter().any(|r| r.name == "public"));
+}
+
+#[test]
+fn load_config_returns_default_when_no_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = load_config(Some(tmp.path()), Some(tmp.path())).unwrap();
+    assert!(config.registries.is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test config::tests --lib`
+Expected: FAIL — `merge_configs` and `load_config` not defined
+
+- [ ] **Step 3: Write implementation**
+
+```rust
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Merge two config layers. Project entries override global entries
+/// with the same `name`. Global entries not shadowed are preserved.
+pub fn merge_configs(global: Config, project: Config) -> Config {
+    let mut registries = project.registries.clone();
+    for entry in global.registries {
+        if !registries.iter().any(|r| r.name == entry.name) {
+            registries.push(entry);
+        }
+    }
+    Config { registries }
+}
+
+/// Load config from the standard locations. Either path can be `None`
+/// to skip that layer (useful in tests or when HOME is unavailable).
+///
+/// - Global: `<global_root>/.config/upskill/config.yaml`
+///   (typically `$HOME/.config/upskill/config.yaml`)
+/// - Project: `<project_root>/.upskill/config.yaml`
+pub fn load_config(global_root: Option<&Path>, project_root: Option<&Path>) -> Result<Config> {
+    let global = match global_root {
+        Some(root) => load_layer(&root.join(".config/upskill/config.yaml"))?,
+        None => Config::default(),
+    };
+    let project = match project_root {
+        Some(root) => load_layer(&root.join(".upskill/config.yaml"))?,
+        None => Config::default(),
+    };
+    Ok(merge_configs(global, project))
+}
+
+fn load_layer(path: &Path) -> Result<Config> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => parse_config(&content)
+            .with_context(|| format!("failed to parse config at {}", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Config::default()),
+        Err(err) => Err(err).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test config::tests --lib`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.rs
+git commit -m "feat(config): load and merge global + project layers"
+```
+
+---
+
+## Task 3: Index Module — Model and Read/Write
+
+**Files:**
+
+- Create: `src/index.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// src/index.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_index() {
+        let index = RegistryIndex {
+            schema: 1,
+            registry: "corp".into(),
+            source: "gitlab:mycompany/ai-skills".into(),
+            head: Some("abc123".into()),
+            indexed_at: "2026-05-24T10:00:00Z".into(),
+            items: vec![IndexedItem {
+                name: "code-review".into(),
+                kind: "skill".into(),
+                description: "Structured code review".into(),
+                path: "skills/code-review".into(),
+            }],
+        };
+        let json = serde_json::to_string_pretty(&index).unwrap();
+        let parsed: RegistryIndex = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.registry, "corp");
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.items[0].name, "code-review");
+    }
+
+    #[test]
+    fn index_cache_path() {
+        let path = cache_path("corp");
+        assert!(path.ends_with("corp.json"));
+        assert!(path.to_str().unwrap().contains("upskill"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test index::tests --lib`
+Expected: FAIL — module doesn't exist
+
+- [ ] **Step 3: Write implementation**
+
+```rust
+// src/index.rs
+//! Local registry index: clone → scan → persist as JSON.
+//! Freshness via `git ls-remote` HEAD comparison.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// On-disk index schema for a single registry.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegistryIndex {
+    pub schema: u32,
+    pub registry: String,
+    pub source: String,
+    pub head: Option<String>,
+    pub indexed_at: String,
+    pub items: Vec<IndexedItem>,
+}
+
+/// A single item in the index.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndexedItem {
+    pub name: String,
+    pub kind: String,
+    pub description: String,
+    pub path: String,
+}
+
+/// Path to the index cache file for a registry.
+pub fn cache_path(registry_name: &str) -> PathBuf {
+    let cache_dir = dirs_cache_dir().join("upskill").join("index");
+    cache_dir.join(format!("{}.json", registry_name))
+}
+
+/// Read a cached index from disk. Returns `None` if not found.
+pub fn read_index(registry_name: &str) -> Result<Option<RegistryIndex>> {
+    let path = cache_path(registry_name);
+    match std::fs::read_to_string(&path) {
+        Ok(content) => {
+            let index: RegistryIndex = serde_json::from_str(&content)
+                .with_context(|| format!("failed to parse index at {}", path.display()))?;
+            Ok(Some(index))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+/// Write an index to disk, creating parent directories as needed.
+pub fn write_index(index: &RegistryIndex) -> Result<()> {
+    let path = cache_path(&index.registry);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create cache dir {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(index)
+        .context("failed to serialize index")?;
+    std::fs::write(&path, json)
+        .with_context(|| format!("failed to write index to {}", path.display()))?;
+    Ok(())
+}
+
+/// Platform cache directory. Uses `$XDG_CACHE_HOME` on Linux,
+/// `~/Library/Caches` on macOS, falls back to `~/.cache`.
+fn dirs_cache_dir() -> PathBuf {
+    std::env::var("XDG_CACHE_HOME")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            crate::source::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".cache")
+        })
+}
+```
+
+- [ ] **Step 4: Register module in lib.rs**
+
+Add to `src/lib.rs`:
+
+```rust
+pub mod index;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test index::tests --lib`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/index.rs src/lib.rs
+git commit -m "feat(index): registry index model and cache read/write"
+```
+
+---
+
+## Task 4: Index Module — HEAD Check and Freshness
+
+**Files:**
+
+- Modify: `src/index.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn ls_remote_head_parses_output() {
+    // Simulates git ls-remote output format
+    let output = "abc123def456789\tHEAD\n";
+    let sha = parse_ls_remote_output(output).unwrap();
+    assert_eq!(sha, "abc123def456789");
+}
+
+#[test]
+fn ls_remote_head_empty_output() {
+    let result = parse_ls_remote_output("");
+    assert!(result.is_none());
+}
+
+#[test]
+fn is_stale_when_head_differs() {
+    let index = RegistryIndex {
+        schema: 1,
+        registry: "test".into(),
+        source: "owner/repo".into(),
+        head: Some("old_sha".into()),
+        indexed_at: "2026-01-01T00:00:00Z".into(),
+        items: vec![],
+    };
+    assert!(is_stale(&index, "new_sha"));
+    assert!(!is_stale(&index, "old_sha"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test index::tests --lib`
+Expected: FAIL — functions not defined
+
+- [ ] **Step 3: Write implementation**
+
+```rust
+use std::process::Command;
+
+/// Run `git ls-remote <url> HEAD` and return the SHA if successful.
+pub fn fetch_remote_head(url: &str) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .args(["ls-remote", url, "HEAD"])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .output()
+        .with_context(|| format!("failed to run git ls-remote {url}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git ls-remote failed: {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_ls_remote_output(&stdout))
+}
+
+/// Parse the SHA from `git ls-remote` output (format: `<sha>\tHEAD\n`).
+fn parse_ls_remote_output(output: &str) -> Option<String> {
+    output
+        .lines()
+        .next()
+        .and_then(|line| line.split('\t').next())
+        .map(|sha| sha.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Check if a cached index is stale relative to the current remote HEAD.
+pub fn is_stale(index: &RegistryIndex, current_head: &str) -> bool {
+    match &index.head {
+        Some(cached_head) => cached_head != current_head,
+        None => true, // No HEAD recorded (local-path index) — always re-scan
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test index::tests --lib`
+Expected: PASS (5 tests total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.rs
+git commit -m "feat(index): HEAD-based freshness check via git ls-remote"
+```
+
+---
+
+## Task 5: Index Module — Scan Registry and Build Index
+
+**Files:**
+
+- Modify: `src/index.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn scan_registry_finds_items() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // Create a skill item
+    let skill_dir = root.join("skills").join("code-review");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: code-review\ndescription: Review code\n---\n\nFirst paragraph of body.\n\nSecond paragraph.\n",
+    ).unwrap();
+
+    // Create a rule item
+    let rule_dir = root.join("skills").join("no-console");
+    std::fs::create_dir_all(&rule_dir).unwrap();
+    std::fs::write(
+        rule_dir.join("RULE.md"),
+        "---\nschema: 1\nname: no-console\ndescription: No console.log\n---\n\nDo not use console.\n",
+    ).unwrap();
+
+    let items = scan_registry(root).unwrap();
+    assert_eq!(items.len(), 2);
+
+    let skill = items.iter().find(|i| i.name == "code-review").unwrap();
+    assert_eq!(skill.kind, "skill");
+    assert_eq!(skill.description, "First paragraph of body.");
+    assert_eq!(skill.path, "skills/code-review");
+
+    let rule = items.iter().find(|i| i.name == "no-console").unwrap();
+    assert_eq!(rule.kind, "rule");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test index::tests::scan_registry_finds_items --lib`
+Expected: FAIL — `scan_registry` not defined
+
+- [ ] **Step 3: Write implementation**
+
+```rust
+use std::fs;
+
+/// Scan a registry root directory and collect all items with metadata.
+pub fn scan_registry(root: &Path) -> Result<Vec<IndexedItem>> {
+    let mut items = Vec::new();
+    scan_dir(root, root, &mut items)?;
+    Ok(items)
+}
+
+fn scan_dir(root: &Path, dir: &Path, items: &mut Vec<IndexedItem>) -> Result<()> {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return Ok(()),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        // Check if this directory is an item (contains SKILL.md, RULE.md, or AGENT.md)
+        if let Some(item) = try_parse_item(root, &path)? {
+            items.push(item);
+        } else {
+            // Recurse one level deeper (handles `skills/<item>/` layout)
+            scan_dir(root, &path, items)?;
+        }
+    }
+    Ok(())
+}
+
+/// Entry-point filenames and their corresponding kind.
+const ENTRYPOINTS: &[(&str, &str)] = &[
+    ("SKILL.md", "skill"),
+    ("RULE.md", "rule"),
+    ("AGENT.md", "agent"),
+];
+
+fn try_parse_item(root: &Path, dir: &Path) -> Result<Option<IndexedItem>> {
+    for &(filename, kind) in ENTRYPOINTS {
+        let entry_path = dir.join(filename);
+        if entry_path.is_file() {
+            let content = fs::read_to_string(&entry_path)
+                .with_context(|| format!("failed to read {}", entry_path.display()))?;
+            let name = dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            let description = extract_description(&content);
+            let rel_path = dir
+                .strip_prefix(root)
+                .unwrap_or(dir)
+                .to_str()
+                .unwrap_or("")
+                .replace('\\', "/");
+            return Ok(Some(IndexedItem {
+                name,
+                kind: kind.to_string(),
+                description,
+                path: rel_path,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+/// Extract the first non-empty paragraph from the body (after frontmatter).
+fn extract_description(content: &str) -> String {
+    let body = match crate::parse::frontmatter::split(content) {
+        Some((_, body)) => body,
+        None => content,
+    };
+    body.trim()
+        .split("\n\n")
+        .next()
+        .unwrap_or("")
+        .lines()
+        .map(|l| l.trim())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim()
+        .to_string()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test index::tests --lib`
+Expected: PASS (6 tests total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.rs
+git commit -m "feat(index): scan registry tree and extract item metadata"
+```
+
+---
+
+## Task 6: Index Module — Build Index for a Registry Entry
+
+**Files:**
+
+- Modify: `src/index.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn build_index_for_local_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // Create a skill
+    let skill_dir = root.join("skills").join("my-skill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: my-skill\ndescription: test\n---\n\nA skill.\n",
+    ).unwrap();
+
+    let entry = crate::config::RegistryEntry {
+        name: "local".into(),
+        source: root.to_str().unwrap().to_string(),
+    };
+    let index = build_index(&entry).unwrap();
+    assert_eq!(index.registry, "local");
+    assert_eq!(index.items.len(), 1);
+    assert_eq!(index.items[0].name, "my-skill");
+    assert!(index.head.is_none()); // local path, no HEAD
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test index::tests::build_index_for_local_path --lib`
+Expected: FAIL — `build_index` not defined
+
+- [ ] **Step 3: Write implementation**
+
+```rust
+use crate::config::RegistryEntry;
+use crate::source::parse_install_source;
+
+/// Build (or rebuild) the index for a registry entry. For git sources,
+/// clones into a temp dir, scans, and returns the index. For local paths,
+/// scans in place.
+pub fn build_index(entry: &RegistryEntry) -> Result<RegistryIndex> {
+    let source = &entry.source;
+    let now = chrono_now();
+
+    // Check if source is a local path
+    if is_local_source(source) {
+        let path = resolve_local_path(source)?;
+        let items = scan_registry(&path)?;
+        return Ok(RegistryIndex {
+            schema: 1,
+            registry: entry.name.clone(),
+            source: entry.source.clone(),
+            head: None,
+            indexed_at: now,
+            items,
+        });
+    }
+
+    // Git source: resolve URL, clone, scan, cleanup
+    let parsed = parse_install_source(source)
+        .with_context(|| format!("invalid registry source: {source}"))?;
+    let url = source_to_clone_url(&parsed)?;
+    let head = fetch_remote_head(&url)?.unwrap_or_default();
+
+    let tmp = tempfile::tempdir().context("failed to create temp dir for index clone")?;
+    crate::fetch::shallow_clone(&url, None, &entry.name, tmp.path(), None)
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    let clone_dir = tmp.path().join(&entry.name);
+    let items = scan_registry(&clone_dir)?;
+
+    Ok(RegistryIndex {
+        schema: 1,
+        registry: entry.name.clone(),
+        source: entry.source.clone(),
+        head: Some(head),
+        indexed_at: now,
+        items,
+    })
+}
+
+fn is_local_source(source: &str) -> bool {
+    source.starts_with('/')
+        || source.starts_with("./")
+        || source.starts_with("../")
+        || source.starts_with("~/")
+}
+
+fn resolve_local_path(source: &str) -> Result<PathBuf> {
+    if source.starts_with("~/") {
+        let home = crate::source::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("HOME not set"))?;
+        Ok(home.join(&source[2..]))
+    } else {
+        Ok(PathBuf::from(source))
+    }
+}
+
+fn source_to_clone_url(source: &crate::source::InstallSource) -> Result<String> {
+    use crate::source::InstallSource;
+    match source {
+        InstallSource::Github(repo) => {
+            Ok(format!("https://github.com/{}/{}.git", repo.owner, repo.name))
+        }
+        InstallSource::Gitlab(repo) => {
+            Ok(format!("https://gitlab.com/{}/{}.git", repo.owner, repo.name))
+        }
+        InstallSource::LocalPath(_) => {
+            anyhow::bail!("local path should not reach source_to_clone_url")
+        }
+    }
+}
+
+/// ISO 8601 timestamp without pulling in `chrono`.
+fn chrono_now() -> String {
+    use std::time::SystemTime;
+    let duration = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    // Simple Unix timestamp — good enough for a cache marker.
+    format!("{}", duration.as_secs())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test index::tests --lib`
+Expected: PASS (7 tests total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.rs
+git commit -m "feat(index): build_index for local and git sources"
+```
+
+---
+
+## Task 7: Index Module — Ensure Fresh Index (Cache-Aware)
+
+**Files:**
+
+- Modify: `src/index.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn ensure_fresh_uses_cache_when_head_matches() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Pre-populate a cache file
+    let index = RegistryIndex {
+        schema: 1,
+        registry: "cached-test".into(),
+        source: "/fake/path".into(),
+        head: Some("sha123".into()),
+        indexed_at: "0".into(),
+        items: vec![IndexedItem {
+            name: "cached-item".into(),
+            kind: "skill".into(),
+            description: "from cache".into(),
+            path: "skills/cached-item".into(),
+        }],
+    };
+    // Write to a custom path for test isolation
+    let cache_file = tmp.path().join("cached-test.json");
+    let json = serde_json::to_string_pretty(&index).unwrap();
+    std::fs::write(&cache_file, json).unwrap();
+
+    let loaded: RegistryIndex =
+        serde_json::from_str(&std::fs::read_to_string(&cache_file).unwrap()).unwrap();
+    assert_eq!(loaded.items[0].name, "cached-item");
+    assert!(!is_stale(&loaded, "sha123"));
+    assert!(is_stale(&loaded, "different_sha"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes** (this test validates existing primitives)
+
+Run: `cargo test index::tests::ensure_fresh_uses_cache --lib`
+Expected: PASS
+
+- [ ] **Step 3: Write the orchestrator function**
+
+```rust
+/// Ensure we have a fresh index for a registry entry. Returns the index
+/// (from cache if fresh, rebuilt if stale or missing).
+///
+/// On network failure with an existing cache, returns stale cache with
+/// a warning printed to stderr.
+pub fn ensure_fresh(entry: &RegistryEntry) -> Result<RegistryIndex> {
+    // Local paths: always re-scan (fast)
+    if is_local_source(&entry.source) {
+        let index = build_index(entry)?;
+        write_index(&index)?;
+        return Ok(index);
+    }
+
+    // Git source: check HEAD
+    let parsed = parse_install_source(&entry.source)
+        .with_context(|| format!("invalid registry source: {}", entry.source))?;
+    let url = source_to_clone_url(&parsed)?;
+
+    let remote_head = match fetch_remote_head(&url) {
+        Ok(Some(head)) => head,
+        Ok(None) => {
+            // Empty repo or no HEAD — rebuild
+            let index = build_index(entry)?;
+            write_index(&index)?;
+            return Ok(index);
+        }
+        Err(_) => {
+            // Network failure — try stale cache
+            if let Ok(Some(cached)) = read_index(&entry.name) {
+                eprintln!(
+                    "warning: using cached index for '{}' (offline)",
+                    entry.name
+                );
+                return Ok(cached);
+            }
+            anyhow::bail!(
+                "cannot reach registry '{}' and no cached index exists",
+                entry.name
+            );
+        }
+    };
+
+    // Check cache freshness
+    if let Ok(Some(cached)) = read_index(&entry.name) {
+        if !is_stale(&cached, &remote_head) {
+            return Ok(cached);
+        }
+    }
+
+    // Stale or missing — rebuild
+    let index = build_index(entry)?;
+    write_index(&index)?;
+    Ok(index)
+}
+```
+
+- [ ] **Step 4: Run all index tests**
+
+Run: `cargo test index::tests --lib`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.rs
+git commit -m "feat(index): ensure_fresh with HEAD-based cache invalidation"
+```
+
+---
+
+## Task 8: Extend Search — Query Local Indexes
+
+**Files:**
+
+- Modify: `src/search.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// Add to src/search.rs tests
+#[test]
+fn search_index_matches_name_and_description() {
+    use crate::index::{IndexedItem, RegistryIndex};
+
+    let index = RegistryIndex {
+        schema: 1,
+        registry: "test".into(),
+        source: "owner/repo".into(),
+        head: Some("sha".into()),
+        indexed_at: "0".into(),
+        items: vec![
+            IndexedItem {
+                name: "code-review".into(),
+                kind: "skill".into(),
+                description: "Structured code review workflow".into(),
+                path: "skills/code-review".into(),
+            },
+            IndexedItem {
+                name: "no-console".into(),
+                kind: "rule".into(),
+                description: "Ban console.log".into(),
+                path: "skills/no-console".into(),
+            },
+        ],
+    };
+
+    let results = search_index(&index, "code", None);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "code-review");
+
+    // Also matches description
+    let results = search_index(&index, "workflow", None);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "code-review");
+
+    // Kind filter
+    let results = search_index(&index, "co", Some("rule"));
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "no-console");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test search::tests::search_index_matches --lib`
+Expected: FAIL — `search_index` not defined
+
+- [ ] **Step 3: Write implementation**
+
+```rust
+use crate::index::{IndexedItem, RegistryIndex};
+
+/// Result from a local index search.
+pub struct IndexSearchResult {
+    pub name: String,
+    pub kind: String,
+    pub description: String,
+    pub path: String,
+    pub registry: String,
+    pub source: String,
+}
+
+/// Search a local index by substring match on name and description.
+/// Optionally filter by kind.
+pub fn search_index(
+    index: &RegistryIndex,
+    query: &str,
+    kind_filter: Option<&str>,
+) -> Vec<IndexSearchResult> {
+    let query_lower = query.to_lowercase();
+    index
+        .items
+        .iter()
+        .filter(|item| {
+            if let Some(kind) = kind_filter {
+                if item.kind != kind {
+                    return false;
+                }
+            }
+            item.name.to_lowercase().contains(&query_lower)
+                || item.description.to_lowercase().contains(&query_lower)
+        })
+        .map(|item| IndexSearchResult {
+            name: item.name.clone(),
+            kind: item.kind.clone(),
+            description: item.description.clone(),
+            path: item.path.clone(),
+            registry: index.registry.clone(),
+            source: index.source.clone(),
+        })
+        .collect()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test search::tests --lib`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/search.rs
+git commit -m "feat(search): search_index for local registry indexes"
+```
+
+---
+
+## Task 9: CLI — Add `--registry` and `--kind` Flags to Search
+
+**Files:**
+
+- Modify: `src/cli.rs`
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create or add to `tests/cli_search.rs`:
+
+```rust
+use assert_cmd::Command;
+
+#[test]
+fn search_accepts_registry_flag() {
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .args(["search", "test", "--registry", "nonexistent"])
+        .assert()
+        .failure(); // Registry not configured — should error gracefully
+}
+
+#[test]
+fn search_accepts_kind_flag() {
+    // --kind is a filter, should not error even if no registries configured
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .args(["search", "test", "--kind", "skill"])
+        .assert()
+        .success();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test cli_search search_accepts`
+Expected: FAIL — unknown flag
+
+- [ ] **Step 3: Add flags to cli.rs**
+
+```rust
+// In Commands::Search variant:
+Search {
+    /// Search query.
+    query: String,
+    /// Maximum number of results (skills.sh only).
+    #[arg(short = 'l', long, default_value = "10")]
+    limit: usize,
+    /// Search only a specific configured registry (skip skills.sh).
+    #[arg(short = 'r', long)]
+    registry: Option<String>,
+    /// Filter results by item kind (skill, rule, agent, bundle).
+    #[arg(short = 'k', long)]
+    kind: Option<String>,
+},
+```
+
+- [ ] **Step 4: Update main.rs dispatch**
+
+```rust
+// In the match arm:
+Commands::Search { query, limit, registry, kind } => {
+    run_search(&query, limit, registry.as_deref(), kind.as_deref())
+}
+```
+
+Update `run_search` signature and implementation:
+
+```rust
+fn run_search(query: &str, limit: usize, registry: Option<&str>, kind: Option<&str>) -> i32 {
+    let config = match upskill::config::load_config(
+        upskill::source::home_dir().as_deref(),
+        Some(Path::new(".")),
+    ) {
+        Ok(c) => c,
+        Err(err) => {
+            print_error(&err);
+            return EXIT_ERROR;
+        }
+    };
+
+    // If --registry is specified, only search that registry
+    if let Some(reg_name) = registry {
+        let entry = match config.registries.iter().find(|r| r.name == reg_name) {
+            Some(e) => e,
+            None => {
+                print_error(format!("registry '{}' not found in config", reg_name));
+                return EXIT_ERROR;
+            }
+        };
+        return run_search_registry(query, entry, kind);
+    }
+
+    // Search skills.sh (unless --kind filters to something skills.sh doesn't support)
+    if kind.is_none() || kind == Some("skill") {
+        match search::search(query, limit) {
+            Ok(results) if !results.is_empty() => {
+                if !style::is_quiet() {
+                    println!("{}", style::dim("── skills.sh ──"));
+                    for skill in &results {
+                        let repo = skill.source
+                            .trim_start_matches("github/")
+                            .trim_start_matches("gitlab/");
+                        println!(
+                            "  {}\t{}\t{}",
+                            style::name(&skill.name),
+                            style::dim(&format!("{} installs", skill.installs)),
+                            style::dim(&format!("upskill add {repo} {}", skill.name))
+                        );
+                    }
+                }
+            }
+            Ok(_) => {}
+            Err(err) => {
+                if !style::is_quiet() {
+                    eprintln!("{} skills.sh: {}", style::warn("warning:"), err);
+                }
+            }
+        }
+    }
+
+    // Search configured registries
+    for entry in &config.registries {
+        run_search_registry(query, entry, kind);
+    }
+
+    EXIT_SUCCESS
+}
+
+fn run_search_registry(query: &str, entry: &upskill::config::RegistryEntry, kind: Option<&str>) -> i32 {
+    let index = match upskill::index::ensure_fresh(entry) {
+        Ok(idx) => idx,
+        Err(err) => {
+            if !style::is_quiet() {
+                eprintln!("{} {}: {}", style::warn("warning:"), entry.name, err);
+            }
+            return EXIT_SUCCESS; // Non-fatal — skip this registry
+        }
+    };
+
+    let results = search::search_index(&index, query, kind);
+    if !results.is_empty() && !style::is_quiet() {
+        println!("\n{}", style::dim(&format!("── {} ──", entry.name)));
+        for item in &results {
+            let source_path = format!("{}:{}", entry.source, item.path);
+            println!(
+                "  {} {}\t{}",
+                style::name(&item.name),
+                style::dim(&format!("[{}]", item.kind)),
+                style::dim(&format!("upskill add {source_path}"))
+            );
+        }
+    }
+
+    EXIT_SUCCESS
+}
+```
+
+- [ ] **Step 5: Run integration tests**
+
+Run: `cargo test --test cli_search`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli.rs src/main.rs tests/cli_search.rs
+git commit -m "feat(search): add --registry and --kind flags, multi-registry output"
+```
+
+---
+
+## Task 10: CLI — Add `index` Subcommand
+
+**Files:**
+
+- Modify: `src/cli.rs`
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `tests/cli_search.rs` (or create `tests/cli_index.rs`):
+
+```rust
+#[test]
+fn index_clear_succeeds_with_no_cache() {
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .args(["index", "--clear"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn index_with_no_registries_configured() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["index"])
+        .assert()
+        .success();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test cli_search index_clear`
+Expected: FAIL — unknown subcommand
+
+- [ ] **Step 3: Add subcommand to cli.rs**
+
+```rust
+/// Build or manage the local registry index cache.
+///
+/// Without flags, rebuilds the index for all configured registries.
+/// Use `--clear` to remove all cached indexes.
+#[command(after_help = "EXAMPLES:\n  \
+        upskill index\n  \
+        upskill index --registry corp\n  \
+        upskill index --clear")]
+Index {
+    /// Rebuild only a specific registry.
+    #[arg(short = 'r', long)]
+    registry: Option<String>,
+    /// Remove all cached indexes.
+    #[arg(long, conflicts_with = "registry")]
+    clear: bool,
+},
+```
+
+- [ ] **Step 4: Add dispatch in main.rs**
+
+```rust
+// In the command match:
+Commands::Index { registry, clear } => run_index(registry.as_deref(), clear),
+
+// Implementation:
+fn run_index(registry: Option<&str>, clear: bool) -> i32 {
+    if clear {
+        let cache_dir = upskill::index::cache_dir();
+        if cache_dir.exists() {
+            if let Err(err) = std::fs::remove_dir_all(&cache_dir) {
+                print_error(&err);
+                return EXIT_ERROR;
+            }
+        }
+        if !style::is_quiet() {
+            println!("cleared index cache");
+        }
+        return EXIT_SUCCESS;
+    }
+
+    let config = match upskill::config::load_config(
+        upskill::source::home_dir().as_deref(),
+        Some(std::path::Path::new(".")),
+    ) {
+        Ok(c) => c,
+        Err(err) => {
+            print_error(&err);
+            return EXIT_ERROR;
+        }
+    };
+
+    let entries: Vec<_> = match registry {
+        Some(name) => match config.registries.iter().find(|r| r.name == name) {
+            Some(e) => vec![e],
+            None => {
+                print_error(format!("registry '{name}' not found in config"));
+                return EXIT_ERROR;
+            }
+        },
+        None => config.registries.iter().collect(),
+    };
+
+    if entries.is_empty() {
+        if !style::is_quiet() {
+            println!("no registries configured");
+        }
+        return EXIT_SUCCESS;
+    }
+
+    let mut errors = 0;
+    for entry in entries {
+        if !style::is_quiet() {
+            eprintln!("{} {}", style::dim("indexing"), style::name(&entry.name));
+        }
+        match upskill::index::build_index(entry) {
+            Ok(index) => {
+                if let Err(err) = upskill::index::write_index(&index) {
+                    print_error(&err);
+                    errors += 1;
+                } else if !style::is_quiet() {
+                    println!(
+                        "  {} ({} items)",
+                        style::name(&entry.name),
+                        index.items.len()
+                    );
+                }
+            }
+            Err(err) => {
+                print_error_chain(&err);
+                errors += 1;
+            }
+        }
+    }
+
+    if errors > 0 { EXIT_ERROR } else { EXIT_SUCCESS }
+}
+```
+
+- [ ] **Step 5: Expose `cache_dir` from index module**
+
+Add to `src/index.rs`:
+
+```rust
+/// The directory where index cache files are stored.
+pub fn cache_dir() -> PathBuf {
+    dirs_cache_dir().join("upskill").join("index")
+}
+```
+
+- [ ] **Step 6: Run integration tests**
+
+Run: `cargo test --test cli_search`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli.rs src/main.rs src/index.rs tests/
+git commit -m "feat(cli): add 'upskill index' subcommand"
+```
+
+---
+
+## Task 11: Update Docs and Spec
+
+**Files:**
+
+- Modify: `docs/commands.md`
+- Modify: `docs/specification.md`
+- Modify: `docs/getting-started.md`
+
+- [ ] **Step 1: Add `index` command to commands.md**
+
+Add a section documenting `upskill index [--registry <name>] [--clear]` with examples.
+
+- [ ] **Step 2: Add `--registry` and `--kind` flags to `search` section in commands.md**
+
+Update the existing search documentation.
+
+- [ ] **Step 3: Add config file documentation to getting-started.md**
+
+Document `~/.config/upskill/config.yaml` with the `registries:` key and an example.
+
+- [ ] **Step 4: Update specification.md**
+
+Add `config.yaml` to the environment/files table. Add `index` to the command table.
+
+- [ ] **Step 5: Run `just lint` to verify docs**
+
+Run: `just lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/
+git commit -m "docs: multi-registry search, index command, config file"
+```
+
+---
+
+## Task 12: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `just check`
+Expected: PASS (all tests, lint, format)
+
+- [ ] **Step 2: Run `just verify`**
+
+Run: `just verify`
+Expected: PASS
+
+- [ ] **Step 3: Manual smoke test**
+
+```bash
+# Create a config with a local registry
+mkdir -p ~/.config/upskill
+cat > ~/.config/upskill/config.yaml << 'EOF'
+registries:
+  - name: local-test
+    source: ~/path/to/your/skills-repo
+EOF
+
+# Search across all registries
+upskill search code-review
+
+# Search specific registry
+upskill search code-review --registry local-test
+
+# Force rebuild index
+upskill index
+
+# Clear cache
+upskill index --clear
+```
+
+- [ ] **Step 4: Final commit if any fixes needed**

--- a/docs/superpowers/plans/2026-05-24-upgrade-ux.md
+++ b/docs/superpowers/plans/2026-05-24-upgrade-ux.md
@@ -1,0 +1,679 @@
+# Upgrade UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `upskill update` auto-remove orphaned items, clean output before regenerating, and prompt before applying destructive changes.
+
+**Architecture:** Three changes to the update pipeline: (1) detect items in lockfile that no longer exist in the fetched source and remove them, (2) delete per-client output files before regenerating to prevent stale file accumulation, (3) show a summary and confirm interactively before applying.
+
+**Tech Stack:** Rust, clap 4, anyhow, serde_json, std::io::IsTerminal
+
+---
+
+### Task 1: Add `Removed` / `WouldRemove` variants to `UpdateStatus`
+
+**Files:**
+
+- Modify: `src/pipeline.rs:1049-1078`
+
+- [ ] **Step 1: Add variants to `UpdateStatus`**
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateStatus {
+    /// SSOT hash matches the lockfile — nothing to do.
+    UpToDate,
+    /// `Apply` mode: the lockfile hash changed (or was previously unset
+    /// and now resolved). Outputs were rewritten.
+    Updated {
+        old_hash: Option<String>,
+        new_hash: Option<String>,
+    },
+    /// `DryRun` mode: SSOT hash differs from the lockfile entry; an
+    /// `update` (without `--dry-run`) would rewrite outputs.
+    WouldChange {
+        old_hash: Option<String>,
+        new_hash: Option<String>,
+    },
+    /// `Apply` mode: item no longer exists in the source. Outputs deleted
+    /// and lockfile entry removed.
+    Removed,
+    /// `DryRun` mode: item no longer exists in the source; an `update`
+    /// (without `--dry-run`) would remove it.
+    WouldRemove,
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check`
+Expected: warnings about unmatched variants in `main.rs` pattern matches (non-exhaustive), but compilation succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "refactor: add Removed/WouldRemove variants to UpdateStatus"
+```
+
+---
+
+### Task 2: Add `--yes` flag to the `Update` CLI command
+
+**Files:**
+
+- Modify: `src/cli.rs:109-122`
+- Modify: `src/main.rs:64` (destructure the new field)
+
+- [ ] **Step 1: Add `yes` field to `Update` variant in `cli.rs`**
+
+In `src/cli.rs`, inside the `Update` struct, after the `project` field:
+
+```rust
+/// Skip the confirmation prompt. Already implicit when stdin is
+/// not a terminal (CI / pipes) or when `--dry-run` is used.
+#[arg(short = 'y', long = "yes")]
+yes: bool,
+```
+
+- [ ] **Step 2: Update the destructure in `main.rs`**
+
+In `src/main.rs`, change the `Update` match arm (around line 60-64) to destructure `yes`:
+
+```rust
+Commands::Update {
+    names,
+    dry_run,
+    global,
+    project,
+    yes,
+} => run_update(&names, dry_run, yes, global, project),
+```
+
+- [ ] **Step 3: Update `run_update` signature to accept `yes`**
+
+```rust
+fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project: bool) -> i32 {
+```
+
+(For now, `yes` is unused — we'll wire it in Task 5.)
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check`
+Expected: warning about unused `yes` parameter, no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.rs src/main.rs
+git commit -m "feat(cli): add --yes flag to update command"
+```
+
+---
+
+### Task 3: Implement orphan detection and removal in `update()`
+
+**Files:**
+
+- Modify: `src/pipeline.rs` — the `update()` function (line 1090–1194)
+- Test: `tests/cli_update.rs`
+
+- [ ] **Step 1: Write failing ATDD test — orphan removed on update**
+
+Append to `tests/cli_update.rs`:
+
+```rust
+#[test]
+fn update_removes_orphaned_item_when_source_no_longer_contains_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    // Verify the item exists before removal.
+    assert!(target.join(".claude/skills/create-api-endpoint/SKILL.md").exists());
+
+    // Remove an item from the source (simulating upstream rename/delete).
+    fs::remove_dir_all(source.join("create-api-endpoint")).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "--yes"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("removed"),
+        "expected 'removed' in output, got:\n{out}"
+    );
+
+    // Output files should be gone.
+    assert!(!target.join(".claude/skills/create-api-endpoint/SKILL.md").exists());
+    assert!(!target.join(".github/skills/create-api-endpoint/SKILL.md").exists());
+    assert!(!target.join(".agents/skills/create-api-endpoint/SKILL.md").exists());
+
+    // Lockfile should no longer contain the item.
+    assert!(lockfile_hash_for(&target, "create-api-endpoint").is_none());
+}
+
+#[test]
+fn update_dry_run_reports_would_remove_without_deleting() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    fs::remove_dir_all(source.join("create-api-endpoint")).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "--dry-run"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("would remove"),
+        "expected 'would remove' in dry-run output, got:\n{out}"
+    );
+
+    // Files must still exist.
+    assert!(target.join(".claude/skills/create-api-endpoint/SKILL.md").exists());
+    // Lockfile must still contain the item.
+    assert!(lockfile_hash_for(&target, "create-api-endpoint").is_some());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test cli_update update_removes_orphaned_item update_dry_run_reports_would_remove`
+Expected: FAIL (no `removed` / `would remove` in output)
+
+- [ ] **Step 3: Implement orphan detection in `update()`**
+
+In `src/pipeline.rs`, modify the `update()` function. After fetching the source and computing hashes, detect entries that are no longer in the source:
+
+Replace the inner loop body for both `Apply` and `DryRun` modes. The key change: after computing `new_hashes` (in DryRun) or `new_hashes` from the install report (in Apply), check if the entry's `(kind, name)` is absent from the discovered items.
+
+In the `DryRun` branch (starting at line 1166), replace the `for entry in &source_entries` loop:
+
+```rust
+UpdateMode::DryRun => {
+    let (root, _guard) = fetch_ssot(&source)?;
+    let new_hashes = hash_source_items(&root);
+    for entry in &source_entries {
+        let kind = parse_kind(&entry.kind)?;
+        let key = (kind, entry.name.clone());
+        if !new_hashes.contains_key(&key) {
+            // Item no longer in source — would be removed.
+            report.items.push(UpdatedItem {
+                kind,
+                name: entry.name.clone(),
+                source: source_label.clone(),
+                status: UpdateStatus::WouldRemove,
+            });
+            continue;
+        }
+        let new_hash = new_hashes.get(&key).cloned().flatten();
+        let status = if new_hash == entry.hash {
+            UpdateStatus::UpToDate
+        } else {
+            UpdateStatus::WouldChange {
+                old_hash: entry.hash.clone(),
+                new_hash,
+            }
+        };
+        report.items.push(UpdatedItem {
+            kind,
+            name: entry.name.clone(),
+            source: source_label.clone(),
+            status,
+        });
+    }
+}
+```
+
+In the `Apply` branch (starting at line 1137), replace the `for entry in &source_entries` loop:
+
+```rust
+UpdateMode::Apply => {
+    let install_report = install_with_lockfile(&source, target, &[], plugin_scope)?;
+    let mut new_hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> =
+        std::collections::BTreeMap::new();
+    for it in &install_report.items {
+        new_hashes.insert((it.kind, it.name.clone()), it.source_hash.clone());
+    }
+    for entry in &source_entries {
+        let kind = parse_kind(&entry.kind)?;
+        let key = (kind, entry.name.clone());
+        if !new_hashes.contains_key(&key) {
+            // Item no longer in source — remove it.
+            remove_item_outputs(target, kind, &entry.name);
+            let mut lock = crate::lockfile::Lockfile::load(target)?;
+            lock.remove(&entry.kind, &entry.name);
+            lock.save(target)?;
+            report.items.push(UpdatedItem {
+                kind,
+                name: entry.name.clone(),
+                source: source_label.clone(),
+                status: UpdateStatus::Removed,
+            });
+            continue;
+        }
+        let new_hash = new_hashes
+            .get(&key)
+            .cloned()
+            .flatten();
+        let status = if new_hash == entry.hash {
+            UpdateStatus::UpToDate
+        } else {
+            UpdateStatus::Updated {
+                old_hash: entry.hash.clone(),
+                new_hash,
+            }
+        };
+        report.items.push(UpdatedItem {
+            kind,
+            name: entry.name.clone(),
+            source: source_label.clone(),
+            status,
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Add `remove_item_outputs` helper**
+
+Add this helper function in `src/pipeline.rs` (near the existing `output_path` function):
+
+```rust
+/// Delete all per-client output files for an item. Best-effort: ignores
+/// errors (file may already be gone). Also removes empty parent dirs.
+fn remove_item_outputs(target: &Path, kind: ItemKind, name: &str) {
+    for client in ALL_CLIENTS {
+        let rel = output_path(kind, client, name);
+        let full = target.join(&rel);
+        if full.exists() {
+            let _ = fs::remove_file(&full);
+            if let Some(parent) = full.parent() {
+                let _ = fs::remove_dir(parent);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Update `print_update_report` in `main.rs` to handle new variants**
+
+In `src/main.rs`, in the `print_update_report` function, add arms for the new variants:
+
+```rust
+UpdateStatus::Removed => style::error("removed — no longer in source"),
+UpdateStatus::WouldRemove => style::warn("would remove — no longer in source"),
+```
+
+Also update the changes count filter to include removals:
+
+```rust
+let changes = report
+    .items
+    .iter()
+    .filter(|i| !matches!(i.status, UpdateStatus::UpToDate))
+    .count();
+```
+
+(This already works since `Removed`/`WouldRemove` don't match `UpToDate`.)
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test --test cli_update`
+Expected: all tests pass, including the two new ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pipeline.rs src/main.rs tests/cli_update.rs
+git commit -m "feat: auto-remove orphaned items during update"
+```
+
+---
+
+### Task 4: Clean output before regenerating (prevent stale files)
+
+**Files:**
+
+- Modify: `src/pipeline.rs` — the per-kind install loops (around lines 1534–1549, 1577–1592, 1620–1635)
+- Test: `tests/cli_update.rs`
+
+- [ ] **Step 1: Write failing test — stale output file removed on update**
+
+Append to `tests/cli_update.rs`:
+
+```rust
+#[test]
+fn update_removes_stale_output_file_from_previous_generation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    // Simulate a stale file that was previously generated but no longer
+    // should be (e.g., output from a previous version of the generator).
+    let stale_file = target.join(".claude/skills/create-api-endpoint/OLD_FILE.md");
+    fs::write(&stale_file, "stale content").unwrap();
+    assert!(stale_file.exists());
+
+    // Mutate the skill so update actually regenerates it.
+    mutate_skill(&source);
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "--yes"])
+        .assert()
+        .success();
+
+    // The stale file should be gone after regeneration.
+    assert!(
+        !stale_file.exists(),
+        "stale file should have been removed during clean-and-regenerate"
+    );
+    // But the real output should still exist.
+    assert!(target.join(".claude/skills/create-api-endpoint/SKILL.md").exists());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test cli_update update_removes_stale_output`
+Expected: FAIL (stale file still exists)
+
+- [ ] **Step 3: Add clean step before writing output**
+
+In `src/pipeline.rs`, in the skill install loop (around line 1534), before writing output for each item, clean the parent directory. The cleanest approach is to call `remove_item_outputs` before the per-client render loop for each item:
+
+Find the skill loop (starts around line 1523 with `let entry_path = dir.join("SKILL.md");`). Before the `for client in ALL_CLIENTS` loop at line 1534, insert:
+
+```rust
+// Clean previous output to prevent stale files from lingering
+// after upstream renames/removes files within the item.
+remove_item_outputs(target, ItemKind::Skill, &name);
+```
+
+Do the same for the rule loop (before the `for client in ALL_CLIENTS` around line 1577):
+
+```rust
+remove_item_outputs(target, ItemKind::Rule, &name);
+```
+
+And the agent loop (before the `for client in ALL_CLIENTS` around line 1620):
+
+```rust
+remove_item_outputs(target, ItemKind::Agent, &name);
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test cli_update`
+Expected: all tests pass including the new one.
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `cargo test`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipeline.rs tests/cli_update.rs
+git commit -m "feat: clean output before regenerating to prevent stale files"
+```
+
+---
+
+### Task 5: Interactive confirmation prompt before applying
+
+**Files:**
+
+- Modify: `src/main.rs` — `run_update()` function
+- Modify: `src/pipeline.rs` — split update into plan + apply phases
+- Test: `tests/cli_update.rs`
+
+- [ ] **Step 1: Write failing test — update without --yes prompts (non-TTY auto-proceeds)**
+
+Append to `tests/cli_update.rs`:
+
+```rust
+#[test]
+fn update_without_yes_proceeds_in_non_tty() {
+    // In non-TTY (like test harness), update should proceed without
+    // blocking — same as remove's behavior.
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    mutate_skill(&source);
+
+    // No --yes flag, but stdin is not a TTY so it should proceed.
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update"])
+        .assert()
+        .success();
+
+    let out_path = target.join(".claude/skills/create-api-endpoint/SKILL.md");
+    let content = fs::read_to_string(&out_path).unwrap();
+    assert!(
+        content.contains("mutated by test"),
+        "update should have applied without prompt in non-TTY"
+    );
+}
+```
+
+- [ ] **Step 2: Refactor `update()` to support a two-phase plan-then-apply pattern**
+
+The confirmation prompt needs to show the plan before applying. The cleanest approach: `update()` already computes the report. We change the flow in `main.rs` so that:
+
+1. First call `update()` with `DryRun` to get the plan.
+2. If nothing to do → print and exit.
+3. If changes exist and TTY and no `--yes` → show summary and prompt.
+4. If confirmed → call `update()` with `Apply`.
+
+Modify `run_update` in `src/main.rs`:
+
+```rust
+fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project: bool) -> i32 {
+    let target = match install_target(global, project) {
+        Ok(t) => t,
+        Err(err) => {
+            print_error(&err);
+            return EXIT_ERROR;
+        }
+    };
+
+    let plugin_scope = scope_to_plugin_scope(global, project);
+
+    if dry_run {
+        // Pure dry-run: report and exit.
+        match update(&target, names, UpdateMode::DryRun, plugin_scope) {
+            Ok(report) => {
+                print_update_report(&report, true);
+                EXIT_SUCCESS
+            }
+            Err(err) => {
+                print_error_chain(&err);
+                EXIT_ERROR
+            }
+        }
+    } else {
+        // Plan phase: dry-run to compute what would change.
+        let plan = match update(&target, names, UpdateMode::DryRun, plugin_scope) {
+            Ok(r) => r,
+            Err(err) => {
+                print_error_chain(&err);
+                return EXIT_ERROR;
+            }
+        };
+
+        let has_changes = plan.items.iter().any(|i| !matches!(i.status, UpdateStatus::UpToDate));
+        if !has_changes {
+            print_update_report(&plan, false);
+            return EXIT_SUCCESS;
+        }
+
+        // Show plan and confirm.
+        print_update_plan(&plan);
+        if !yes && !confirm_update() {
+            eprintln!("aborted.");
+            return EXIT_SUCCESS;
+        }
+
+        // Apply phase.
+        match update(&target, names, UpdateMode::Apply, plugin_scope) {
+            Ok(report) => {
+                print_update_report(&report, false);
+                EXIT_SUCCESS
+            }
+            Err(err) => {
+                print_error_chain(&err);
+                EXIT_ERROR
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add `print_update_plan` and `confirm_update` in `main.rs`**
+
+```rust
+fn print_update_plan(report: &UpdateReport) {
+    if style::is_quiet() {
+        return;
+    }
+    let updated = report
+        .items
+        .iter()
+        .filter(|i| matches!(i.status, UpdateStatus::WouldChange { .. }))
+        .count();
+    let removed = report
+        .items
+        .iter()
+        .filter(|i| matches!(i.status, UpdateStatus::WouldRemove))
+        .count();
+    let unchanged = report
+        .items
+        .iter()
+        .filter(|i| matches!(i.status, UpdateStatus::UpToDate))
+        .count();
+
+    println!();
+    if updated > 0 {
+        println!(
+            "  {}  {} item(s)",
+            style::success("update:"),
+            updated
+        );
+    }
+    if removed > 0 {
+        println!(
+            "  {}  {} item(s) (no longer in source)",
+            style::error("remove:"),
+            removed
+        );
+    }
+    if unchanged > 0 {
+        println!(
+            "  {} {} item(s)",
+            style::dim("unchanged:"),
+            unchanged
+        );
+    }
+    println!();
+}
+
+/// Prompt user to confirm update. Returns `true` to proceed.
+/// Non-TTY stdin → returns `true` (same convention as `confirm_bulk_remove`).
+fn confirm_update() -> bool {
+    use std::io::{BufRead, IsTerminal, Write};
+
+    if !std::io::stdin().is_terminal() {
+        return true;
+    }
+
+    eprint!("Apply? [y/N] ");
+    let _ = std::io::stderr().flush();
+
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    if stdin.lock().read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim().to_lowercase().as_str(), "y" | "yes")
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test cli_update`
+Expected: all tests pass. The existing tests pass `--yes` or run in non-TTY (test harness), so they proceed without blocking.
+
+- [ ] **Step 5: Fix existing tests that don't pass `--yes`**
+
+The existing tests (`update_no_change_reports_up_to_date`, `update_after_ssot_mutation_rewrites_outputs_and_lockfile_hash`) run in non-TTY so `confirm_update()` returns `true`. They should still pass. If any fail, add `--yes` to their args.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cargo test`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main.rs src/pipeline.rs tests/cli_update.rs
+git commit -m "feat: interactive confirmation prompt before update applies"
+```
+
+---
+
+### Task 6: Lint, format, and verify
+
+**Files:**
+
+- All modified files
+
+- [ ] **Step 1: Format**
+
+Run: `just fmt`
+
+- [ ] **Step 2: Lint**
+
+Run: `just lint`
+Expected: no warnings, no errors.
+
+- [ ] **Step 3: Full verification**
+
+Run: `just verify`
+Expected: all checks pass.
+
+- [ ] **Step 4: Final commit if formatting changed anything**
+
+```bash
+git add -A
+git commit -m "chore: fmt"
+```

--- a/docs/superpowers/specs/2026-05-24-item-conflict-resolution-design.md
+++ b/docs/superpowers/specs/2026-05-24-item-conflict-resolution-design.md
@@ -1,0 +1,175 @@
+# Item Conflict Resolution & Source Locking
+
+**Date**: 2026-05-24
+**Status**: Draft
+**Scope**: `upskill add`, bundle install, lockfile, alias mechanism
+
+---
+
+## Problem
+
+When two source registries publish items with the same `(kind, name)`, consumers
+hit conflicts with no graceful resolution path. Today:
+
+- Direct `upskill add` silently overwrites an existing item from a different source.
+- Bundle resolution hard-errors on `(kind, name)` duplicates within the dependency
+  graph, but offers no resolution mechanism.
+- There is no way to keep two items with the same short name from different sources.
+
+This leads to accidental overrides, unintended shadowing, and poor DX when
+composing content from multiple registries.
+
+## Design Principles
+
+1. **Short names are the only user-facing handle.** Agents trigger skills by short
+   name; users type `/skill-name`. No namespaces, scopes, or qualified IDs in
+   daily usage.
+2. **Locked by default.** Once an item is installed, its `(kind, name)` is bound to
+   its source. Replacement from a different source requires explicit opt-in.
+3. **Deterministic behavior.** No interactive prompts — errors are clear and
+   actionable, with flags to resolve. Works identically in CI and local.
+4. **Aliases for coexistence.** When two items with the same upstream name are both
+   needed, one is installed under an alias.
+
+## Design
+
+### 1. Source Affinity (Implicit Locking)
+
+Every `LockedItem` in `.upskill-lock.json` already records a `source` field. This
+field becomes the lock: any subsequent `upskill add` that would write a `(kind,
+name)` already present in the lockfile from a **different source** is an error.
+
+No new lockfile fields are needed for locking. The existing `source` field is
+sufficient.
+
+### 2. Conflict Detection
+
+On `upskill add <source>`, after resolving which items the source provides:
+
+1. For each resolved `(kind, name)`, check the lockfile.
+2. If the `(kind, name)` exists and `source` matches → this is an **update**, proceed
+   normally.
+3. If the `(kind, name)` exists and `source` differs → **conflict error**.
+
+Error message:
+
+```
+Error: skill `brainstorming` is already installed from `driftsys/superpowers`.
+       Use --force to replace, or --as <alt-name> to keep both.
+```
+
+### 3. Resolution Flags
+
+#### `--force`
+
+Overrides the source lock. Removes the existing item and installs the new one in
+its place. The lockfile entry is updated to the new source.
+
+```bash
+upskill add other-org/repo:brainstorming --force --claude
+```
+
+#### `--as <alias>`
+
+Installs the item under an alternate short name, avoiding the conflict entirely.
+
+```bash
+upskill add other-org/repo:brainstorming --as brainstorming-v2 --claude
+```
+
+- The alias becomes the item's name in all generated client outputs.
+- The alias must follow standard naming rules (lowercase `a-z`, digits `0-9`,
+  hyphens, max 64 chars, no leading/trailing hyphen).
+- The alias must not conflict with another installed `(kind, name)`.
+
+### 4. Lockfile: Aliased Items
+
+When `--as` is used, the lockfile records the original source name so that
+`upskill update` can fetch the correct SSOT:
+
+```json
+{
+  "kind": "skill",
+  "name": "brainstorming-v2",
+  "source": "other-org/repo",
+  "source_name": "brainstorming",
+  "ref": "main",
+  "hash": "def456..."
+}
+```
+
+- `source_name` (optional, string): the item's name in the source registry. Only
+  present when it differs from `name` (i.e., when aliased).
+- `upskill update` uses `source_name` (falling back to `name`) to locate the SSOT
+  file in the source.
+
+Schema remains `1` — this is an additive, backwards-compatible field.
+
+### 5. Bundle Install Conflicts
+
+When a bundle install resolves items that conflict with existing locked entries,
+the same rules apply per-item.
+
+**Single conflict:**
+
+```
+Error: bundle `android-baseline` provides skill `systematic-debugging`
+       which is already installed from `driftsys/superpowers`.
+       Use --force to replace, or --exclude systematic-debugging to skip it,
+       or --as systematic-debugging=android-debugging to alias it.
+```
+
+**Multiple conflicts:**
+
+```
+Error: bundle `android-baseline` conflicts with 3 installed items:
+  - skill `systematic-debugging` (from `driftsys/superpowers`)
+  - rule `license-awareness` (from `company/legal-bundle`)
+  - agent `security-reviewer` (from `driftsys/superpowers`)
+
+Use --force to replace all, or resolve individually with --exclude or --as.
+```
+
+**Bundle flags:**
+
+| Flag                         | Behavior                          |
+| ---------------------------- | --------------------------------- |
+| `--force`                    | Replace all conflicting items     |
+| `--exclude <name>`           | Skip specific items (repeatable)  |
+| `--as <source-name>=<alias>` | Alias specific items (repeatable) |
+
+**Bundle-to-bundle conflict** (two bundles in a `requires` chain list the same
+`(kind, name)`): remains a hard error as today. This is an authoring bug in the
+bundle graph, not a consumer-side conflict.
+
+### 6. Same-Source Reinstall
+
+When `(kind, name)` exists and the source matches, `upskill add` treats it as an
+update — fetches the latest, regenerates outputs, updates the hash. No error, no
+prompt.
+
+### 7. CI Behavior
+
+No special CI mode needed. The behavior is deterministic everywhere:
+
+- Conflict → error with actionable message
+- `--force` or `--as` resolves it
+- No interactive prompts in any mode
+
+## Changes Summary
+
+| Area             | Change                                                                  |
+| ---------------- | ----------------------------------------------------------------------- |
+| Lockfile         | Add optional `source_name` field. No schema bump.                       |
+| `upskill add`    | Conflict detection. New flags: `--force`, `--as`.                       |
+| Bundle install   | Per-item conflict detection. New flags: `--force`, `--exclude`, `--as`. |
+| `upskill update` | Use `source_name` when fetching aliased items.                          |
+| Error messages   | Actionable guidance: what conflicted, from where, how to resolve.       |
+| No new commands  | Locking is implicit via source affinity.                                |
+
+## Out of Scope
+
+- Namespace/scope syntax (rejected — DX tax too high for the problem).
+- Interactive prompts (rejected — deterministic errors are simpler and CI-safe).
+- `pin`/`unpin` commands (rejected — locked-by-default eliminates the need).
+- Canonical qualified IDs in user-facing flows (internal bookkeeping only).

--- a/docs/superpowers/specs/2026-05-24-multi-registry-search-design.md
+++ b/docs/superpowers/specs/2026-05-24-multi-registry-search-design.md
@@ -1,0 +1,196 @@
+# Multi-Registry Search with Local Index
+
+## Summary
+
+Extend `upskill search` to query configured git-based registries in addition
+to skills.sh. Introduce a general config file and a local index cache with
+HEAD-based invalidation for fast, offline-capable discovery.
+
+## Motivation
+
+Users with corporate registries (or well-known public repos like Anthropic,
+Microsoft) cannot discover content via `upskill search` today — it only
+queries skills.sh. They must know the exact `owner/repo:path` to install.
+Multi-registry search closes this gap.
+
+## Design
+
+### 1. Configuration
+
+**First upskill config file.** General-purpose, extensible for future settings.
+
+| Scope   | Path                            | Committed? |
+| ------- | ------------------------------- | ---------- |
+| Global  | `~/.config/upskill/config.yaml` | No         |
+| Project | `.upskill/config.yaml`          | Yes        |
+
+Merge order: built-in → global → project. Duplicate registry names: project
+overrides global overrides built-in.
+
+```yaml
+# ~/.config/upskill/config.yaml
+registries:
+  - name: corp
+    source: gitlab:mycompany/ai-skills
+  - name: anthropic
+    source: anthropics/skills
+```
+
+**Model:**
+
+```rust
+struct Config {
+    registries: Vec<RegistryEntry>,
+}
+
+struct RegistryEntry {
+    name: String,
+    source: String, // parsed via existing source.rs
+}
+```
+
+The `source` field accepts the same syntax as `upskill add` (owner/repo,
+gitlab:owner/repo, full URLs, local paths).
+
+**Built-in registries:** skills.sh remains the only built-in for now. Well-known
+public git registries (Anthropic, Microsoft) can be added later as the ecosystem
+matures — no code change needed, just add entries to the hardcoded list.
+
+### 2. Local Index
+
+**Location:** `~/.cache/upskill/index/<registry-name>.json`
+
+**Schema:**
+
+```json
+{
+  "schema": 1,
+  "registry": "corp",
+  "source": "gitlab:mycompany/ai-skills",
+  "head": "abc123def456...",
+  "indexed_at": "2026-05-24T10:00:00Z",
+  "items": [
+    {
+      "name": "code-review",
+      "kind": "skill",
+      "description": "Structured code review workflow with checklists",
+      "path": "skills/code-review"
+    }
+  ]
+}
+```
+
+**Description extraction:** First non-empty paragraph from the SSOT body (after
+YAML frontmatter). Uses existing frontmatter parsing.
+
+**Freshness check:**
+
+1. `git ls-remote <url> HEAD` → current HEAD sha (~100ms)
+2. Compare with `head` field in cached index
+3. Same → serve from cache
+4. Different → shallow clone into temp dir, scan, rebuild index, delete clone
+
+No persistent clone storage — only the index JSON persists.
+
+**Local-path registries:** When `source` is a local path (`./`, `../`, `/`,
+`~/`), skip the clone entirely — scan the directory in place. No HEAD check;
+always re-scan (local FS is fast). Still write an index file for consistency
+but without a `head` field.
+
+### 3. Search UX
+
+**Unified search:**
+
+```
+upskill search foo
+```
+
+1. Query skills.sh API (existing, unchanged)
+2. Query local index for each configured registry (substring match on name +
+   description)
+3. Merge results, grouped by source
+
+**Output:**
+
+```
+── skills.sh ──────────────────────────────────────────
+  code-review          stasson/skills:skills/code-review (12 installs)
+
+── corp ───────────────────────────────────────────────
+  code-review          gitlab:mycompany/ai-skills:skills/code-review
+  code-review-strict   gitlab:mycompany/ai-skills:skills/code-review-strict
+
+── anthropic ──────────────────────────────────────────
+  code-review          anthropics/skills:skills/code-review
+```
+
+**Targeted search:**
+
+```
+upskill search foo --registry corp
+```
+
+Only searches the named registry. Skips skills.sh and others.
+
+**Flags:**
+
+- `--registry <name>` — search a specific registry only
+- `--kind <skill|rule|agent|bundle>` — filter by item kind
+- `--limit N` — existing, applies to skills.sh results
+
+**Install from results:** User copies the source path and runs
+`upskill add <source>` as today. No new install syntax.
+
+### 4. Index Lifecycle
+
+**When indexing happens:**
+
+- First search after adding a registry → clone + index (foreground with
+  progress)
+- Subsequent searches → HEAD check, serve from cache or re-index
+- `upskill index` → force rebuild all
+- `upskill index --registry corp` → rebuild one
+
+**Error handling:**
+
+- Network failure + cache exists → serve stale with warning
+  (`"using cached index for 'corp' (offline)"`)
+- Network failure + no cache → skip registry, warn
+- Invalid/empty registry → warn, produce empty index
+- Auth failure → hint about tokens (reuses `auth.rs`)
+
+**Cache management:**
+
+- `upskill index --clear` removes all cached indexes
+- Removing a registry from config does not auto-delete its cache
+
+### 5. Implementation
+
+**New modules:**
+
+- `src/config.rs` — parse + merge config layers
+- `src/index.rs` — clone, scan, build/read/write index JSON, HEAD check
+
+**Modified modules:**
+
+- `src/search.rs` — extend to query local indexes
+- `src/main.rs` — add `index` subcommand, `--registry`/`--kind` flags on
+  `search`
+
+**New CLI surface:**
+
+```
+upskill search <query> [--registry <name>] [--kind <kind>] [--limit N]
+upskill index [--registry <name>] [--clear]
+```
+
+**Dependencies:** None new. Uses `serde_yaml_ng` (config), `serde_json`
+(index), git shell-out (clone/ls-remote via existing `fetch.rs` patterns).
+
+### 6. Out of Scope
+
+- Named registry install syntax (`upskill add corp --skill foo`) — the
+  `owner/repo:path` syntax already works
+- Full-text body search — name + description covers discovery needs
+- Background re-indexing — foreground is acceptable given shallow clone speed
+- Registry publishing/hosting — remains out of scope per spec §7

--- a/docs/superpowers/specs/2026-05-24-upgrade-ux-design.md
+++ b/docs/superpowers/specs/2026-05-24-upgrade-ux-design.md
@@ -1,0 +1,154 @@
+# Upgrade UX Design
+
+Date: 2026-05-24
+
+## Problem
+
+`upskill update` has three gaps that leave stale artifacts on disk:
+
+1. **File-level staleness** — when a file inside a skill is renamed or removed
+   upstream (e.g., `scripts/old.js` → `scripts/new.js`), the old output file
+   lingers because update overwrites but never deletes.
+
+2. **Item-level staleness** — when an item is renamed or removed from a source,
+   the lockfile entry becomes an orphan. The user must manually discover this
+   (via `doctor`) and run `upskill remove`. There is no automatic cleanup.
+
+3. **No confirmation** — `update` applies changes silently. Now that update will
+   perform removals, a confirmation step is needed for safety.
+
+## Design
+
+### 1. Clean-and-regenerate
+
+Before writing new output for an item, delete the entire per-client output
+directory for that item.
+
+**Affected paths per item (example: skill named `foo`):**
+
+- `.claude/skills/foo/`
+- `.github/skills/foo/`
+- `.agents/skills/foo/`
+
+**Behavior:**
+
+- Applies during `update` (Apply mode) and `add` (re-install of existing item).
+- Does NOT apply during `--dry-run` (no side effects).
+- If deletion fails (permissions, etc.), report the error and continue with
+  other items.
+
+**Rationale:** Output directories are generated artifacts. Users should not add
+files to them. Clean-and-regenerate is correct by construction with zero
+additional state.
+
+### 2. Auto-remove orphans on update
+
+After fetching a source, compare lockfile entries for that source against the
+items actually discovered in the fetched SSOT.
+
+**Detection:**
+
+- For each lockfile entry whose `source` matches the fetched source:
+  - If the item `(kind, name)` is NOT present in the fetched SSOT → orphan.
+
+**Action (Apply mode):**
+
+- Delete per-client output directories for the orphan.
+- Remove the lockfile entry.
+- Include in the update report as `Removed` with reason.
+
+**Action (DryRun mode):**
+
+- Include in the report as `WouldRemove`.
+
+**Edge cases:**
+
+- Item-filtered update (`upskill update foo bar`): only the named items are
+  checked. Orphan detection applies only to the subset the user asked to update.
+  Rationale: if the user said "update foo", they didn't ask us to remove `baz`.
+- Full update (`upskill update`): orphan detection applies to all entries for
+  each fetched source.
+
+### 3. Interactive confirmation
+
+After computing the full update plan (updated, removed, unchanged), display a
+summary and prompt before applying.
+
+**Format:**
+
+```
+upskill update — github:owner/repo
+
+  updated:   2 items (code-review, secret-scanner)
+  removed:   1 item  (old-lint-rule — no longer in source)
+  unchanged: 3 items
+
+Apply? [y/N]
+```
+
+**Skip conditions (no prompt, apply immediately):**
+
+- `--yes` / `-y` flag passed.
+- stdin is not a TTY (CI, pipes).
+- `--dry-run` (never applies, so no prompt needed).
+- Nothing to do (all items unchanged, no removals).
+
+**CLI change:**
+
+Add `--yes` / `-y` flag to the `Update` command (same pattern as `Remove`
+already has).
+
+### Non-goals
+
+- **Auto-update** — no hooks, daemons, or staleness nudges. Users run
+  `upskill update` manually or in CI.
+- **Rename detection** — no attempt to match old→new names. The effect is
+  correct: old item removed, new item installed.
+- **Per-file tracking in lockfile** — clean-and-regenerate eliminates the need.
+- **Warning before wiping user-added files** — output dirs are generated; adding
+  files there is unsupported.
+
+## Implementation notes
+
+### Modules affected
+
+- `src/pipeline.rs` — `update()` function: add orphan detection, add
+  clean-before-regenerate, compute plan before applying, return enriched report.
+- `src/cli.rs` — add `--yes` flag to `Update` command.
+- `src/main.rs` — `run_update()`: display plan summary, prompt, then call apply.
+- `src/lockfile.rs` — add `remove_item()` method if not already present.
+
+### UpdateReport changes
+
+Add a new variant to `UpdateStatus`:
+
+```rust
+pub enum UpdateStatus {
+    UpToDate,
+    Updated { old_hash: Option<String>, new_hash: Option<String> },
+    WouldChange { old_hash: Option<String>, new_hash: Option<String> },
+    Removed,       // NEW
+    WouldRemove,   // NEW
+}
+```
+
+### Clean-and-regenerate implementation
+
+In the install/regenerate path, before writing output files for an item:
+
+```rust
+fn clean_item_outputs(target: &Path, kind: ItemKind, name: &str) {
+    for client in ALL_CLIENTS {
+        let dir = target.join(output_dir(kind, client, name));
+        if dir.is_dir() {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+}
+```
+
+Call this in `install_from_source` (or the per-item render step) before writing.
+
+### Lockfile schema
+
+No schema change. `schema: 1` is preserved. Removal is just deleting entries.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -119,6 +119,10 @@ pub enum Commands {
         /// fallback to global when `cwd` is not inside a git repo.
         #[arg(short = 'p', long = "project")]
         project: bool,
+        /// Skip the confirmation prompt. Already implicit when stdin is
+        /// not a terminal (CI / pipes) or when `--dry-run` is used.
+        #[arg(short = 'y', long = "yes")]
+        yes: bool,
     },
     /// List installed content recorded in `.upskill-lock.json`.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,8 +507,20 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
                 EXIT_ERROR
             }
         }
+    } else if yes || !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        // No confirmation needed — apply directly (single fetch).
+        match update(&target, names, UpdateMode::Apply, plugin_scope) {
+            Ok(report) => {
+                print_update_report(&report, false);
+                EXIT_SUCCESS
+            }
+            Err(err) => {
+                print_error_chain(&err);
+                EXIT_ERROR
+            }
+        }
     } else {
-        // Two-phase: dry-run first to compute the plan, then apply if confirmed.
+        // Interactive: dry-run first to show plan, then apply if confirmed.
         let plan = match update(&target, names, UpdateMode::DryRun, plugin_scope) {
             Ok(r) => r,
             Err(err) => {
@@ -533,7 +545,7 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
             print_update_plan(&plan);
         }
 
-        if !yes && !confirm_update() {
+        if !confirm_update() {
             eprintln!("aborted.");
             return EXIT_SUCCESS;
         }
@@ -615,16 +627,20 @@ fn print_update_report(report: &UpdateReport, dry_run: bool) {
         println!("nothing to update — lockfile is empty");
         return;
     }
-    let header: colored::ColoredString = if dry_run {
-        style::warn("Dry-run: would update")
-    } else {
-        style::success("Updated")
-    };
     let changes = report
         .items
         .iter()
         .filter(|i| !matches!(i.status, UpdateStatus::UpToDate))
         .count();
+    if changes == 0 && !dry_run {
+        println!("everything is up to date — nothing to do");
+        return;
+    }
+    let header: colored::ColoredString = if dry_run {
+        style::warn("Dry-run: would update")
+    } else {
+        style::success("Updated")
+    };
     println!("{header} {} of {} item(s)", changes, report.items.len());
     for item in &report.items {
         let kind_label = match item.kind {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,8 @@ fn main() {
             dry_run,
             global,
             project,
-        } => run_update(&names, dry_run, global, project),
+            yes,
+        } => run_update(&names, dry_run, yes, global, project),
         Commands::List {
             global,
             project,
@@ -483,7 +484,7 @@ fn print_remove_report(report: &RemoveReport) {
     }
 }
 
-fn run_update(names: &[String], dry_run: bool, global: bool, project: bool) -> i32 {
+fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
@@ -544,6 +545,8 @@ fn print_update_report(report: &UpdateReport, dry_run: bool) {
             UpdateStatus::WouldChange { new_hash, .. } => {
                 style::warn(&format!("would change → {}", short(new_hash)))
             }
+            UpdateStatus::Removed => style::error_label("removed — no longer in source"),
+            UpdateStatus::WouldRemove => style::warn("would remove — no longer in source"),
         };
         println!(
             "  {} {:<32} {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -570,11 +570,7 @@ fn print_update_plan(report: &UpdateReport) {
         .count();
 
     if update_count > 0 {
-        println!(
-            "  {}  {} item(s)",
-            style::success("update:"),
-            update_count
-        );
+        println!("  {}  {} item(s)", style::success("update:"), update_count);
     }
     if remove_count > 0 {
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -492,24 +492,123 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
             return EXIT_ERROR;
         }
     };
-    let mode = if dry_run {
-        UpdateMode::DryRun
-    } else {
-        UpdateMode::Apply
-    };
 
     let plugin_scope = scope_to_plugin_scope(global, project);
 
-    match update(&target, names, mode, plugin_scope) {
-        Ok(report) => {
-            print_update_report(&report, dry_run);
-            EXIT_SUCCESS
+    if dry_run {
+        // Explicit --dry-run: compute and report without applying.
+        match update(&target, names, UpdateMode::DryRun, plugin_scope) {
+            Ok(report) => {
+                print_update_report(&report, true);
+                EXIT_SUCCESS
+            }
+            Err(err) => {
+                print_error_chain(&err);
+                EXIT_ERROR
+            }
         }
-        Err(err) => {
-            print_error_chain(&err);
-            EXIT_ERROR
+    } else {
+        // Two-phase: dry-run first to compute the plan, then apply if confirmed.
+        let plan = match update(&target, names, UpdateMode::DryRun, plugin_scope) {
+            Ok(r) => r,
+            Err(err) => {
+                print_error_chain(&err);
+                return EXIT_ERROR;
+            }
+        };
+
+        let has_changes = plan
+            .items
+            .iter()
+            .any(|i| !matches!(i.status, UpdateStatus::UpToDate));
+
+        if !has_changes {
+            if !style::is_quiet() {
+                println!("everything is up to date — nothing to do");
+            }
+            return EXIT_SUCCESS;
+        }
+
+        if !style::is_quiet() {
+            print_update_plan(&plan);
+        }
+
+        if !yes && !confirm_update() {
+            eprintln!("aborted.");
+            return EXIT_SUCCESS;
+        }
+
+        match update(&target, names, UpdateMode::Apply, plugin_scope) {
+            Ok(report) => {
+                print_update_report(&report, false);
+                EXIT_SUCCESS
+            }
+            Err(err) => {
+                print_error_chain(&err);
+                EXIT_ERROR
+            }
         }
     }
+}
+
+/// Show a summary plan of what an update would do.
+fn print_update_plan(report: &UpdateReport) {
+    let update_count = report
+        .items
+        .iter()
+        .filter(|i| matches!(i.status, UpdateStatus::WouldChange { .. }))
+        .count();
+    let remove_count = report
+        .items
+        .iter()
+        .filter(|i| matches!(i.status, UpdateStatus::WouldRemove))
+        .count();
+    let unchanged_count = report
+        .items
+        .iter()
+        .filter(|i| matches!(i.status, UpdateStatus::UpToDate))
+        .count();
+
+    if update_count > 0 {
+        println!(
+            "  {}  {} item(s)",
+            style::success("update:"),
+            update_count
+        );
+    }
+    if remove_count > 0 {
+        println!(
+            "  {}  {} item(s) (no longer in source)",
+            style::error_label("remove:"),
+            remove_count
+        );
+    }
+    if unchanged_count > 0 {
+        println!(
+            "  {}  {} item(s)",
+            style::dim("unchanged:"),
+            unchanged_count
+        );
+    }
+}
+
+/// Interactive confirmation for update. Auto-proceeds in non-TTY (CI/pipes).
+fn confirm_update() -> bool {
+    use std::io::{BufRead, IsTerminal, Write};
+
+    if !std::io::stdin().is_terminal() {
+        return true;
+    }
+
+    eprint!("Apply? [y/N] ");
+    let _ = std::io::stderr().flush();
+
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    if stdin.lock().read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim().to_lowercase().as_str(), "y" | "yes")
 }
 
 fn print_update_report(report: &UpdateReport, dry_run: bool) {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1083,6 +1083,20 @@ pub struct UpdateReport {
     pub items: Vec<UpdatedItem>,
 }
 
+/// Delete all per-client output files for an item (best-effort).
+fn remove_item_outputs(target: &Path, kind: ItemKind, name: &str) {
+    for client in ALL_CLIENTS {
+        let rel = output_path(kind, client, name);
+        let full = target.join(&rel);
+        if full.exists() {
+            let _ = fs::remove_file(&full);
+            if let Some(parent) = full.parent() {
+                let _ = fs::remove_dir(parent);
+            }
+        }
+    }
+}
+
 /// Re-fetch every source recorded in `<target>/.upskill-lock.json` and
 /// either reinstall (`Apply`) or report what would change (`DryRun`).
 ///
@@ -1149,6 +1163,20 @@ pub fn update(
                 }
                 for entry in &source_entries {
                     let kind = parse_kind(&entry.kind)?;
+                    if !new_hashes.contains_key(&(kind, entry.name.clone())) {
+                        // Orphan: item no longer in source — remove it.
+                        remove_item_outputs(target, kind, &entry.name);
+                        let mut lock = crate::lockfile::Lockfile::load(target)?;
+                        lock.remove(&entry.kind, &entry.name);
+                        lock.save(target)?;
+                        report.items.push(UpdatedItem {
+                            kind,
+                            name: entry.name.clone(),
+                            source: source_label.clone(),
+                            status: UpdateStatus::Removed,
+                        });
+                        continue;
+                    }
                     let new_hash = new_hashes
                         .get(&(kind, entry.name.clone()))
                         .cloned()
@@ -1174,6 +1202,15 @@ pub fn update(
                 let new_hashes = hash_source_items(&root);
                 for entry in &source_entries {
                     let kind = parse_kind(&entry.kind)?;
+                    if !new_hashes.contains_key(&(kind, entry.name.clone())) {
+                        report.items.push(UpdatedItem {
+                            kind,
+                            name: entry.name.clone(),
+                            source: source_label.clone(),
+                            status: UpdateStatus::WouldRemove,
+                        });
+                        continue;
+                    }
                     let new_hash = new_hashes
                         .get(&(kind, entry.name.clone()))
                         .cloned()

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1094,15 +1094,14 @@ fn remove_item_outputs(target: &Path, kind: ItemKind, name: &str) {
         // If the item has its own directory (e.g. `.claude/skills/<name>/`),
         // remove it entirely so stale sibling files are cleaned up.
         // Only remove the parent if it's item-specific (contains the name).
-        if let Some(parent) = full.parent() {
-            if parent
+        if let Some(parent) = full.parent()
+            && parent
                 .file_name()
                 .and_then(|f| f.to_str())
                 .is_some_and(|f| f == name)
-                && parent.is_dir()
-            {
-                let _ = fs::remove_dir_all(parent);
-            }
+            && parent.is_dir()
+        {
+            let _ = fs::remove_dir_all(parent);
         }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1088,10 +1088,11 @@ fn remove_item_outputs(target: &Path, kind: ItemKind, name: &str) {
     for client in ALL_CLIENTS {
         let rel = output_path(kind, client, name);
         let full = target.join(&rel);
-        if full.exists() {
-            let _ = fs::remove_file(&full);
-            if let Some(parent) = full.parent() {
-                let _ = fs::remove_dir(parent);
+        // Remove the entire item directory (e.g. `.claude/skills/<name>/`)
+        // so stale files from previous generations are cleaned up.
+        if let Some(parent) = full.parent() {
+            if parent.is_dir() {
+                let _ = fs::remove_dir_all(parent);
             }
         }
     }
@@ -1574,6 +1575,7 @@ fn install_skills(
         let audience = skill.audience.as_deref();
         let source_hash = hash_item_dir(&dir);
 
+        remove_item_outputs(target, ItemKind::Skill, &name);
         for client in ALL_CLIENTS {
             if !targets(client, audience) {
                 continue;
@@ -1617,6 +1619,7 @@ fn install_rules(
         let audience = rule.audience.as_deref();
         let source_hash = hash_item_dir(&dir);
 
+        remove_item_outputs(target, ItemKind::Rule, &name);
         for client in ALL_CLIENTS {
             if !targets(client, audience) {
                 continue;
@@ -1660,6 +1663,7 @@ fn install_agents(
         let audience = agent.audience.as_deref();
         let source_hash = hash_item_dir(&dir);
 
+        remove_item_outputs(target, ItemKind::Agent, &name);
         for client in ALL_CLIENTS {
             if !targets(client, audience) {
                 continue;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1170,21 +1170,32 @@ pub fn update(
                 for it in &install_report.items {
                     new_hashes.insert((it.kind, it.name.clone()), it.source_hash.clone());
                 }
+                // Collect orphans first, then batch-remove from lockfile.
+                let mut orphans: Vec<(&crate::lockfile::LockedItem, ItemKind)> = Vec::new();
                 for entry in &source_entries {
                     let kind = parse_kind(&entry.kind)?;
                     if !new_hashes.contains_key(&(kind, entry.name.clone())) {
-                        // Orphan: item no longer in source — remove it.
-                        remove_item_outputs(target, kind, &entry.name);
-                        let mut lock = crate::lockfile::Lockfile::load(target)?;
+                        orphans.push((entry, kind));
+                    }
+                }
+                if !orphans.is_empty() {
+                    let mut lock = crate::lockfile::Lockfile::load(target)?;
+                    for (entry, kind) in &orphans {
+                        remove_item_outputs(target, *kind, &entry.name);
                         lock.remove(&entry.kind, &entry.name);
-                        lock.save(target)?;
                         report.items.push(UpdatedItem {
-                            kind,
+                            kind: *kind,
                             name: entry.name.clone(),
                             source: source_label.clone(),
                             status: UpdateStatus::Removed,
                         });
-                        continue;
+                    }
+                    lock.save(target)?;
+                }
+                for entry in &source_entries {
+                    let kind = parse_kind(&entry.kind)?;
+                    if !new_hashes.contains_key(&(kind, entry.name.clone())) {
+                        continue; // already handled as orphan
                     }
                     let new_hash = new_hashes
                         .get(&(kind, entry.name.clone()))

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1062,6 +1062,12 @@ pub enum UpdateStatus {
         old_hash: Option<String>,
         new_hash: Option<String>,
     },
+    /// `Apply` mode: item no longer exists in the source. Outputs deleted
+    /// and lockfile entry removed.
+    Removed,
+    /// `DryRun` mode: item no longer exists in the source; an `update`
+    /// (without `--dry-run`) would remove it.
+    WouldRemove,
 }
 
 #[derive(Debug, Clone)]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1088,10 +1088,19 @@ fn remove_item_outputs(target: &Path, kind: ItemKind, name: &str) {
     for client in ALL_CLIENTS {
         let rel = output_path(kind, client, name);
         let full = target.join(&rel);
-        // Remove the entire item directory (e.g. `.claude/skills/<name>/`)
-        // so stale files from previous generations are cleaned up.
+        if full.exists() {
+            let _ = fs::remove_file(&full);
+        }
+        // If the item has its own directory (e.g. `.claude/skills/<name>/`),
+        // remove it entirely so stale sibling files are cleaned up.
+        // Only remove the parent if it's item-specific (contains the name).
         if let Some(parent) = full.parent() {
-            if parent.is_dir() {
+            if parent
+                .file_name()
+                .and_then(|f| f.to_str())
+                .is_some_and(|f| f == name)
+                && parent.is_dir()
+            {
                 let _ = fs::remove_dir_all(parent);
             }
         }

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -76,12 +76,8 @@ fn update_no_change_reports_up_to_date() {
         .success();
     let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     assert!(
-        out.contains("Updated 0 of 4 item(s)"),
+        out.contains("everything is up to date"),
         "expected no changes, got:\n{out}"
-    );
-    assert!(
-        out.contains("up to date"),
-        "expected up-to-date status, got:\n{out}"
     );
 }
 
@@ -290,7 +286,7 @@ fn update_empty_lockfile_is_no_op() {
         .success();
     let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     assert!(
-        out.contains("nothing to update"),
+        out.contains("everything is up to date") || out.contains("nothing to update"),
         "expected empty-lockfile message: {out}"
     );
 }
@@ -331,5 +327,36 @@ fn update_removes_stale_output_file_from_previous_generation() {
     assert!(
         real_output.exists(),
         "regenerated output should exist after update"
+    );
+}
+
+/// Non-TTY (test harness) should auto-proceed without `--yes`.
+#[test]
+fn update_without_yes_proceeds_in_non_tty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    // Mutate source so there's something to update.
+    mutate_skill(&source);
+
+    let hash_before = lockfile_hash_for(&target, "create-api-endpoint");
+
+    // Run update WITHOUT --yes; non-TTY should auto-proceed.
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update"])
+        .assert()
+        .success();
+
+    let hash_after = lockfile_hash_for(&target, "create-api-endpoint");
+    assert_ne!(
+        hash_before, hash_after,
+        "update should have applied without --yes in non-TTY"
     );
 }

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -192,6 +192,93 @@ fn update_unknown_name_is_general_error() {
 }
 
 #[test]
+fn update_removes_orphaned_item_when_source_no_longer_contains_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    // Verify the skill is installed.
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists(),
+        "skill should be installed before removal"
+    );
+    assert!(lockfile_hash_for(&target, "create-api-endpoint").is_some());
+
+    // Remove the item from the source so it becomes an orphan.
+    fs::remove_dir_all(source.join("create-api-endpoint")).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "--yes"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("removed") || out.contains("Removed"),
+        "expected removed status, got:\n{out}"
+    );
+
+    // Output files should be gone.
+    assert!(
+        !target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists(),
+        "skill output should be deleted after orphan removal"
+    );
+    // Lockfile entry should be gone.
+    assert!(
+        lockfile_hash_for(&target, "create-api-endpoint").is_none(),
+        "lockfile entry should be removed for orphaned item"
+    );
+}
+
+#[test]
+fn update_dry_run_reports_would_remove_without_deleting() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    // Remove the item from the source so it becomes an orphan.
+    fs::remove_dir_all(source.join("create-api-endpoint")).unwrap();
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "--dry-run"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("would remove"),
+        "expected `would remove` status, got:\n{out}"
+    );
+
+    // Output files should still exist.
+    assert!(
+        target
+            .join(".claude/skills/create-api-endpoint/SKILL.md")
+            .exists(),
+        "dry-run must not delete output files"
+    );
+    // Lockfile entry should still exist.
+    assert!(
+        lockfile_hash_for(&target, "create-api-endpoint").is_some(),
+        "dry-run must not remove lockfile entry"
+    );
+}
+
+#[test]
 fn update_empty_lockfile_is_no_op() {
     let tmp = tempfile::tempdir().unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -294,3 +294,42 @@ fn update_empty_lockfile_is_no_op() {
         "expected empty-lockfile message: {out}"
     );
 }
+
+#[test]
+fn update_removes_stale_output_file_from_previous_generation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    stage_source(&source);
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+    install(&target, &source);
+
+    // Inject a stale file into the generated output directory.
+    let stale_path = target.join(".claude/skills/create-api-endpoint/OLD_FILE.md");
+    fs::write(&stale_path, "# stale content").unwrap();
+    assert!(stale_path.exists());
+
+    // Mutate the source so update will regenerate.
+    mutate_skill(&source);
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(&target)
+        .args(["update", "--yes"])
+        .assert()
+        .success();
+
+    // Stale file should be removed.
+    assert!(
+        !stale_path.exists(),
+        "stale file should have been removed during regeneration"
+    );
+
+    // Real output should still exist.
+    let real_output = target.join(".claude/skills/create-api-endpoint/SKILL.md");
+    assert!(
+        real_output.exists(),
+        "regenerated output should exist after update"
+    );
+}


### PR DESCRIPTION
## Summary

Three improvements to `upskill update`:

1. **Auto-remove orphaned items** — when a source no longer contains an item that's in the lockfile, `update` removes its output files and lockfile entry (Apply mode) or reports "would remove" (DryRun mode).

2. **Clean-and-regenerate** — before writing new output for any item, existing output files/dirs are removed. Prevents stale files from lingering when upstream renames or removes files within a skill.

3. **Interactive confirmation** — `update` shows a plan summary (items to update/remove/unchanged) and prompts "Apply? [y/N]" before applying. Skipped with `--yes`, `--dry-run`, or non-TTY stdin.

## Changes

- `src/pipeline.rs`: Added `Removed`/`WouldRemove` variants to `UpdateStatus`, orphan detection in `update()`, `remove_item_outputs` helper, clean-before-regenerate in install loops
- `src/cli.rs`: Added `--yes` flag to Update command
- `src/main.rs`: Two-phase update (DryRun→confirm→Apply), `print_update_plan`, `confirm_update`
- `tests/cli_update.rs`: 4 new ATDD tests (orphan removal, dry-run would-remove, stale file cleanup, non-TTY auto-proceed)

## Test Results

All 251 unit tests + all integration tests pass. Clippy clean.