### PR TITLE
chore: P1 baseline batch — available_skills, type-safe ItemKind, CONTRIBUTING.md

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,6 @@
   "MD024": {
     "siblings_only": true
   },
+  "MD033": false,
   "MD040": false
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,49 @@ Token resolution order:
   - When adding behavior, prefer extending the matching file or creating
     a new `cli_<area>.rs` / `pipeline_<area>.rs` / `generate_<area>.rs`.
 
+### Available skills
+
+Skills provide specialized instructions and workflows for specific tasks.
+Use the skill tool to load a skill when a task matches its description.
+
+<available_skills>
+<skill>
+<name>evaluating-prompts</name>
+<description>Use when setting up the RED-GREEN-REFACTOR cycle for a rule, skill, or subagent — i.e., when the `writing-*` skills tell you to "run a failing test first." Trigger when authoring meta-skills, when validating that an existing rule/skill/subagent actually shapes behavior, or when auditing whether a skill activates correctly. Do NOT trigger for content authoring itself — see writing-rules, writing-skills, writing-subagents.</description>
+<location>skills/evaluating-prompts/SKILL.md</location>
+</skill>
+<skill>
+<name>prompt-design</name>
+<description>Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to prompt-distilling, writing-rules, writing-skills, writing-subagents, or using-upskill.</description>
+<location>skills/prompt-design/SKILL.md</location>
+</skill>
+<skill>
+<name>prompt-distilling</name>
+<description>Use BEFORE authoring any rule, skill, or subagent. Trigger when someone says "we should encode X", "the agent keeps forgetting Y", "let's add a rule for Z", or any variant where new behavior needs to live somewhere in the framework. Also trigger when reviewing existing content that is misbehaving — wrong-layer placement is a common silent root cause. Do NOT trigger for refining content already correctly placed; hand off to writing-rules, writing-skills, or writing-subagents.</description>
+<location>skills/prompt-distilling/SKILL.md</location>
+</skill>
+<skill>
+<name>using-upskill</name>
+<description>Use when working in an upskill-consumer repo and needing to add, modify, vendor, audit, or remove installed content (rules, skills, agents, bundles). Trigger when `upskill lint` or `upskill doctor` reports issues. Trigger when adding a third-party bundle or updating one from upstream. Trigger when generated per-client files (e.g., `.claude/`, `.github/skills/`) look stale or wrong. Do NOT trigger for actual authoring decisions — hand off to prompt-distilling, writing-rules, writing-skills, or writing-subagents. Do NOT trigger for cosmetic typo fixes in skill bodies; raw edits to source registry files plus `upskill lint` are sufficient.</description>
+<location>skills/using-upskill/SKILL.md</location>
+</skill>
+<skill>
+<name>writing-rules</name>
+<description>Use when adding or editing rules in CLAUDE.md, AGENTS.md, or any always-loaded instructions file. Trigger when authoring repo conventions, invariants, or behavioral guardrails. Also trigger when an existing rule is being violated despite being present — that means the rule needs refactoring, not the agent. Do NOT trigger for skill or subagent authoring; see writing-skills and writing-subagents.</description>
+<location>skills/writing-rules/SKILL.md</location>
+</skill>
+<skill>
+<name>writing-skill-bundles</name>
+<description>Use when authoring or editing upskill .bundle.yaml manifests — declaring items, plugins, requires dependencies, naming conventions, or troubleshooting bundle resolution errors. Also use when adding plugin install declarations for client CLIs (Claude Code, Copilot, VS Code, opencode).</description>
+<location>skills/writing-skill-bundles/SKILL.md</location>
+</skill>
+<skill>
+<name>writing-subagents</name>
+<description>Use when designing a new subagent or modifying an existing one's system prompt, tool surface, or return contract. Trigger when the parent is observed doing work inline that should be delegated, OR when a subagent is observed dumping raw output, OR when subagent scope is drifting. Also trigger when designing managed/project-scoped/user-global subagent tiers with different permission models. Do NOT trigger for skill or rule authoring; see writing-skills and writing-rules.</description>
+<location>skills/writing-subagents/SKILL.md</location>
+</skill>
+</available_skills>
+
 ## Workflow
 
 Workflow model:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to upskill
