### PR TITLE
feat: P1 batch 3 — CLI discoverability, skill output contracts

### DIFF
--- a/skills/evaluating-prompts/SKILL.md
+++ b/skills/evaluating-prompts/SKILL.md
@@ -148,8 +148,6 @@ scope creep.
 
 Evaluation requires a clean room: a fresh agent with only the prompt
 under test loaded, no carryover context, no memory of previous runs.
-In Claude Code, this means spawning a subagent. In other clients with
-no native subagent, this means a fresh session or a separate process.
 
 The harness must:
 
@@ -162,10 +160,16 @@ The harness must:
   LLMs are stochastic. A scenario that passes once and fails twice
   is failing.
 
-For meta-skills like the writing-* set, the harness can be informal:
-spawn a subagent with the prompt, paste in the scenario, read the
-output. For production rollouts to 100+ repos, a more formal harness
-is justified — but the methodology is the same.
+<!-- @client:claude -->
+
+In Claude Code, the clean room is a subagent: spawn a fresh subagent
+with only the prompt under test loaded. For meta-skills like the
+writing-* set, the harness can be informal: spawn a subagent with the
+prompt, paste in the scenario, read the output. For production rollouts
+to 100+ repos, a more formal harness is justified — but the methodology
+is the same.
+
+<!-- @endclient -->
 
 ## Pressure scenario construction
 
@@ -316,3 +320,10 @@ the existing meta-skills (`writing-rules`, `writing-subagents`,
 when applied to those four, this skill earns its slot. If authors
 end up evaluating prompts the same way regardless of whether this
 skill is present, the skill itself is unjustified.
+
+## You Are Done When
+
+- At least one scenario file exists in `eval/`
+- RED phase: the scenario fails without the content
+- GREEN phase: the scenario passes with the content
+- The rationalization table documents activation precision

--- a/skills/prompt-design/SKILL.md
+++ b/skills/prompt-design/SKILL.md
@@ -167,3 +167,8 @@ own skill later. This skill has not yet been through its own
 RED-GREEN-REFACTOR cycle; the bet is that an explicit entry point
 reduces the activation cost of the discipline enough to be worth its
 slot.
+
+## You Are Done When
+
+- The author's intent is classified (new content vs. debugging vs. cross-cutting)
+- You have routed to the correct downstream skill

--- a/skills/prompt-distilling/SKILL.md
+++ b/skills/prompt-distilling/SKILL.md
@@ -256,3 +256,9 @@ expert-classified correct distillations and placements, run them past
 an author subagent without the skill present, then with, and measure
 the delta. If authors already distill and place correctly without the
 skill, the skill itself is unjustified.
+
+## You Are Done When
+
+- The behavior is classified into exactly one layer (rule, skill, or subagent)
+- The rationale for placement is documented
+- You have handed off to the appropriate `writing-*` skill

--- a/skills/using-upskill/SKILL.md
+++ b/skills/using-upskill/SKILL.md
@@ -271,3 +271,10 @@ scenarios (author a new skill, add a bundle, update from upstream,
 audit, hand-edit a generated file) past a subagent without the skill,
 then with, and measure whether the agent makes correct workflow
 decisions in both cases.
+
+## You Are Done When
+
+- The lifecycle operation completed successfully (`add`, `update`, `remove`, etc.)
+- `upskill doctor` reports clean state (exit 0)
+- Generated per-client files are committed alongside `.upskill-lock.json`
+- No hand-edited generated files remain

--- a/skills/writing-rules/SKILL.md
+++ b/skills/writing-rules/SKILL.md
@@ -133,3 +133,10 @@ yet been validated against an eval set the way superpowers' original
 methodology has. Before declaring this skill ready, run it against its
 own RED-GREEN-REFACTOR cycle using a battery of real rule-authoring
 requests from the org framework.
+
+## You Are Done When
+
+- A pressure scenario WITHOUT the rule produced a documented violation
+- The rule is written in the target instructions file
+- A pressure scenario WITH the rule produces correct behavior
+- The rule passes `upskill lint` (if in SSOT format)

--- a/skills/writing-skill-bundles/SKILL.md
+++ b/skills/writing-skill-bundles/SKILL.md
@@ -221,3 +221,9 @@ Common findings:
 This skill has not been through a RED-GREEN-REFACTOR evaluation cycle.
 It is reference documentation distilled from ADR-0007, ADR-0008, and
 the format-spec. Gaps may exist in edge-case coverage.
+
+## You Are Done When
+
+- The `.bundle.yaml` manifest exists with valid schema
+- All declared items resolve to existing SSOT files
+- `upskill lint` passes on the bundle

--- a/skills/writing-subagents/SKILL.md
+++ b/skills/writing-subagents/SKILL.md
@@ -52,6 +52,15 @@ observed without the subagent, the work probably belongs in a skill.
 
 ## RED phase — scenarios per interface
 
+<!-- @client:claude -->
+
+Run each scenario by spawning a fresh subagent with only the relevant
+prompt loaded. The parent's invocation tests run in the parent session
+with the subagent registered. The return tests run on the subagent
+directly in isolation.
+
+<!-- @endclient -->
+
 ### Invocation tests (run on the parent, subagent present)
 
 - **Should-delegate task** — does parent invoke?
@@ -167,3 +176,10 @@ Before declaring this skill ready, run it through its own
 RED-GREEN-REFACTOR cycle using real subagent designs from the
 framework's priority list (explorer, test-runner, git-assistant first;
 license-checker and classification-guard next).
