### PR TITLE
fix: P0 baseline bugs — path traversal, atomic writes, search hint

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -137,16 +137,38 @@ pub(crate) fn resolve_subfolder(
     name: &str,
 ) -> Result<PathBuf, String> {
     if let Some(sub) = subfolder {
-        let sub_path = clone_dir.join(sub);
-        // Subfolders are usually directories (item-root paths) but bundle
-        // sources point at a `<name>.bundle.yaml` file directly. Accept
-        // both — the install layer dispatches on file vs dir.
-        if !sub_path.exists() {
+        // Reject absolute paths and obvious traversal attempts before joining.
+        if sub.starts_with('/') || sub.starts_with('~') {
             return Err(format!(
-                "subfolder '{}' not found in {}/{}",
+                "subfolder '{}' in {}/{} must be a relative path (no leading '/' or '~')",
                 sub, owner, name
             ));
         }
+
+        let sub_path = clone_dir.join(sub);
+
+        // Canonicalize both paths and verify the subfolder stays within the
+        // clone directory. This catches `..` traversal and symlink escapes.
+        let canon_base = clone_dir.canonicalize().map_err(|e| {
+            format!(
+                "failed to canonicalize clone dir {}: {}",
+                clone_dir.display(),
+                e
+            )
+        })?;
+        let canon_sub = sub_path
+            .canonicalize()
+            .map_err(|_| format!("subfolder '{}' not found in {}/{}", sub, owner, name))?;
+        if !canon_sub.starts_with(&canon_base) {
+            return Err(format!(
+                "subfolder '{}' in {}/{} escapes the repository root",
+                sub, owner, name
+            ));
+        }
+
+        // Subfolders are usually directories (item-root paths) but bundle
+        // sources point at a `<name>.bundle.yaml` file directly. Accept
+        // both — the install layer dispatches on file vs dir.
         Ok(sub_path)
     } else {
         Ok(clone_dir.to_path_buf())
@@ -312,6 +334,54 @@ mod tests {
             .expect_err("must fail");
 
         assert!(err.contains("subfolder 'nonexistent' not found"));
+    }
+
+    #[test]
+    fn resolve_subfolder_rejects_absolute_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let clone_dir = tmp.path().join("cloned");
+        fs::create_dir_all(&clone_dir).unwrap();
+
+        let err = resolve_subfolder(&clone_dir, Some("/etc/passwd"), "test", "repo")
+            .expect_err("absolute path must fail");
+        assert!(err.contains("must be a relative path"));
+    }
+
+    #[test]
+    fn resolve_subfolder_rejects_tilde_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let clone_dir = tmp.path().join("cloned");
+        fs::create_dir_all(&clone_dir).unwrap();
+
+        let err = resolve_subfolder(&clone_dir, Some("~/something"), "test", "repo")
+            .expect_err("tilde path must fail");
+        assert!(err.contains("must be a relative path"));
+    }
+
+    #[test]
+    fn resolve_subfolder_rejects_dot_dot_escape() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let clone_dir = tmp.path().join("cloned");
+        fs::create_dir_all(&clone_dir).unwrap();
+        // Create a sibling directory that .. would reach
+        fs::create_dir_all(tmp.path().join("secret")).unwrap();
+
+        let err = resolve_subfolder(&clone_dir, Some("../../etc"), "test", "repo")
+            .expect_err("dot-dot escape must fail");
+        // Either "not found" (doesn't exist) or "escapes" (exists but outside)
+        assert!(err.contains("not found") || err.contains("escapes"));
+    }
+
+    #[test]
+    fn resolve_subfolder_allows_internal_dot_dot() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let clone_dir = tmp.path().join("cloned");
+        fs::create_dir_all(clone_dir.join("a/b")).unwrap();
+        fs::create_dir_all(clone_dir.join("c")).unwrap();
+
+        // a/../c resolves to c which is still inside clone_dir
+        let result = resolve_subfolder(&clone_dir, Some("a/../c"), "test", "repo");
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -217,8 +217,11 @@ impl Lockfile {
     pub fn save(&self, project_root: &Path) -> Result<()> {
         let path = lockfile_path(project_root);
         let json = serde_json::to_string_pretty(self).context("serialize lockfile")?;
-        std::fs::write(&path, format!("{json}\n"))
-            .with_context(|| format!("write {}", path.display()))
+        let tmp_path = path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, format!("{json}\n"))
+            .with_context(|| format!("write {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &path)
+            .with_context(|| format!("rename {} to {}", tmp_path.display(), path.display()))
     }
 }
 
@@ -342,6 +345,23 @@ mod tests {
 
         let loaded = Lockfile::load(tmp.path()).expect("load");
         assert_eq!(loaded, lock);
+    }
+
+    #[test]
+    fn save_is_atomic_no_tmp_file_remains() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut lock = Lockfile::new();
+        lock.upsert(item("skill", "test-atomic"));
+        lock.save(tmp.path()).expect("save");
+
+        // The .tmp file must not persist after a successful save.
+        let tmp_path = tmp.path().join(".upskill-lock.json.tmp");
+        assert!(
+            !tmp_path.exists(),
+            ".tmp file should not persist after save"
+        );
+        // The actual lockfile must exist.
+        assert!(tmp.path().join(LOCKFILE_NAME).exists());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1156,7 +1156,7 @@ fn run_search(query: &str, limit: usize, registry: Option<&str>, kind: Option<&s
                                 "  {}\t{}\t{}",
                                 style::name(&skill.name),
                                 style::dim(&format!("{} installs", skill.installs)),
-                                style::dim(&format!("upskill add {repo} --skill {}", skill.name))
+                                style::dim(&format!("upskill add {repo} {}", skill.name))
                             );
                         }
                     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1772,6 +1772,10 @@ fn install_skills(
         let audience = skill.audience.as_deref();
         let source_hash = hash_item_dir(&dir);
 
+        // Clean existing output directories for this specific item before
+        // writing new outputs. This removes stale sibling files (e.g. renamed
+        // resources) while keeping other items' outputs intact if generation
+        // fails later.
         remove_item_outputs(target, ItemKind::Skill, &name);
         for client in ALL_CLIENTS {
             if !targets(client, audience) {
@@ -1816,6 +1820,9 @@ fn install_rules(
         let audience = rule.audience.as_deref();
         let source_hash = hash_item_dir(&dir);
 
+        // Clean existing output directories for this specific item before
+        // writing new outputs. This removes stale sibling files while keeping
+        // other items' outputs intact if generation fails later.
         remove_item_outputs(target, ItemKind::Rule, &name);
         for client in ALL_CLIENTS {
             if !targets(client, audience) {
@@ -1860,6 +1867,9 @@ fn install_agents(
         let audience = agent.audience.as_deref();
         let source_hash = hash_item_dir(&dir);
 
+        // Clean existing output directories for this specific item before
+        // writing new outputs. This removes stale sibling files while keeping
+        // other items' outputs intact if generation fails later.
         remove_item_outputs(target, ItemKind::Agent, &name);
         for client in ALL_CLIENTS {
             if !targets(client, audience) {
@@ -1876,6 +1886,26 @@ fn install_agents(
                 output_path: rel,
                 source_hash: source_hash.clone(),
             });
+        }
+        // Clean up outputs for clients no longer targeted.
+        for client in ALL_CLIENTS {
+            if targets(client, audience) {
+                continue;
+            }
+            let rel = agent_output_path(client, &name);
+            let full = target.join(&rel);
+            if full.exists() {
+                let _ = fs::remove_file(&full);
+            }
+            if let Some(parent) = full.parent()
+                && parent
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .is_some_and(|f| f == name)
+                && parent.is_dir()
+            {
+                let _ = fs::remove_dir(parent);
+            }
         }
     }
     Ok(())

--- a/tests/cli_search.rs
+++ b/tests/cli_search.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
-use predicates::str::contains;
+use predicates::prelude::PredicateBooleanExt;
+use predicates::str::{contains, is_match};
 use std::io::{Read, Write};
 use tempfile::tempdir;
 
@@ -103,9 +104,10 @@ fn search_shows_install_command() {
         .args(["search", "rust"])
         .assert()
         .code(0)
-        .stdout(contains(
-            "upskill add awesome-copilot --skill rust-mcp-server-generator",
-        ));
+        // Positional syntax: `upskill add <source> <name>`
+        .stdout(is_match("upskill add \\S+ rust-mcp-server-generator").unwrap())
+        // Must NOT contain the old --skill flag
+        .stdout(predicates::str::contains("--skill").not());
 }
 
 #[test]


### PR DESCRIPTION
Closes #177, closes #178, closes #179

Epic: #176

## Changes

1. **fetch.rs**: Validate subfolder is relative and contained within clone root. Rejects absolute paths, tilde paths, and `../` traversal that escapes the repository boundary. Uses canonicalization to catch symlink escapes.

2. **lockfile.rs**: Write lockfile atomically via write-to-tmp + rename. Prevents partial/corrupt lockfile on crash between file write and save.

3. **pipeline.rs**: Added comments clarifying per-item output cleanup scope. Added post-generation cleanup for agent outputs when audience changes remove a client from targeting.

4. **main.rs**: Fix search install hint from `--skill` flag (invalid) to positional syntax `upskill add <source> <name>`.