### PR TITLE
feat: item conflict resolution and source locking

### DIFF
--- a/docs/superpowers/plans/2026-05-24-item-conflict-resolution.md
+++ b/docs/superpowers/plans/2026-05-24-item-conflict-resolution.md
@@ -10,6 +10,8 @@
 
 ---
 
+## Tasks
+
 ### Task 1: Add `source_name` field to `LockedItem`
 
 **Files:**

--- a/docs/superpowers/plans/2026-05-24-upgrade-ux.md
+++ b/docs/superpowers/plans/2026-05-24-upgrade-ux.md
@@ -10,6 +10,8 @@
 
 ---
 
+## Tasks
+
 ### Task 1: Add `Removed` / `WouldRemove` variants to `UpdateStatus`
 
 **Files:**

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,17 @@ pub enum Commands {
         /// fallback to global when `cwd` is not inside a git repo.
         #[arg(short = 'p', long = "project")]
         project: bool,
+        /// Replace existing items from a different source without error.
+        #[arg(long = "force")]
+        force: bool,
+        /// Install under an alternate name to avoid conflicts.
+        /// For direct installs: `--as alt-name`.
+        /// For bundle installs: `--as original=alias` (repeatable).
+        #[arg(long = "as", value_name = "ALIAS")]
+        alias: Vec<String>,
+        /// Skip specific items during install (repeatable).
+        #[arg(long = "exclude", value_name = "NAME")]
+        exclude: Vec<String>,
     },
     /// Remove installed content.
     ///

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -1,0 +1,144 @@
+//! Item conflict detection for `upskill add`.
+//!
+//! Detects when an incoming item would collide with an already-installed
+//! item from a different source.
+
+use crate::lockfile::Lockfile;
+use crate::pipeline::ItemKind;
+
+/// A conflict between an incoming item and an already-installed item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ItemConflict {
+    pub kind: ItemKind,
+    pub name: String,
+    pub existing_source: String,
+    pub incoming_source: String,
+}
+
+/// Detect conflicts between incoming items and the current lockfile.
+///
+/// An item conflicts if the same `(kind, name)` pair exists in the lockfile
+/// with a different `source`.
+pub fn detect_conflicts(
+    incoming: &[(ItemKind, String)],
+    lockfile: &Lockfile,
+    incoming_source: &str,
+) -> Vec<ItemConflict> {
+    let mut conflicts = Vec::new();
+    for (kind, name) in incoming {
+        let kind_str = kind_to_str(*kind);
+        for locked in &lockfile.items {
+            if locked.kind == kind_str && locked.name == *name && locked.source != incoming_source {
+                conflicts.push(ItemConflict {
+                    kind: *kind,
+                    name: name.clone(),
+                    existing_source: locked.source.clone(),
+                    incoming_source: incoming_source.to_owned(),
+                });
+                break;
+            }
+        }
+    }
+    conflicts
+}
+
+/// Format conflicts into a user-facing error message.
+pub fn format_conflict_error(conflicts: &[ItemConflict]) -> String {
+    match conflicts.len() {
+        0 => String::new(),
+        1 => {
+            let c = &conflicts[0];
+            format!(
+                "{} `{}` is already installed from `{}`.\n\
+                 Use --force to replace, or --as <alt-name> to keep both.",
+                kind_to_str(c.kind),
+                c.name,
+                c.existing_source,
+            )
+        }
+        _ => {
+            let mut msg =
+                String::from("The following items conflict with existing installations:\n");
+            for c in conflicts {
+                msg.push_str(&format!(
+                    "  - {} `{}` (installed from `{}`)\n",
+                    kind_to_str(c.kind),
+                    c.name,
+                    c.existing_source,
+                ));
+            }
+            msg.push_str(
+                "Use --force to replace all, or resolve individually with --exclude or --as.",
+            );
+            msg
+        }
+    }
+}
+
+fn kind_to_str(kind: ItemKind) -> &'static str {
+    match kind {
+        ItemKind::Rule => "rule",
+        ItemKind::Skill => "skill",
+        ItemKind::Agent => "agent",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lockfile::Lockfile;
+
+    fn make_lockfile(items: Vec<(&str, &str, &str)>) -> Lockfile {
+        use crate::lockfile::LockedItem;
+        Lockfile {
+            schema: 1,
+            items: items
+                .into_iter()
+                .map(|(kind, name, source)| LockedItem {
+                    kind: kind.to_owned(),
+                    name: name.to_owned(),
+                    source: source.to_owned(),
+                    git_ref: None,
+                    hash: None,
+                    source_name: None,
+                })
+                .collect(),
+            bundles: vec![],
+            plugins: vec![],
+        }
+    }
+
+    #[test]
+    fn no_conflict_same_source() {
+        let lf = make_lockfile(vec![("skill", "brainstorming", "driftsys/superpowers")]);
+        let incoming = vec![(ItemKind::Skill, "brainstorming".to_owned())];
+        let conflicts = detect_conflicts(&incoming, &lf, "driftsys/superpowers");
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn conflict_different_source() {
+        let lf = make_lockfile(vec![("skill", "brainstorming", "driftsys/superpowers")]);
+        let incoming = vec![(ItemKind::Skill, "brainstorming".to_owned())];
+        let conflicts = detect_conflicts(&incoming, &lf, "other/repo");
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].name, "brainstorming");
+        assert_eq!(conflicts[0].existing_source, "driftsys/superpowers");
+    }
+
+    #[test]
+    fn no_conflict_item_not_in_lockfile() {
+        let lf = make_lockfile(vec![("skill", "debugging", "driftsys/superpowers")]);
+        let incoming = vec![(ItemKind::Skill, "brainstorming".to_owned())];
+        let conflicts = detect_conflicts(&incoming, &lf, "other/repo");
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn same_name_different_kind_no_conflict() {
+        let lf = make_lockfile(vec![("rule", "brainstorming", "driftsys/superpowers")]);
+        let incoming = vec![(ItemKind::Skill, "brainstorming".to_owned())];
+        let conflicts = detect_conflicts(&incoming, &lf, "other/repo");
+        assert!(conflicts.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod ancillary;
 pub mod auth;
 pub mod bundle;
 pub mod cli;
+pub mod conflict;
 pub mod fetch;
 pub mod fmt;
 pub mod generate;

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -51,6 +51,11 @@ pub struct LockedItem {
     /// `update` / `doctor` for drift detection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
+    /// Original item name in the source registry. Only present when the
+    /// consumer installed with `--as <alias>` so `name` differs from the
+    /// SSOT name. Used by `update` to locate the correct source file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_name: Option<String>,
 }
 
 /// Bundle entry recorded when an install resolves a `.bundle.yaml` file
@@ -249,6 +254,7 @@ pub fn items_from_report(
             source: source_label.to_string(),
             git_ref: git_ref.map(str::to_string),
             hash: hash_for(entry.kind, &entry.name),
+            source_name: None,
         });
     }
     out
@@ -276,6 +282,7 @@ mod tests {
             source: "github:driftsys/skills".to_string(),
             git_ref: Some("v1.0.0".to_string()),
             hash: Some("sha256:deadbeef".to_string()),
+            source_name: None,
         }
     }
 
