### PR TITLE
refactor: P1 batch 2 — unify install, docs fixes, UX hints

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,3 +15,15 @@
 
 - [Specification](specification.md)
 - [Portable format](format-spec.md)
+
+# Architecture Decisions
+
+- [ADR-0000: Implementation baseline](adr/0000-implementation-baseline.md)
+- [ADR-0001: Multi-kind compiler architecture](adr/0001-multi-kind-compiler-architecture.md)
+- [ADR-0002: Portable content format](adr/0002-portable-content-format.md)
+- [ADR-0003: SSOT-to-client generation pipeline](adr/0003-generation-pipeline.md)
+- [ADR-0004: CLI surface](adr/0004-cli-surface.md)
+- [ADR-0005: skills.sh ecosystem interop](adr/0005-skills-sh-ecosystem-interop.md)
+- [ADR-0006: Flat item layout](adr/0006-flat-item-layout.md)
+- [ADR-0007: Bundle file format](adr/0007-bundle-yaml-format.md)
+- [ADR-0008: Plugin installation](adr/0008-plugin-install-shellout.md)

--- a/docs/adr/0004-cli-surface.md
+++ b/docs/adr/0004-cli-surface.md
@@ -24,8 +24,8 @@ This ADR is one of four child ADRs of [ADR-0001](./0001-multi-kind-compiler-arch
 upskill add <source> [items...]    Install content from any source.
 upskill remove [<name>]            Remove installed content.
 upskill update [<name>]            Pull latest, regenerate changed items.
-upskill list [--available]         Show installed (or available) content.
-upskill info <name>                Show item/bundle details.
+upskill list [--json]              Show installed content.
+upskill search <query>             Search the public registry.
 upskill new <kind> <name>          Scaffold a new rule/skill/agent.
 upskill doctor                     Verify installation consistency.
 upskill lint [paths...]            Validate SSOT files.
@@ -157,3 +157,9 @@ partial cases without TTY interaction (also: scriptable, CI-friendly).
 - Sibling ADRs: [ADR-0002](./0002-portable-content-format.md),
   [ADR-0003](./0003-generation-pipeline.md),
   [ADR-0005](./0005-skills-sh-ecosystem-interop.md)
+
+## Amendments
+
+- **2026-05-24**: Replace `info <name>` with `search <query>` (implemented
+  as skills.sh API search). Change `list [--available]` to `list [--json]`;
+  `--available` is deferred to a future release.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,12 +21,12 @@
 
 These work on every subcommand:
 
-| Flag              | Effect                                                              |
-| ----------------- | ------------------------------------------------------------------- |
-| `--no-color`      | Disable colored output. Honored alongside `NO_COLOR`, `TERM=dumb`.  |
-| `-q`, `--quiet`   | Suppress informational stdout. Errors and exit codes are unchanged. |
-| `-h`, `--help`    | Show help.                                                          |
-| `-V`, `--version` | Show version.                                                       |
+| Flag              | Effect                                                                                 |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| `--no-color`      | Disable colored output. Honored alongside `NO_COLOR`, `UPSKILL_NO_COLOR`, `TERM=dumb`. |
+| `-q`, `--quiet`   | Suppress informational stdout. Errors and exit codes are unchanged.                    |
+| `-h`, `--help`    | Show help.                                                                             |
+| `-V`, `--version` | Show version.                                                                          |
 
 ## Consumer commands
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -1,6 +1,6 @@
 # Portable Format for AI-Assistance Content
 
-**Version**: 0.2.0-draft
+**Version**: 0.6.0
 **Status**: Draft
 **Date**: 2026-05-13
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -248,7 +248,8 @@ and across-repo continuity for global scope.
       "ref": "v0.4.0",
       "items": ["code-review", "secret-scanner"]
     }