+
+## Prerequisites
+
+| Tool       | Version                    | Install                        |
+| ---------- | -------------------------- | ------------------------------ |
+| Rust       | ≥ 1.85 (edition 2024 MSRV) | [rustup.rs](https://rustup.rs) |
+| just       | latest                     | `cargo install just`           |
+| dprint     | latest                     | `cargo install dprint`         |
+| shellcheck | latest                     | `brew install shellcheck`      |
+| mdbook     | latest                     | `cargo install mdbook`         |
+
+## Quick start
+
+```bash
+git clone https://github.com/driftsys/upskill.git
+cd upskill
+./bootstrap
+just build
+```
+
+## Daily workflow
+
+| Command       | Purpose                            |
+| ------------- | ---------------------------------- |
+| `just test`   | Run all tests                      |
+| `just fmt`    | Format Rust + Markdown             |
+| `just lint`   | Clippy + shellcheck + dprint check |
+| `just verify` | Full pre-commit check              |
+| `just build`  | Compile + check                    |
+
+## Branch model
+
+Normal git branches for humans. The `.claude/worktrees/` model is for AI
+agents only — see [AGENTS.md](AGENTS.md) for details.
+
+## Commit convention
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `refactor:` — code restructuring
+- `docs:` — documentation only
+- `test:` — test additions/changes
+- `chore:` — tooling, CI, dependencies
+
+Not enforced by hook — just documented.
+
+## PR checklist
+
+1. Run `just fmt && just verify` before opening.
+2. One PR per story/task.
+3. Keep code + tests + docs together.
+
+## AI agents
+
+See [AGENTS.md](AGENTS.md) for AI-specific conventions, issue model, and
+workflow rules.

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -26,9 +26,8 @@ pub fn detect_conflicts(
 ) -> Vec<ItemConflict> {
     let mut conflicts = Vec::new();
     for (kind, name) in incoming {
-        let kind_str = kind_to_str(*kind);
         for locked in &lockfile.items {
-            if locked.kind == kind_str && locked.name == *name && locked.source != incoming_source {
+            if locked.kind == *kind && locked.name == *name && locked.source != incoming_source {
                 conflicts.push(ItemConflict {
                     kind: *kind,
                     name: name.clone(),
@@ -51,9 +50,7 @@ pub fn format_conflict_error(conflicts: &[ItemConflict]) -> String {
             format!(
                 "{} `{}` is already installed from `{}`.\n\
                  Use --force to replace, or --as <alt-name> to keep both.",
-                kind_to_str(c.kind),
-                c.name,
-                c.existing_source,
+                c.kind, c.name, c.existing_source,
             )
         }
         _ => {
@@ -62,9 +59,7 @@ pub fn format_conflict_error(conflicts: &[ItemConflict]) -> String {
             for c in conflicts {
                 msg.push_str(&format!(
                     "  - {} `{}` (installed from `{}`)\n",
-                    kind_to_str(c.kind),
-                    c.name,
-                    c.existing_source,
+                    c.kind, c.name, c.existing_source,
                 ));
             }
             msg.push_str(
@@ -75,27 +70,19 @@ pub fn format_conflict_error(conflicts: &[ItemConflict]) -> String {
     }
 }
 
-fn kind_to_str(kind: ItemKind) -> &'static str {
-    match kind {
-        ItemKind::Rule => "rule",
-        ItemKind::Skill => "skill",
-        ItemKind::Agent => "agent",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::lockfile::Lockfile;
 
-    fn make_lockfile(items: Vec<(&str, &str, &str)>) -> Lockfile {
+    fn make_lockfile(items: Vec<(ItemKind, &str, &str)>) -> Lockfile {
         use crate::lockfile::LockedItem;
         Lockfile {
             schema: 1,
             items: items
                 .into_iter()
                 .map(|(kind, name, source)| LockedItem {
-                    kind: kind.to_owned(),
+                    kind,
                     name: name.to_owned(),
                     source: source.to_owned(),
                     git_ref: None,
@@ -110,7 +97,11 @@ mod tests {
 
     #[test]
     fn no_conflict_same_source() {
-        let lf = make_lockfile(vec![("skill", "brainstorming", "driftsys/superpowers")]);
+        let lf = make_lockfile(vec![(
+            ItemKind::Skill,
+            "brainstorming",
+            "driftsys/superpowers",
+        )]);
         let incoming = vec![(ItemKind::Skill, "brainstorming".to_owned())];
         let conflicts = detect_conflicts(&incoming, &lf, "driftsys/superpowers");
         assert!(conflicts.is_empty());
@@ -118,7 +109,11 @@ mod tests {
 
     #[test]
     fn conflict_different_source() {
-        let lf = make_lockfile(vec![("skill", "brainstorming", "driftsys/superpowers")]);
+        let lf = make_lockfile(vec![(
+            ItemKind::Skill,
+            "brainstorming",
+            "driftsys/superpowers",
+        )]);
         let incoming = vec![(ItemKind::Skill, "brainstorming".to_owned())];
         let conflicts = detect_conflicts(&incoming, &lf, "other/repo");
         assert_eq!(conflicts.len(), 1);
@@ -128,7 +123,7 @@ mod tests {
 
     #[test]
     fn no_conflict_item_not_in_lockfile() {
-        let lf = make_lockfile(vec![("skill", "debugging", "driftsys/superpowers")]);
+        let lf = make_lockfile(vec![(ItemKind::Skill, "debugging", "driftsys/superpowers")]);
         let incoming = vec![(ItemKind::Skill, "brainstorming".to_owned())];
         let conflicts = detect_conflicts(&incoming, &lf, "other/repo");
         assert!(conflicts.is_empty());
@@ -136,7 +131,11 @@ mod tests {
 
     #[test]
     fn same_name_different_kind_no_conflict() {
-        let lf = make_lockfile(vec![("rule", "brainstorming", "driftsys/superpowers")]);
+        let lf = make_lockfile(vec![(
+            ItemKind::Rule,
+            "brainstorming",
+            "driftsys/superpowers",
+        )]);
         let incoming = vec![(ItemKind::Skill, "brainstorming".to_owned())];
         let conflicts = detect_conflicts(&incoming, &lf, "other/repo");
         assert!(conflicts.is_empty());

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -37,7 +37,7 @@ pub struct Lockfile {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LockedItem {
     /// `rule` | `skill` | `agent`.
-    pub kind: String,
+    pub kind: ItemKind,
     pub name: String,
     /// Canonical source label (see [`crate::source::InstallSource`]'s
     /// `Display` impl).
@@ -185,7 +185,7 @@ impl Lockfile {
     }
 
     /// Remove by `(kind, name)`.
-    pub fn remove(&mut self, kind: &str, name: &str) {
+    pub fn remove(&mut self, kind: ItemKind, name: &str) {
         self.items
             .retain(|existing| !(existing.kind == kind && existing.name == name));
     }
@@ -252,7 +252,7 @@ pub fn items_from_report(
             continue;
         }
         out.push(LockedItem {
-            kind: kind_label(entry.kind).to_string(),
+            kind: entry.kind,
             name: entry.name.clone(),
             source: source_label.to_string(),
             git_ref: git_ref.map(str::to_string),
@@ -263,14 +263,6 @@ pub fn items_from_report(
     out
 }
 
-fn kind_label(kind: ItemKind) -> &'static str {
-    match kind {
-        ItemKind::Rule => "rule",
-        ItemKind::Skill => "skill",
-        ItemKind::Agent => "agent",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,9 +270,9 @@ mod tests {
     use crate::pipeline::InstalledItem;
     use std::path::PathBuf;
 
-    fn item(kind: &str, name: &str) -> LockedItem {
+    fn item(kind: ItemKind, name: &str) -> LockedItem {
         LockedItem {
-            kind: kind.to_string(),
+            kind,
             name: name.to_string(),
             source: "github:driftsys/skills".to_string(),
             git_ref: Some("v1.0.0".to_string()),
@@ -300,8 +292,8 @@ mod tests {
     #[test]
     fn upsert_replaces_existing_item_with_same_kind_and_name() {
         let mut lock = Lockfile::new();
-        lock.upsert(item("skill", "code-review"));
-        let mut updated = item("skill", "code-review");
+        lock.upsert(item(ItemKind::Skill, "code-review"));
+        let mut updated = item(ItemKind::Skill, "code-review");
         updated.git_ref = Some("v2.0.0".to_string());
         lock.upsert(updated);
         assert_eq!(lock.items.len(), 1);
@@ -312,16 +304,16 @@ mod tests {
     fn upsert_keeps_distinct_kinds_separate() {
         // A rule and a skill with the same name MUST coexist.
         let mut lock = Lockfile::new();
-        lock.upsert(item("rule", "shared-name"));
-        lock.upsert(item("skill", "shared-name"));
+        lock.upsert(item(ItemKind::Rule, "shared-name"));
+        lock.upsert(item(ItemKind::Skill, "shared-name"));
         assert_eq!(lock.items.len(), 2);
     }
 
     #[test]
     fn items_are_sorted_for_deterministic_output() {
         let mut lock = Lockfile::new();
-        lock.upsert(item("skill", "z"));
-        lock.upsert(item("skill", "a"));
+        lock.upsert(item(ItemKind::Skill, "z"));
+        lock.upsert(item(ItemKind::Skill, "a"));
         let names: Vec<_> = lock.items.iter().map(|i| i.name.as_str()).collect();
         assert_eq!(names, vec!["a", "z"]);
     }
@@ -329,18 +321,18 @@ mod tests {
     #[test]
     fn remove_filters_by_kind_and_name() {
         let mut lock = Lockfile::new();
-        lock.upsert(item("rule", "shared-name"));
-        lock.upsert(item("skill", "shared-name"));
-        lock.remove("rule", "shared-name");
+        lock.upsert(item(ItemKind::Rule, "shared-name"));
+        lock.upsert(item(ItemKind::Skill, "shared-name"));
+        lock.remove(ItemKind::Rule, "shared-name");
         assert_eq!(lock.items.len(), 1);
-        assert_eq!(lock.items[0].kind, "skill");
+        assert_eq!(lock.items[0].kind, ItemKind::Skill);
     }
 
     #[test]
     fn save_and_load_roundtrip() {
         let tmp = tempfile::tempdir().unwrap();
         let mut lock = Lockfile::new();
-        lock.upsert(item("skill", "code-review"));
+        lock.upsert(item(ItemKind::Skill, "code-review"));
         lock.save(tmp.path()).expect("save");
 
         let loaded = Lockfile::load(tmp.path()).expect("load");
@@ -351,7 +343,7 @@ mod tests {
     fn save_is_atomic_no_tmp_file_remains() {
         let tmp = tempfile::tempdir().unwrap();
         let mut lock = Lockfile::new();
-        lock.upsert(item("skill", "test-atomic"));
+        lock.upsert(item(ItemKind::Skill, "test-atomic"));
         lock.save(tmp.path()).expect("save");
 
         // The .tmp file must not persist after a successful save.
@@ -426,7 +418,7 @@ mod tests {
             Some("sha256:abc".into())
         });
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].kind, "skill");
+        assert_eq!(items[0].kind, ItemKind::Skill);
         assert_eq!(items[0].name, "code-review");
         assert_eq!(items[0].source, "local:./src");
         assert_eq!(items[0].hash, Some("sha256:abc".into()));
@@ -565,7 +557,7 @@ mod tests {
     #[test]
     fn locked_item_serializes_source_name_when_present() {
         let item = LockedItem {
-            kind: "skill".to_string(),
+            kind: ItemKind::Skill,
             name: "brainstorming-v2".to_string(),
             source: "github:other-org/repo".to_string(),
             git_ref: None,
@@ -579,7 +571,7 @@ mod tests {
     #[test]
     fn locked_item_omits_source_name_when_none() {
         let item = LockedItem {
-            kind: "skill".to_string(),
+            kind: ItemKind::Skill,
             name: "brainstorming".to_string(),
             source: "github:driftsys/superpowers".to_string(),
             git_ref: None,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -21,7 +21,7 @@
 //! restricts emission to listed clients; absence means all clients.
 
 use anyhow::{Context, Result, anyhow};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -32,12 +32,44 @@ use crate::model::{Agent, Audience, Rule, Skill};
 use crate::parse::frontmatter;
 use crate::source::{GithubRepo, GitlabRepo, InstallSource};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ItemKind {
     Rule,
     Skill,
     Agent,
+}
+
+impl std::fmt::Display for ItemKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rule => write!(f, "rule"),
+            Self::Skill => write!(f, "skill"),
+            Self::Agent => write!(f, "agent"),
+        }
+    }
+}
+
+impl std::str::FromStr for ItemKind {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "rule" => Ok(Self::Rule),
+            "skill" => Ok(Self::Skill),
+            "agent" => Ok(Self::Agent),
+            other => anyhow::bail!("unknown item kind: {other}"),
+        }
+    }
+}
+
+impl ItemKind {
+    pub fn entrypoint_filename(self) -> &'static str {
+        match self {
+            Self::Rule => "RULE.md",
+            Self::Skill => "SKILL.md",
+            Self::Agent => "AGENT.md",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -901,8 +933,7 @@ pub fn remove(target: &Path, filter: RemoveFilter) -> Result<RemoveReport> {
 
     let mut report = RemoveReport::default();
     for entry in &to_remove {
-        let kind = parse_kind(&entry.kind)
-            .with_context(|| format!("lockfile entry {}: unknown kind", entry.name))?;
+        let kind = entry.kind;
         let mut deleted_files = Vec::new();
         for client in ALL_CLIENTS {
             let rel = output_path(kind, client, &entry.name);
@@ -915,7 +946,7 @@ pub fn remove(target: &Path, filter: RemoveFilter) -> Result<RemoveReport> {
                 }
             }
         }
-        lock.remove(&entry.kind, &entry.name);
+        lock.remove(entry.kind, &entry.name);
         report.items.push(RemovedItem {
             kind,
             name: entry.name.clone(),
@@ -957,15 +988,6 @@ pub fn remove(target: &Path, filter: RemoveFilter) -> Result<RemoveReport> {
 
     lock.save(target)?;
     Ok(report)
-}
-
-fn parse_kind(s: &str) -> Result<ItemKind> {
-    match s {
-        "skill" => Ok(ItemKind::Skill),
-        "rule" => Ok(ItemKind::Rule),
-        "agent" => Ok(ItemKind::Agent),
-        other => anyhow::bail!("unknown kind `{other}`"),
-    }
 }
 
 /// One per-client output file the lockfile said should exist but doesn't.
@@ -1082,12 +1104,7 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
     let mut report = DoctorReport::default();
 
     for entry in &lock.items {
-        let kind = parse_kind(&entry.kind).with_context(|| {
-            format!(
-                "lockfile entry {}: unknown kind `{}`",
-                entry.name, entry.kind
-            )
-        })?;
+        let kind = entry.kind;
 
         let mut missing = Vec::new();
         for client in ALL_CLIENTS {
@@ -1350,7 +1367,7 @@ pub fn update(
                 // Collect orphans first, then batch-remove from lockfile.
                 let mut orphans: Vec<(&crate::lockfile::LockedItem, ItemKind)> = Vec::new();
                 for entry in &source_entries {
-                    let kind = parse_kind(&entry.kind)?;
+                    let kind = entry.kind;
                     if !new_hashes.contains_key(&(kind, entry.name.clone())) {
                         orphans.push((entry, kind));
                     }
@@ -1359,7 +1376,7 @@ pub fn update(
                     let mut lock = crate::lockfile::Lockfile::load(target)?;
                     for (entry, kind) in &orphans {
                         remove_item_outputs(target, *kind, &entry.name);
-                        lock.remove(&entry.kind, &entry.name);
+                        lock.remove(entry.kind, &entry.name);
                         report.items.push(UpdatedItem {
                             kind: *kind,
                             name: entry.name.clone(),
@@ -1370,7 +1387,7 @@ pub fn update(
                     lock.save(target)?;
                 }
                 for entry in &source_entries {
-                    let kind = parse_kind(&entry.kind)?;
+                    let kind = entry.kind;
                     if !new_hashes.contains_key(&(kind, entry.name.clone())) {
                         continue; // already handled as orphan
                     }
@@ -1398,7 +1415,7 @@ pub fn update(
                 let (root, _guard) = fetch_ssot(&source)?;
                 let new_hashes = hash_source_items(&root);
                 for entry in &source_entries {
-                    let kind = parse_kind(&entry.kind)?;
+                    let kind = entry.kind;
                     let lookup_name = entry.source_name.as_deref().unwrap_or(&entry.name);
                     if !new_hashes.contains_key(&(kind, lookup_name.to_string())) {
                         report.items.push(UpdatedItem {
@@ -1519,12 +1536,7 @@ pub fn list(target: &Path) -> Result<ListReport> {
     let lock = crate::lockfile::Lockfile::load(target)?;
     let mut report = ListReport::default();
     for entry in &lock.items {
-        let kind = parse_kind(&entry.kind).with_context(|| {
-            format!(
-                "lockfile entry {}: unknown kind `{}`",
-                entry.name, entry.kind
-            )
-        })?;
+        let kind = entry.kind;
         let listed = ListedItem {
             kind,
             name: entry.name.clone(),
@@ -2239,26 +2251,6 @@ mod tests {
         assert_eq!(percent_encode_userinfo("@"), "%40");
         assert_eq!(percent_encode_userinfo("/"), "%2F");
         assert_eq!(percent_encode_userinfo("%"), "%25");
-    }
-
-    #[test]
-    fn parse_kind_round_trips_lockfile_strings() {
-        // The labels written by `lockfile::items_from_report` MUST round-
-        // trip through `parse_kind` so `remove` can dispatch on them.
-        for k in [ItemKind::Rule, ItemKind::Skill, ItemKind::Agent] {
-            let label = match k {
-                ItemKind::Rule => "rule",
-                ItemKind::Skill => "skill",
-                ItemKind::Agent => "agent",
-            };
-            assert_eq!(parse_kind(label).unwrap(), k);
-        }
-    }
-
-    #[test]
-    fn parse_kind_rejects_unknown_string() {
-        let err = parse_kind("bundle").expect_err("must reject");
-        assert!(err.to_string().contains("bundle"));
     }
 
     #[test]

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -81,7 +81,7 @@ fn install_writes_lockfile_at_target_root() {
     let keys: Vec<_> = parsed
         .items
         .iter()
-        .map(|i| (i.kind.as_str(), i.name.as_str()))
+        .map(|i| (i.kind, i.name.as_str()))
         .collect();
     let mut sorted = keys.clone();
     sorted.sort();
@@ -138,7 +138,7 @@ fn install_preserves_unrelated_existing_entries() {
     // Pre-seed the lockfile with an entry from a different source.
     let mut seed = Lockfile::new();
     seed.upsert(LockedItem {
-        kind: "skill".into(),
+        kind: upskill::pipeline::ItemKind::Skill,
         name: "from-other-source".into(),
         source: "github:other/repo@v1.0".into(),
         git_ref: Some("v1.0".into()),


### PR DESCRIPTION
Closes #185, closes #182, closes #183

Epic: #176

## Changes

1. **AGENTS.md**: Add `<available_skills>` block listing all bundled skills
2. **model/lockfile/pipeline/conflict**: Type-safe `ItemKind` with Display/FromStr/serde, delete scattered kind_label/parse_kind free functions
3. **CONTRIBUTING.md**: Human contributor onboarding with toolchain prereqs
4. **.markdownlint.json**: Disable MD033 (inline HTML) for XML blocks in AGENTS.md