+
+## You Are Done When
+
+- The subagent system prompt exists as an AGENT.md with valid frontmatter
+- The authority test passes (subagent stays in scope)
+- The return contract is explicit and the parent can consume the output
+- `upskill lint` passes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,11 +12,16 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(name = "upskill")]
 #[command(version)]
-#[command(about = "Author and distribute AI-assistance content across coding agents")]
 #[command(
-    after_help = "DOCUMENTATION:\n  https://driftsys.github.io/upskill/\n\n\
-        REPORT BUGS:\n  https://github.com/driftsys/upskill/issues"
+    about = "Install and manage AI-assistance content (rules, skills, agents) for Claude Code, Copilot, and opencode"
 )]
+#[command(after_help = "QUICK START:\n  \
+        upskill add owner/repo          Install from a GitHub repo\n  \
+        upskill list                    See what's installed\n  \
+        upskill update                  Pull latest versions\n  \
+        upskill search <query>          Find skills in the public registry\n\n\
+        DOCUMENTATION:\n  https://driftsys.github.io/upskill/\n\n\
+        REPORT BUGS:\n  https://github.com/driftsys/upskill/issues")]
 pub struct Cli {
     /// Disable colored output. Honored alongside `NO_COLOR`,
     /// `UPSKILL_NO_COLOR`, `TERM=dumb`, and TTY auto-detection.
@@ -33,20 +38,23 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Install rules / skills / agents from a source.
+    /// Install rules, skills, or agents from a GitHub/GitLab repo or local path.
     ///
     /// Parses each item from the source, renders per-client output, and
     /// records the install in `.upskill-lock.json`. Default scope is the
     /// current project; falls back to global (`$HOME`) when `cwd` is not
     /// inside a git repo.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 1,
+        after_help = "EXAMPLES:\n  \
             upskill add owner/repo\n  \
             upskill add owner/repo@v1.2\n  \
             upskill add owner/repo:skills/code-review\n  \
             upskill add owner/repo code-review secret-scanner\n  \
             upskill add gitlab:team/repo\n  \
             upskill add ./local-source\n  \
-            upskill add owner/repo --global")]
+            upskill add owner/repo --global"
+    )]
     Add {
         /// Source: `owner/repo[@ref][:subfolder]`, full https URL, or local path.
         source: String,
@@ -80,11 +88,14 @@ pub enum Commands {
     /// `upskill remove` is rejected — be explicit. Ancillary files
     /// (`CLAUDE.md`, `opencode.json`, `.vscode/settings.json`) are not
     /// touched.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 4,
+        after_help = "EXAMPLES:\n  \
             upskill remove code-review\n  \
             upskill remove rule-a skill-b agent-c\n  \
             upskill remove --source github:owner/repo\n  \
-            upskill remove --global code-review")]
+            upskill remove --global code-review"
+    )]
     Remove {
         /// Item names to remove. Mutually exclusive with `--source`.
         names: Vec<String>,
@@ -112,11 +123,14 @@ pub enum Commands {
     /// entries and reinstalls those sources. With `--dry-run`, hashes
     /// the new SSOT and reports what would change without writing.
     /// `update` always fetches.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 3,
+        after_help = "EXAMPLES:\n  \
             upskill update\n  \
             upskill update code-review\n  \
             upskill update --dry-run\n  \
-            upskill update --global")]
+            upskill update --global"
+    )]
     Update {
         /// Item names to update (omit to update everything).
         names: Vec<String>,
@@ -141,9 +155,12 @@ pub enum Commands {
     /// present, are surfaced as a separate section. The command never
     /// fetches and never inspects per-client output files — for that, run
     /// `upskill doctor`.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 2,
+        after_help = "EXAMPLES:\n  \
             upskill list\n  \
-            upskill list --global")]
+            upskill list --global"
+    )]
     List {
         /// Read `$HOME/.upskill-lock.json` instead of the current directory.
         #[arg(short = 'g', long = "global", conflicts_with = "project")]
@@ -166,9 +183,12 @@ pub enum Commands {
     ///
     /// Doctor never fetches; remote-source drift detection is
     /// `update --dry-run`. Exit 0 when clean, 1 when any drift is found.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 5,
+        after_help = "EXAMPLES:\n  \
             upskill doctor\n  \
-            upskill doctor --global")]
+            upskill doctor --global"
+    )]
     Doctor {
         /// Operate on `$HOME` instead of the current directory.
         #[arg(short = 'g', long = "global", conflicts_with = "project")]
@@ -184,11 +204,14 @@ pub enum Commands {
         json: bool,
     },
     /// Search the public skills registry and configured registries.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 6,
+        after_help = "EXAMPLES:\n  \
             upskill search code-review\n  \
             upskill search api --limit 5\n  \
             upskill search auth --registry corp\n  \
-            upskill search auth --kind rule")]
+            upskill search auth --kind rule"
+    )]
     Search {
         /// Search query.
         query: String,
@@ -209,10 +232,13 @@ pub enum Commands {
     /// Default mode emits warnings and exits 0 unless an error rule
     /// fires; `--strict` promotes warnings to errors (CI mode). With no
     /// paths, lints the current directory.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 10,
+        after_help = "EXAMPLES:\n  \
             upskill lint\n  \
             upskill lint rules/\n  \
-            upskill lint --strict")]
+            upskill lint --strict"
+    )]
     Lint {
         /// Files or directories to lint. Empty = current directory.
         paths: Vec<PathBuf>,
@@ -226,9 +252,12 @@ pub enum Commands {
     /// markdown is left untouched (dprint's job). Refuses to run inside
     /// a consumer project (detected by `.upskill-lock.json`). With no
     /// paths, formats the current directory.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 12,
+        after_help = "EXAMPLES:\n  \
             upskill fmt\n  \
-            upskill fmt rules/")]
+            upskill fmt rules/"
+    )]
     Fmt {
         /// Files or directories to format. Empty = current directory.
         paths: Vec<PathBuf>,
@@ -239,10 +268,13 @@ pub enum Commands {
     /// defaults (e.g. `mode: subagent` / `model: sonnet` for agents)
     /// into `<cwd>/<kind>s/<name>/<KIND>.md`. Author command — refuses
     /// to run inside a consumer project.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 11,
+        after_help = "EXAMPLES:\n  \
             upskill new rule no-direct-database-access\n  \
             upskill new skill code-review\n  \
-            upskill new agent security-reviewer")]
+            upskill new agent security-reviewer"
+    )]
     New {
         /// One of `rule`, `skill`, `agent`.
         kind: String,
@@ -250,10 +282,13 @@ pub enum Commands {
         name: String,
     },
     /// Build or manage the local registry index cache.
-    #[command(after_help = "EXAMPLES:\n  \
+    #[command(
+        display_order = 7,
+        after_help = "EXAMPLES:\n  \
             upskill index\n  \
             upskill index --registry corp\n  \
-            upskill index --clear")]
+            upskill index --clear"
+    )]
     Index {
         /// Rebuild only a specific registry.
         #[arg(short = 'r', long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -923,7 +923,10 @@ fn print_list_report(report: &ListReport) {
         return;
     }
     if report.is_empty() {
-        println!("no items installed");
+        println!("No items installed.");
+        println!();
+        println!("  Get started: upskill add owner/repo");
+        println!("  Browse:      upskill search <query>");
         return;
     }
 