-  ]
+  ],
+  "plugins": []
 }
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,10 +103,8 @@ fn install_signal_handlers() -> anyhow::Result<()> {
         // ensures the `was_interrupted()` check in main() sees true even
         // if the eprintln races with process teardown.
         INTERRUPTED.store(true, Ordering::SeqCst);
-        // clig.dev §"Responsiveness": say something before cleanup so
-        // the user knows their Ctrl-C registered. Stderr only — never
-        // touches stdout-as-data.
         eprintln!("\n{} cleaning up", style::warn("interrupted:"));
+        eprintln!("  hint: run 'upskill doctor' to check for partial installs");
     })
     .context("failed to install signal handler")
 }
@@ -168,6 +166,12 @@ fn run_add(
         excludes: excludes.to_vec(),
     };
 
+    let is_global = global || (!project && !is_inside_git_repo());
+    let scope_label = if is_global { "global" } else { "project" };
+    if !style::is_quiet() {
+        eprintln!("scope: {} ({})", scope_label, target.display());
+    }
+
     print_install_progress(&parsed);
     match install_with_lockfile(&parsed, &target, items, plugin_scope, &options) {
         Ok(report) => {
@@ -177,6 +181,8 @@ fn run_add(
         }
         Err(err) => {
             print_error_chain(&err);
+            eprintln!();
+            eprintln!("  hint: run 'upskill doctor' to check for inconsistencies");
             EXIT_ERROR
         }
     }
@@ -489,6 +495,8 @@ fn run_remove(
         }
         Err(err) => {
             print_error_chain(&err);
+            eprintln!();
+            eprintln!("  hint: run 'upskill doctor' to check for inconsistencies");
             EXIT_ERROR
         }
     }
@@ -542,6 +550,8 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
             }
             Err(err) => {
                 print_error_chain(&err);
+                eprintln!();
+                eprintln!("  hint: run 'upskill doctor' to check for inconsistencies");
                 EXIT_ERROR
             }
         }
@@ -554,6 +564,8 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
             }
             Err(err) => {
                 print_error_chain(&err);
+                eprintln!();
+                eprintln!("  hint: run 'upskill doctor' to check for inconsistencies");
                 EXIT_ERROR
             }
         }
@@ -563,6 +575,8 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
             Ok(r) => r,
             Err(err) => {
                 print_error_chain(&err);
+                eprintln!();
+                eprintln!("  hint: run 'upskill doctor' to check for inconsistencies");
                 return EXIT_ERROR;
             }
         };
@@ -595,6 +609,8 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
             }
             Err(err) => {
                 print_error_chain(&err);
+                eprintln!();
+                eprintln!("  hint: run 'upskill doctor' to check for inconsistencies");
                 EXIT_ERROR
             }
         }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -152,9 +152,9 @@ pub fn install_from_local_path(
         return install_bundle_file(source, target);
     }
     let mut report = InstallReport::default();
-    install_skills(source, target, &mut report, filter)?;
-    install_rules(source, target, &mut report, filter)?;
-    install_agents(source, target, &mut report, filter)?;
+    for kind in [ItemKind::Skill, ItemKind::Rule, ItemKind::Agent] {
+        install_items_of_kind(kind, source, target, &mut report, filter)?;
+    }
     Ok(report)
 }
 
@@ -187,9 +187,15 @@ fn install_bundle_file(bundle_path: &Path, target: &Path) -> Result<InstallRepor
         bundles: resolved.bundles.clone(),
         ..InstallReport::default()
     };
-    install_skills(&registry_root, target, &mut report, Some(&resolved.items))?;
-    install_rules(&registry_root, target, &mut report, Some(&resolved.items))?;
-    install_agents(&registry_root, target, &mut report, Some(&resolved.items))?;
+    for kind in [ItemKind::Skill, ItemKind::Rule, ItemKind::Agent] {
+        install_items_of_kind(
+            kind,
+            &registry_root,
+            target,
+            &mut report,
+            Some(&resolved.items),
+        )?;
+    }
     Ok(report)
 }
 
@@ -1761,150 +1767,102 @@ pub fn install_from_git_url(
     install_from_local_path(&source, target, filter)
 }
 