@@ -533,6 +540,34 @@ mod tests {
         .unwrap();
         let lock = Lockfile::load(tmp.path()).expect("must parse");
         assert_eq!(lock.plugins[0].status, PluginInstallStatus::Installed);
+    }
+
+    #[test]
+    fn locked_item_serializes_source_name_when_present() {
+        let item = LockedItem {
+            kind: "skill".to_string(),
+            name: "brainstorming-v2".to_string(),
+            source: "github:other-org/repo".to_string(),
+            git_ref: None,
+            hash: None,
+            source_name: Some("brainstorming".to_string()),
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("\"source_name\":\"brainstorming\""), "{json}");
+    }
+
+    #[test]
+    fn locked_item_omits_source_name_when_none() {
+        let item = LockedItem {
+            kind: "skill".to_string(),
+            name: "brainstorming".to_string(),
+            source: "github:driftsys/superpowers".to_string(),
+            git_ref: None,
+            hash: None,
+            source_name: None,
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(!json.contains("source_name"), "{json}");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -514,7 +514,7 @@ fn print_remove_report(report: &RemoveReport) {
     }
 }
 
-fn run_update(names: &[String], dry_run: bool, _yes: bool, global: bool, project: bool) -> i32 {
+fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -514,7 +514,7 @@ fn print_remove_report(report: &RemoveReport) {
     }
 }
 
-fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project: bool) -> i32 {
+fn run_update(names: &[String], dry_run: bool, _yes: bool, global: bool, project: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,9 +132,9 @@ fn run_add(
     items: &[String],
     global: bool,
     project: bool,
-    _force: bool,
-    _aliases: &[String],
-    _excludes: &[String],
+    force: bool,
+    aliases: &[String],
+    excludes: &[String],
 ) -> i32 {
     let parsed = match parse_install_source(source) {
         Ok(s) => s,
@@ -154,8 +154,14 @@ fn run_add(
 
     let plugin_scope = scope_to_plugin_scope(global, project);
 
+    let options = upskill::pipeline::AddOptions {
+        force,
+        aliases: parse_alias_args(aliases),
+        excludes: excludes.to_vec(),
+    };
+
     print_install_progress(&parsed);
-    match install_with_lockfile(&parsed, &target, items, plugin_scope) {
+    match install_with_lockfile(&parsed, &target, items, plugin_scope, &options) {
         Ok(report) => {
             print_install_report(&report, source);
             print_plugin_results(&report);
@@ -166,6 +172,19 @@ fn run_add(
             EXIT_ERROR
         }
     }
+}
+
+/// Parse `--as` arguments. Direct: `"alt-name"`. Bundle: `"original=alias"`.
+fn parse_alias_args(args: &[String]) -> Vec<(String, String)> {
+    args.iter()
+        .map(|a| {
+            if let Some((from, to)) = a.split_once('=') {
+                (from.to_string(), to.to_string())
+            } else {
+                (String::new(), a.to_string())
+            }
+        })
+        .collect()
 }
 
 /// Interactive y/n prompt for bulk removal by source label. Returns

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,10 @@ fn main() {
             items,
             global,
             project,
-        } => run_add(&source, &items, global, project),
+            force,
+            alias,
+            exclude,
+        } => run_add(&source, &items, global, project, force, &alias, &exclude),
         Commands::Remove {
             names,
             source,
@@ -124,7 +127,15 @@ fn map_clap_error(err: &clap::Error) -> i32 {
     }
 }
 
-fn run_add(source: &str, items: &[String], global: bool, project: bool) -> i32 {
+fn run_add(
+    source: &str,
+    items: &[String],
+    global: bool,
+    project: bool,
+    _force: bool,
+    _aliases: &[String],
+    _excludes: &[String],
+) -> i32 {
     let parsed = match parse_install_source(source) {
         Ok(s) => s,
         Err(err) => {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -88,6 +88,18 @@ pub struct PluginResult {
     pub summary: Option<String>,
 }
 
+/// Options that control conflict resolution during install.
+#[derive(Debug, Clone, Default)]
+pub struct AddOptions {
+    /// When true, replace items from different sources without error.
+    pub force: bool,
+    /// Alias mappings. For direct `--as alt-name`: vec contains `("", "alt-name")`.
+    /// For bundle `--as original=alias`: vec contains `("original", "alias")`.
+    pub aliases: Vec<(String, String)>,
+    /// Item names to skip during install.
+    pub excludes: Vec<String>,
+}
+
 const ALL_CLIENTS: [Client; 3] = [Client::Claude, Client::Copilot, Client::OpenCode];
 
 /// Install every item under `source` into `target`, generating per-client
@@ -286,6 +298,7 @@ pub fn install_with_lockfile(
     target: &Path,
     items: &[String],
     plugin_scope: crate::plugin::PluginScope,
+    options: &AddOptions,
 ) -> Result<InstallReport> {
     let mut report = if items.is_empty() {
         // No names → install everything (existing default).
@@ -303,7 +316,36 @@ pub fn install_with_lockfile(
     let plugin_results = install_plugins_from_bundles(&report.bundles, plugin_scope, target);
     report.plugin_results = plugin_results;
 
+    // -- Conflict detection --
     let label = source.to_string();
+    let existing_lock = crate::lockfile::Lockfile::load(target)?;
+    let incoming: Vec<(ItemKind, String)> = {
+        let mut seen = std::collections::BTreeSet::new();
+        report
+            .items
+            .iter()
+            .filter(|i| !options.excludes.contains(&i.name))
+            .filter_map(|i| {
+                if seen.insert((i.kind, i.name.clone())) {
+                    Some((i.kind, i.name.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
+    let conflicts = crate::conflict::detect_conflicts(&incoming, &existing_lock, &label);
+    if !conflicts.is_empty() && !options.force {
+        anyhow::bail!("{}", crate::conflict::format_conflict_error(&conflicts));
+    }
+
+    // -- Apply excludes --
+    if !options.excludes.is_empty() {
+        report
+            .items
+            .retain(|item| !options.excludes.contains(&item.name));
+    }
+
     let git_ref = match source {
         InstallSource::Github(r) => r.git_ref.as_deref(),
         InstallSource::Gitlab(r) => r.git_ref.as_deref(),
@@ -1164,7 +1206,13 @@ pub fn update(
 
         match mode {
             UpdateMode::Apply => {
-                let install_report = install_with_lockfile(&source, target, &[], plugin_scope)?;
+                let install_report = install_with_lockfile(
+                    &source,
+                    target,
+                    &[],
+                    plugin_scope,
+                    &AddOptions::default(),
+                )?;
                 let mut new_hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> =
                     std::collections::BTreeMap::new();
                 for it in &install_report.items {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -283,6 +283,13 @@ fn bundle_item_names(bundle: &crate::model::Bundle) -> Vec<String> {
     out
 }
 
+/// Replace the item name component in an output path.
+/// E.g., `.claude/skills/foo/SKILL.md` → `.claude/skills/bar/SKILL.md`
+fn rename_output_path(path: &Path, old_name: &str, new_name: &str) -> PathBuf {
+    let path_str = path.to_string_lossy();
+    PathBuf::from(path_str.replacen(old_name, new_name, 1))
+}
+
 /// Install + write lockfile. Consumer-facing entry point.
 ///
 /// Calls [`install_from_source`] then merges the resulting [`InstallReport`]
@@ -317,6 +324,7 @@ pub fn install_with_lockfile(
     report.plugin_results = plugin_results;
 
     // -- Conflict detection --
+    // When aliases are provided, check under the alias name instead.
     let label = source.to_string();
     let existing_lock = crate::lockfile::Lockfile::load(target)?;
     let incoming: Vec<(ItemKind, String)> = {
@@ -326,8 +334,14 @@ pub fn install_with_lockfile(
             .iter()
             .filter(|i| !options.excludes.contains(&i.name))
             .filter_map(|i| {
-                if seen.insert((i.kind, i.name.clone())) {
-                    Some((i.kind, i.name.clone()))
+                let effective_name = options
+                    .aliases
+                    .iter()
+                    .find(|(from, _)| from.is_empty() || *from == i.name)
+                    .map(|(_, to)| to.clone())
+                    .unwrap_or_else(|| i.name.clone());
+                if seen.insert((i.kind, effective_name.clone())) {
+                    Some((i.kind, effective_name))
                 } else {
                     None
                 }
@@ -346,6 +360,43 @@ pub fn install_with_lockfile(
             .retain(|item| !options.excludes.contains(&item.name));
     }
 
+    // -- Apply aliases --
+    let mut aliased_names: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    if !options.aliases.is_empty() {
+        // Rename output files on disk and update report items.
+        for item in &mut report.items {
+            let alias = options
+                .aliases
+                .iter()
+                .find(|(from, _)| from.is_empty() || *from == item.name);
+            if let Some((_, alias_name)) = alias {
+                let old_path = target.join(&item.output_path);
+                let new_output = rename_output_path(&item.output_path, &item.name, alias_name);
+                let new_path = target.join(&new_output);
+
+                if old_path.exists() {
+                    if let Some(parent) = new_path.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    fs::rename(&old_path, &new_path).with_context(|| {
+                        format!("rename {} to {}", old_path.display(), new_path.display())
+                    })?;
+                    // Clean up empty parent directory
+                    if let Some(parent) = old_path.parent() {
+                        let _ = fs::remove_dir(parent);
+                    }
+                }
+
+                aliased_names
+                    .entry(alias_name.clone())
+                    .or_insert_with(|| item.name.clone());
+                item.output_path = new_output;
+                item.name = alias_name.clone();
+            }
+        }
+    }
+
     let git_ref = match source {
         InstallSource::Github(r) => r.git_ref.as_deref(),
         InstallSource::Gitlab(r) => r.git_ref.as_deref(),
@@ -361,7 +412,10 @@ pub fn install_with_lockfile(
     });
 
     let mut lock = crate::lockfile::Lockfile::load(target)?;
-    for item in new_items {
+    for mut item in new_items {
+        if let Some(original) = aliased_names.get(&item.name) {
+            item.source_name = Some(original.clone());
+        }
         lock.upsert(item);
     }
     for bundle in &report.bundles {
@@ -1206,13 +1260,22 @@ pub fn update(
 
         match mode {
             UpdateMode::Apply => {
-                let install_report = install_with_lockfile(
-                    &source,
-                    target,
-                    &[],
-                    plugin_scope,
-                    &AddOptions::default(),
-                )?;
+                // Build aliases from lockfile entries that have source_name
+                let aliases: Vec<(String, String)> = source_entries
+                    .iter()
+                    .filter_map(|e| {
+                        e.source_name
+                            .as_ref()
+                            .map(|sn| (sn.clone(), e.name.clone()))
+                    })
+                    .collect();
+                let options = AddOptions {
+                    force: true,
+                    aliases,
+                    excludes: vec![],
+                };
+                let install_report =
+                    install_with_lockfile(&source, target, &[], plugin_scope, &options)?;
                 let mut new_hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> =
                     std::collections::BTreeMap::new();
                 for it in &install_report.items {
@@ -1270,7 +1333,8 @@ pub fn update(
                 let new_hashes = hash_source_items(&root);
                 for entry in &source_entries {
                     let kind = parse_kind(&entry.kind)?;
-                    if !new_hashes.contains_key(&(kind, entry.name.clone())) {
+                    let lookup_name = entry.source_name.as_deref().unwrap_or(&entry.name);
+                    if !new_hashes.contains_key(&(kind, lookup_name.to_string())) {
                         report.items.push(UpdatedItem {
                             kind,
                             name: entry.name.clone(),
@@ -1280,7 +1344,7 @@ pub fn update(
                         continue;
                     }
                     let new_hash = new_hashes
-                        .get(&(kind, entry.name.clone()))
+                        .get(&(kind, lookup_name.to_string()))
                         .cloned()
                         .flatten();
                     let status = if new_hash == entry.hash {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -210,6 +210,63 @@ fn has_matching_items(source: &Path, name: &str) -> bool {
         || item_dir.join("AGENT.md").is_file()
 }
 
+/// Scan a source directory for item (kind, name) pairs without generating output.
+fn scan_source_items(source: &Path) -> Vec<(ItemKind, String)> {
+    let mut items = Vec::new();
+    let Ok(entries) = fs::read_dir(source) else {
+        return items;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        if is_item_dir(&path) {
+            if path.join("SKILL.md").is_file() {
+                items.push((ItemKind::Skill, name.to_string()));
+            }
+            if path.join("RULE.md").is_file() {
+                items.push((ItemKind::Rule, name.to_string()));
+            }
+            if path.join("AGENT.md").is_file() {
+                items.push((ItemKind::Agent, name.to_string()));
+            }
+        } else {
+            // Category subdir: source/<category>/<item>/ENTRY.md
+            if let Ok(sub_entries) = fs::read_dir(&path) {
+                for sub_entry in sub_entries.flatten() {
+                    let sub_path = sub_entry.path();
+                    if !sub_path.is_dir() {
+                        continue;
+                    }
+                    let Some(sub_name) = sub_path.file_name().and_then(|n| n.to_str()) else {
+                        continue;
+                    };
+                    if sub_name.starts_with('.') {
+                        continue;
+                    }
+                    if sub_path.join("SKILL.md").is_file() {
+                        items.push((ItemKind::Skill, sub_name.to_string()));
+                    }
+                    if sub_path.join("RULE.md").is_file() {
+                        items.push((ItemKind::Rule, sub_name.to_string()));
+                    }
+                    if sub_path.join("AGENT.md").is_file() {
+                        items.push((ItemKind::Agent, sub_name.to_string()));
+                    }
+                }
+            }
+        }
+    }
+    items
+}
+
 /// Walk up from `bundle_path`'s parent until a directory is found that
 /// looks like an SSOT root — a directory whose direct children include
 /// at least one item directory (containing `RULE.md`, `SKILL.md`, or
@@ -286,8 +343,15 @@ fn bundle_item_names(bundle: &crate::model::Bundle) -> Vec<String> {
 /// Replace the item name component in an output path.
 /// E.g., `.claude/skills/foo/SKILL.md` → `.claude/skills/bar/SKILL.md`
 fn rename_output_path(path: &Path, old_name: &str, new_name: &str) -> PathBuf {
-    let path_str = path.to_string_lossy();
-    PathBuf::from(path_str.replacen(old_name, new_name, 1))
+    path.iter()
+        .map(|component| {
+            if component == old_name {
+                std::ffi::OsStr::new(new_name)
+            } else {
+                component
+            }
+        })
+        .collect()
 }
 
 /// Install + write lockfile. Consumer-facing entry point.
@@ -307,51 +371,66 @@ pub fn install_with_lockfile(
     plugin_scope: crate::plugin::PluginScope,
     options: &AddOptions,
 ) -> Result<InstallReport> {
-    let mut report = if items.is_empty() {
-        // No names → install everything (existing default).
-        install_from_source(source, target, None)?
-    } else {
-        // Names provided → try item-filter first, then bundle-by-name.
-        install_with_name_resolution(source, target, items)?
-    };
-
-    // -- Plugin installation (ADR-0008) --
-    // After items are generated, iterate the resolved bundles' plugins
-    // and shell out to each client CLI. Results are appended to the
-    // report for main.rs to display; successful installs are recorded
-    // in the lockfile for remove/update/doctor.
-    let plugin_results = install_plugins_from_bundles(&report.bundles, plugin_scope, target);
-    report.plugin_results = plugin_results;
-
-    // -- Conflict detection --
-    // When aliases are provided, check under the alias name instead.
     let label = source.to_string();
-    let existing_lock = crate::lockfile::Lockfile::load(target)?;
+
+    // -- Pre-flight: fetch SSOT and scan for items before writing anything --
+    let (local_source, _tmp_guard) = fetch_ssot(source)?;
+    let scanned_items = scan_source_items(&local_source);
+
+    // -- Validate bare --as with multi-item source --
+    if options.aliases.iter().any(|(from, _)| from.is_empty()) {
+        let unique_names: std::collections::BTreeSet<&str> = scanned_items
+            .iter()
+            .filter(|(_, n)| !options.excludes.contains(n))
+            .map(|(_, n)| n.as_str())
+            .collect();
+        if unique_names.len() > 1 {
+            anyhow::bail!(
+                "--as <alias> cannot be used with a source containing multiple items ({} found). \
+                 Use --as <original>=<alias> syntax to alias specific items.",
+                unique_names.len()
+            );
+        }
+    }
+
+    // -- Conflict detection (before any files are written) --
+    let mut lock = crate::lockfile::Lockfile::load(target)?;
     let incoming: Vec<(ItemKind, String)> = {
         let mut seen = std::collections::BTreeSet::new();
-        report
-            .items
+        scanned_items
             .iter()
-            .filter(|i| !options.excludes.contains(&i.name))
-            .filter_map(|i| {
+            .filter(|(_, n)| !options.excludes.contains(n))
+            .filter(|(_, n)| items.is_empty() || items.contains(n))
+            .filter_map(|(kind, name)| {
                 let effective_name = options
                     .aliases
                     .iter()
-                    .find(|(from, _)| from.is_empty() || *from == i.name)
+                    .find(|(from, _)| from.is_empty() || *from == *name)
                     .map(|(_, to)| to.clone())
-                    .unwrap_or_else(|| i.name.clone());
-                if seen.insert((i.kind, effective_name.clone())) {
-                    Some((i.kind, effective_name))
+                    .unwrap_or_else(|| name.clone());
+                if seen.insert((*kind, effective_name.clone())) {
+                    Some((*kind, effective_name))
                 } else {
                     None
                 }
             })
             .collect()
     };
-    let conflicts = crate::conflict::detect_conflicts(&incoming, &existing_lock, &label);
+    let conflicts = crate::conflict::detect_conflicts(&incoming, &lock, &label);
     if !conflicts.is_empty() && !options.force {
         anyhow::bail!("{}", crate::conflict::format_conflict_error(&conflicts));
     }
+
+    // -- Now proceed with generation (files are written here) --
+    let mut report = if items.is_empty() {
+        install_from_local_path(&local_source, target, None)?
+    } else {
+        install_with_name_resolution_from_local(&local_source, target, items)?
+    };
+
+    // -- Plugin installation (ADR-0008) --
+    let plugin_results = install_plugins_from_bundles(&report.bundles, plugin_scope, target);
+    report.plugin_results = plugin_results;
 
     // -- Apply excludes --
     if !options.excludes.is_empty() {
@@ -411,7 +490,6 @@ pub fn install_with_lockfile(
         hashes.get(&(k, n.to_string())).cloned().flatten()
     });
 
-    let mut lock = crate::lockfile::Lockfile::load(target)?;
     for mut item in new_items {
         if let Some(original) = aliased_names.get(&item.name) {
             item.source_name = Some(original.clone());
@@ -475,35 +553,25 @@ pub fn install_with_lockfile(
     Ok(report)
 }
 
-/// Resolve positional names against both items and bundles.
-///
-/// For each name:
-/// - If it matches items AND a bundle → error (ambiguity).
-/// - If it matches only a bundle → install via bundle dispatch.
-/// - If it matches only items → install via item filter.
-/// - If it matches neither → error.
-///
-/// When the list contains a mix (some names are bundles, some are items),
-/// all bundle installs run first, then item installs run with the
-/// remaining names as a filter.
-fn install_with_name_resolution(
-    source: &InstallSource,
+/// Like [`install_with_name_resolution_from_local`] but operates on an already-fetched
+/// local source path (avoids double-fetch when `install_with_lockfile` has
+/// already called `fetch_ssot`).
+fn install_with_name_resolution_from_local(
+    local_source: &Path,
     target: &Path,
     names: &[String],
 ) -> Result<InstallReport> {
-    let (local_source, _tmp) = fetch_ssot(source)?;
-
     let mut bundle_paths: Vec<PathBuf> = Vec::new();
     let mut item_names: Vec<String> = Vec::new();
 
     for name in names {
-        let has_items = has_matching_items(&local_source, name);
-        let bundle_path = find_bundle_by_name(&local_source, name);
+        let has_items = has_matching_items(local_source, name);
+        let bundle_path = find_bundle_by_name(local_source, name);
 
         match (has_items, bundle_path) {
             (true, Some(bp)) => {
                 let rel = bp
-                    .strip_prefix(&local_source)
+                    .strip_prefix(local_source)
                     .unwrap_or(&bp)
                     .display()
                     .to_string();
@@ -515,7 +583,7 @@ fn install_with_name_resolution(
                      upskill add <source>:{}",
                     name,
                     name,
-                    detect_item_entrypoint(&local_source, name),
+                    detect_item_entrypoint(local_source, name),
                     rel,
                     rel,
                 );
@@ -530,21 +598,19 @@ fn install_with_name_resolution(
 
     let mut report = InstallReport::default();
 
-    // Install bundles first.
     for bp in &bundle_paths {
         let bundle_report = install_bundle_file(bp, target)?;
         report.items.extend(bundle_report.items);
         report.bundles.extend(bundle_report.bundles);
     }
 
-    // Install remaining items via the standard filter path.
     if !item_names.is_empty() {
         let filter = crate::bundle::ResolvedItems {
             rules: item_names.clone(),
             skills: item_names.clone(),
             agents: item_names.clone(),
         };
-        let item_report = install_from_local_path(&local_source, target, Some(&filter))?;
+        let item_report = install_from_local_path(local_source, target, Some(&filter))?;
         report.items.extend(item_report.items);
     }
 

--- a/tests/cli_conflict.rs
+++ b/tests/cli_conflict.rs
@@ -34,12 +34,8 @@ fn setup_conflict(tmp: &std::path::Path) {
     )
     .unwrap();
 
-    // Init git repo so upskill uses project scope
-    Command::new("git")
-        .args(["init"])
-        .current_dir(tmp)
-        .assert()
-        .success();
+    // Fake git repo so upskill uses project scope
+    fs::create_dir_all(tmp.join(".git")).unwrap();
 }
 
 #[test]
@@ -99,11 +95,7 @@ fn add_from_same_source_succeeds_without_force() {
     )
     .unwrap();
 
-    Command::new("git")
-        .args(["init"])
-        .current_dir(tmp.path())
-        .assert()
-        .success();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     Command::cargo_bin("upskill")
         .unwrap()
@@ -132,11 +124,7 @@ fn add_with_exclude_skips_named_item() {
     )
     .unwrap();
 
-    Command::new("git")
-        .args(["init"])
-        .current_dir(tmp.path())
-        .assert()
-        .success();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     Command::cargo_bin("upskill")
         .unwrap()
@@ -187,11 +175,7 @@ fn add_with_alias_installs_under_alternate_name() {
     )
     .unwrap();
 
-    Command::new("git")
-        .args(["init"])
-        .current_dir(tmp.path())
-        .assert()
-        .success();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     // Install with alias to avoid conflict
     Command::cargo_bin("upskill")
@@ -245,11 +229,7 @@ fn update_handles_aliased_items() {
     )
     .unwrap();
 
-    Command::new("git")
-        .args(["init"])
-        .current_dir(tmp.path())
-        .assert()
-        .success();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     // Update should succeed (finds original-skill in source, installs as my-alias)
     Command::cargo_bin("upskill")
@@ -301,11 +281,7 @@ fn update_dry_run_handles_aliased_items() {
     )
     .unwrap();
 
-    Command::new("git")
-        .args(["init"])
-        .current_dir(tmp.path())
-        .assert()
-        .success();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     // Dry-run should detect changes (hash differs)
     Command::cargo_bin("upskill")

--- a/tests/cli_conflict.rs
+++ b/tests/cli_conflict.rs
@@ -155,3 +155,163 @@ fn add_with_exclude_skips_named_item() {
         "expected no skill-b: {lock_content}"
     );
 }
+
+#[test]
+fn add_with_alias_installs_under_alternate_name() {
+    let tmp = TempDir::new().unwrap();
+
+    // Existing lockfile with item from different source (creates conflict)
+    let lockfile = serde_json::json!({
+        "schema": 1,
+        "items": [{
+            "kind": "skill",
+            "name": "test-skill",
+            "source": "github:org-a/repo-a",
+            "hash": "sha256:aaa"
+        }],
+        "bundles": [],
+        "plugins": []
+    });
+    fs::write(
+        tmp.path().join(".upskill-lock.json"),
+        serde_json::to_string_pretty(&lockfile).unwrap(),
+    )
+    .unwrap();
+
+    // Local source with the conflicting skill
+    let skill_dir = tmp.path().join("source/test-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: test-skill\ndescription: A test skill\n---\nContent here.\n",
+    )
+    .unwrap();
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Install with alias to avoid conflict
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source", "--as", "test-skill-v2"])
+        .assert()
+        .success();
+
+    // Verify lockfile has the alias with source_name
+    let lock_content = fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap();
+    assert!(
+        lock_content.contains("test-skill-v2"),
+        "expected alias in lockfile: {lock_content}"
+    );
+    assert!(
+        lock_content.contains("source_name") && lock_content.contains("test-skill"),
+        "expected source_name tracking: {lock_content}"
+    );
+}
+
+#[test]
+fn update_handles_aliased_items() {
+    let tmp = TempDir::new().unwrap();
+
+    // Create source with a skill
+    let skill_dir = tmp.path().join("source/original-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: original-skill\ndescription: Original skill\n---\nUpdated content v2.\n",
+    )
+    .unwrap();
+
+    // Lockfile with an aliased item (as if previously installed with --as)
+    let lockfile = serde_json::json!({
+        "schema": 1,
+        "items": [{
+            "kind": "skill",
+            "name": "my-alias",
+            "source": "local:./source",
+            "source_name": "original-skill",
+            "hash": "sha256:oldoldold"
+        }],
+        "bundles": [],
+        "plugins": []
+    });
+    fs::write(
+        tmp.path().join(".upskill-lock.json"),
+        serde_json::to_string_pretty(&lockfile).unwrap(),
+    )
+    .unwrap();
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Update should succeed (finds original-skill in source, installs as my-alias)
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["update"])
+        .assert()
+        .success();
+
+    // Verify the alias is preserved in lockfile
+    let lock_content = fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap();
+    assert!(
+        lock_content.contains("my-alias"),
+        "alias preserved: {lock_content}"
+    );
+    assert!(
+        lock_content.contains("source_name"),
+        "source_name preserved: {lock_content}"
+    );
+}
+
+#[test]
+fn update_dry_run_handles_aliased_items() {
+    let tmp = TempDir::new().unwrap();
+
+    let skill_dir = tmp.path().join("source/original-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: original-skill\ndescription: Changed\n---\nNew content.\n",
+    )
+    .unwrap();
+
+    let lockfile = serde_json::json!({
+        "schema": 1,
+        "items": [{
+            "kind": "skill",
+            "name": "my-alias",
+            "source": "local:./source",
+            "source_name": "original-skill",
+            "hash": "sha256:oldoldold"
+        }],
+        "bundles": [],
+        "plugins": []
+    });
+    fs::write(
+        tmp.path().join(".upskill-lock.json"),
+        serde_json::to_string_pretty(&lockfile).unwrap(),
+    )
+    .unwrap();
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Dry-run should detect changes (hash differs)
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["update", "--dry-run"])
+        .assert()
+        .success();
+}

--- a/tests/cli_conflict.rs
+++ b/tests/cli_conflict.rs
@@ -1,0 +1,157 @@
+//! Integration tests for item conflict detection and resolution flags.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+/// Set up a temp dir with a lockfile containing an item from source A,
+/// plus a local source directory with the same-named skill.
+fn setup_conflict(tmp: &std::path::Path) {
+    // Existing lockfile with item from a different source
+    let lockfile = serde_json::json!({
+        "schema": 1,
+        "items": [{
+            "kind": "skill",
+            "name": "test-skill",
+            "source": "github:org-a/repo-a",
+            "hash": "sha256:aaa"
+        }],
+        "bundles": [],
+        "plugins": []
+    });
+    fs::write(
+        tmp.join(".upskill-lock.json"),
+        serde_json::to_string_pretty(&lockfile).unwrap(),
+    )
+    .unwrap();
+
+    // Local source with a skill that will conflict
+    let skill_dir = tmp.join("source/test-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: test-skill\ndescription: A test skill\n---\nContent here.\n",
+    )
+    .unwrap();
+
+    // Init git repo so upskill uses project scope
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp)
+        .assert()
+        .success();
+}
+
+#[test]
+fn add_from_different_source_errors_without_force() {
+    let tmp = TempDir::new().unwrap();
+    setup_conflict(tmp.path());
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("already installed from"));
+}
+
+#[test]
+fn add_from_different_source_succeeds_with_force() {
+    let tmp = TempDir::new().unwrap();
+    setup_conflict(tmp.path());
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source", "--force"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn add_from_same_source_succeeds_without_force() {
+    let tmp = TempDir::new().unwrap();
+
+    // Lockfile with source matching what we'll install from (local:source)
+    let lockfile = serde_json::json!({
+        "schema": 1,
+        "items": [{
+            "kind": "skill",
+            "name": "test-skill",
+            "source": "local:./source",
+            "hash": "sha256:aaa"
+        }],
+        "bundles": [],
+        "plugins": []
+    });
+    fs::write(
+        tmp.path().join(".upskill-lock.json"),
+        serde_json::to_string_pretty(&lockfile).unwrap(),
+    )
+    .unwrap();
+
+    let skill_dir = tmp.path().join("source/test-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nschema: 1\nname: test-skill\ndescription: A test skill\n---\nContent here.\n",
+    )
+    .unwrap();
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn add_with_exclude_skips_named_item() {
+    let tmp = TempDir::new().unwrap();
+
+    let skill_a = tmp.path().join("source/skill-a");
+    let skill_b = tmp.path().join("source/skill-b");
+    fs::create_dir_all(&skill_a).unwrap();
+    fs::create_dir_all(&skill_b).unwrap();
+    fs::write(
+        skill_a.join("SKILL.md"),
+        "---\nschema: 1\nname: skill-a\ndescription: Skill A\n---\nA\n",
+    )
+    .unwrap();
+    fs::write(
+        skill_b.join("SKILL.md"),
+        "---\nschema: 1\nname: skill-b\ndescription: Skill B\n---\nB\n",
+    )
+    .unwrap();
+
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source", "--exclude", "skill-b"])
+        .assert()
+        .success();
+
+    let lock_content = fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap();
+    assert!(
+        lock_content.contains("skill-a"),
+        "expected skill-a: {lock_content}"
+    );
+    assert!(
+        !lock_content.contains("skill-b"),
+        "expected no skill-b: {lock_content}"
+    );
+}

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -140,6 +140,7 @@ fn install_preserves_unrelated_existing_entries() {
         source: "github:other/repo@v1.0".into(),
         git_ref: Some("v1.0".into()),
         hash: Some("a".repeat(64)),
+        source_name: None,
     });
     seed.save(&target).unwrap();
 

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -46,6 +46,7 @@ fn install_writes_lockfile_at_target_root() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -100,6 +101,7 @@ fn re_install_upserts_existing_entries() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install 1");
     let lock1: Lockfile =
@@ -111,6 +113,7 @@ fn re_install_upserts_existing_entries() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install 2");
     let lock2: Lockfile =
@@ -149,6 +152,7 @@ fn install_preserves_unrelated_existing_entries() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -177,6 +181,7 @@ fn install_creates_claude_bridge_when_absent() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -200,6 +205,7 @@ fn install_registers_opencode_rules_glob_when_rules_present() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -229,6 +235,7 @@ fn install_registers_vscode_instructions_location_when_rules_present() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -261,6 +268,7 @@ fn install_preserves_existing_claude_bridge() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -300,6 +308,7 @@ fn bundle_with_plugins_produces_plugin_results() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -346,6 +355,7 @@ fn cli_not_found_plugins_recorded_as_skipped_in_lockfile() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -413,6 +423,7 @@ fn plugin_results_carry_correct_metadata() {
         &target,
         &[],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -476,6 +487,7 @@ fn install_by_name_discovers_bundle_when_no_item_matches() {
         &target,
         &["with-plugins".into()],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 
@@ -513,6 +525,7 @@ fn install_by_name_errors_on_ambiguity() {
         &target,
         &["with-plugins".into()],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect_err("should error on ambiguity");
 
@@ -537,6 +550,7 @@ fn install_by_name_prefers_items_when_only_items_match() {
         &target,
         &["license-awareness".into()],
         PluginScope::Project,
+        &Default::default(),
     )
     .expect("install");
 


### PR DESCRIPTION
## Summary

Prevents accidental item overrides when installing from different sources. Items are now locked to their source by default.

## Changes

- **Conflict detection**: Installing an item that already exists from a different source now errors with actionable guidance
- **`--force` flag**: Overrides source lock to replace items
- **`--as <alias>` flag**: Installs under an alternate name to keep both
- **`--exclude <name>` flag**: Skips specific items during install
- **`source_name` lockfile field**: Tracks original name for aliased items so `update` works correctly
- **Update support**: `upskill update` correctly handles aliased items (fetches by source name, installs under alias)

## New files

- `src/conflict.rs` — conflict detection logic and error formatting

## Test coverage

- 7 integration tests in `tests/cli_conflict.rs`
- 4 unit tests in `src/conflict.rs`
- 2 unit tests for `source_name` serialization in `src/lockfile.rs`

## Design

See `docs/superpowers/specs/2026-05-24-item-conflict-resolution-design.md`