--- a/tests/cli_global_scope.rs
+++ b/tests/cli_global_scope.rs
@@ -197,7 +197,7 @@ fn list_global_reads_home_lockfile() {
         .success();
     let project_out = String::from_utf8(project_assert.get_output().stdout.clone()).unwrap();
     assert!(
-        project_out.contains("no items installed"),
+        project_out.contains("No items installed"),
         "project list empty: {project_out}"
     );
 

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -51,7 +51,7 @@ fn list_empty_lockfile_reports_no_items() {
         .success();
     let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     assert!(
-        out.contains("no items installed"),
+        out.contains("No items installed"),
         "expected empty message: {out}"
     );
 }

--- a/tests/cli_stdio_discipline.rs
+++ b/tests/cli_stdio_discipline.rs
@@ -29,7 +29,7 @@ fn list_data_goes_to_stdout_stderr_is_empty() {
     let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
 
     assert!(
-        stdout.contains("no items installed"),
+        stdout.contains("No items installed"),
         "expected data on stdout, got: {stdout:?}"
     );
     assert!(


### PR DESCRIPTION
Closes #184, closes #186

Epic: #176

## Changes

1. **cli.rs/main.rs**: Improved first-run UX — concrete about string naming all clients, command grouping via display_order, Quick Start block, empty-state call-to-action
2. **skills/**: Added `## You Are Done When` output contracts to all 7 bundled skills, added `@client:claude` directives to gate subagent-specific content in writing-subagents and evaluating-prompts