-fn install_skills(
+fn install_items_of_kind(
+    kind: ItemKind,
     source: &Path,
     target: &Path,
     report: &mut InstallReport,
     filter: Option<&crate::bundle::ResolvedItems>,
 ) -> Result<()> {
+    let entrypoint = kind.entrypoint_filename();
     for (name, dir) in iter_item_dirs(source)? {
         if let Some(items) = filter
-            && !items.contains(ItemKind::Skill, &name)
+            && !items.contains(kind, &name)
         {
             continue;
         }
-        let entry_path = dir.join("SKILL.md");
+        let entry_path = dir.join(entrypoint);
         if !entry_path.exists() {
             continue;
         }
         let raw = fs::read_to_string(&entry_path)
             .with_context(|| format!("read {}", entry_path.display()))?;
-        let (skill, body) = frontmatter::parse::<Skill>(&raw)
-            .with_context(|| format!("parse {}", entry_path.display()))?;
-        let audience = skill.audience.as_deref();
-        let source_hash = hash_item_dir(&dir);
 
-        // Clean existing output directories for this specific item before
-        // writing new outputs. This removes stale sibling files (e.g. renamed
-        // resources) while keeping other items' outputs intact if generation
-        // fails later.
-        remove_item_outputs(target, ItemKind::Skill, &name);
-        for client in ALL_CLIENTS {
-            if !targets(client, audience) {
-                continue;
+        // Parse frontmatter, extract audience, and define a render helper.
+        // Each kind has its own model type, so we dispatch here.
+        let (audience, renders): (Option<Vec<Audience>>, Vec<(Client, String)>) = match kind {
+            ItemKind::Skill => {
+                let (skill, body) = frontmatter::parse::<Skill>(&raw)
+                    .with_context(|| format!("parse {}", entry_path.display()))?;
+                let aud = skill.audience.clone();
+                let mut out = Vec::new();
+                for client in ALL_CLIENTS {
+                    if !targets(client, aud.as_deref()) {
+                        continue;
+                    }
+                    let rendered = generate::render_skill(&skill, body, client)
+                        .with_context(|| format!("render skill {} for {:?}", name, client))?;
+                    out.push((client, rendered));
+                }
+                (aud, out)
             }
-            let rendered = generate::render_skill(&skill, body, client)
-                .with_context(|| format!("render skill {} for {:?}", name, client))?;
-            let rel = skill_output_path(client, &name);
-            write_output(target, &rel, &rendered)?;
-            report.items.push(InstalledItem {
-                kind: ItemKind::Skill,
-                name: name.clone(),
-                client,
-                output_path: rel,
-                source_hash: source_hash.clone(),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn install_rules(
-    source: &Path,
-    target: &Path,
-    report: &mut InstallReport,
-    filter: Option<&crate::bundle::ResolvedItems>,
-) -> Result<()> {
-    for (name, dir) in iter_item_dirs(source)? {
-        if let Some(items) = filter
-            && !items.contains(ItemKind::Rule, &name)
-        {
-            continue;
-        }
-        let entry_path = dir.join("RULE.md");
-        if !entry_path.exists() {
-            continue;
-        }
-        let raw = fs::read_to_string(&entry_path)
-            .with_context(|| format!("read {}", entry_path.display()))?;
-        let (rule, body) = frontmatter::parse::<Rule>(&raw)
-            .with_context(|| format!("parse {}", entry_path.display()))?;
-        let audience = rule.audience.as_deref();
-        let source_hash = hash_item_dir(&dir);
-
-        // Clean existing output directories for this specific item before
-        // writing new outputs. This removes stale sibling files while keeping
-        // other items' outputs intact if generation fails later.
-        remove_item_outputs(target, ItemKind::Rule, &name);
-        for client in ALL_CLIENTS {
-            if !targets(client, audience) {
-                continue;
+            ItemKind::Rule => {
+                let (rule, body) = frontmatter::parse::<Rule>(&raw)
+                    .with_context(|| format!("parse {}", entry_path.display()))?;
+                let aud = rule.audience.clone();
+                let mut out = Vec::new();
+                for client in ALL_CLIENTS {
+                    if !targets(client, aud.as_deref()) {
+                        continue;
+                    }
+                    let rendered = generate::render_rule(&rule, body, client)
+                        .with_context(|| format!("render rule {} for {:?}", name, client))?;
+                    out.push((client, rendered));
+                }
+                (aud, out)
             }
-            let rendered = generate::render_rule(&rule, body, client)
-                .with_context(|| format!("render rule {} for {:?}", name, client))?;
-            let rel = rule_output_path(client, &name);
-            write_output(target, &rel, &rendered)?;
-            report.items.push(InstalledItem {
-                kind: ItemKind::Rule,
-                name: name.clone(),
-                client,
-                output_path: rel,
-                source_hash: source_hash.clone(),
-            });
-        }
-    }
-    Ok(())
-}
+            ItemKind::Agent => {
+                let (agent, body) = frontmatter::parse::<Agent>(&raw)
+                    .with_context(|| format!("parse {}", entry_path.display()))?;
+                let aud = agent.audience.clone();
+                let mut out = Vec::new();
+                for client in ALL_CLIENTS {
+                    if !targets(client, aud.as_deref()) {
+                        continue;
+                    }
+                    let rendered = generate::render_agent(&agent, body, client)
+                        .with_context(|| format!("render agent {} for {:?}", name, client))?;
+                    out.push((client, rendered));
+                }
+                (aud, out)
+            }
+        };
 
-fn install_agents(
-    source: &Path,
-    target: &Path,
-    report: &mut InstallReport,
-    filter: Option<&crate::bundle::ResolvedItems>,
-) -> Result<()> {
-    for (name, dir) in iter_item_dirs(source)? {
-        if let Some(items) = filter
-            && !items.contains(ItemKind::Agent, &name)
-        {
-            continue;
-        }
-        let entry_path = dir.join("AGENT.md");
-        if !entry_path.exists() {
-            continue;
-        }
-        let raw = fs::read_to_string(&entry_path)
-            .with_context(|| format!("read {}", entry_path.display()))?;
-        let (agent, body) = frontmatter::parse::<Agent>(&raw)
-            .with_context(|| format!("parse {}", entry_path.display()))?;
-        let audience = agent.audience.as_deref();
         let source_hash = hash_item_dir(&dir);
 
         // Clean existing output directories for this specific item before
         // writing new outputs. This removes stale sibling files while keeping
         // other items' outputs intact if generation fails later.
-        remove_item_outputs(target, ItemKind::Agent, &name);
-        for client in ALL_CLIENTS {
-            if !targets(client, audience) {
-                continue;
-            }
-            let rendered = generate::render_agent(&agent, body, client)
-                .with_context(|| format!("render agent {} for {:?}", name, client))?;
-            let rel = agent_output_path(client, &name);
-            write_output(target, &rel, &rendered)?;
+        remove_item_outputs(target, kind, &name);
+
+        for (client, rendered) in &renders {
+            let rel = output_path(kind, *client, &name);
+            write_output(target, &rel, rendered)?;
             report.items.push(InstalledItem {
-                kind: ItemKind::Agent,
+                kind,
                 name: name.clone(),
-                client,
+                client: *client,
                 output_path: rel,
                 source_hash: source_hash.clone(),
             });
         }
+
         // Clean up outputs for clients no longer targeted.
         for client in ALL_CLIENTS {
-            if targets(client, audience) {
+            if targets(client, audience.as_deref()) {
                 continue;
             }
-            let rel = agent_output_path(client, &name);
+            let rel = output_path(kind, client, &name);
             let full = target.join(&rel);
             if full.exists() {
                 let _ = fs::remove_file(&full);


### PR DESCRIPTION
Closes #181, closes #187, closes #188

Epic: #176

## Changes

1. **pipeline.rs**: Unify `install_skills/rules/agents` into single parameterized `install_items_of_kind`
2. **docs/**: Fix stale ADR-0004, add plugins to lockfile spec, add ADRs to SUMMARY.md, update format-spec version, document UPSKILL_NO_COLOR
3. **main.rs**: Surface `upskill doctor` in error messages, print resolved scope on install, add hint to Ctrl-C handler