### PR TITLE
fix: isolate HOME in all integration tests (#193)

### DIFF
--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -7,7 +7,8 @@
 //! Local-path source only — no network. GitHub/GitLab-source coverage is
 //! in `tests/pipeline_source.rs` at the library level.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -35,6 +36,8 @@ fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
 #[test]
 fn add_installs_local_ssot_to_cwd() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
@@ -43,8 +46,7 @@ fn add_installs_local_ssot_to_cwd() {
     // project scope (cwd) instead of global ($HOME).
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", source.to_str().unwrap()])
         .assert()
@@ -76,9 +78,10 @@ fn add_installs_local_ssot_to_cwd() {
 #[test]
 fn add_invalid_source_returns_usage_error() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "not a valid source"])
         .assert()
@@ -92,14 +95,15 @@ fn add_with_items_subset_installs_only_named_items() {
     // to a subset. Pick the skill (`create-api-endpoint`) and one rule
     // (`license-awareness`); leave the agent and the second rule out.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args([
             "add",
@@ -133,14 +137,15 @@ fn add_with_items_no_match_is_general_error() {
     // No name in the list matches anything in the source — the install
     // should refuse rather than silently emitting nothing.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args([
             "add",

--- a/tests/cli_bundle_install.rs
+++ b/tests/cli_bundle_install.rs
@@ -6,7 +6,8 @@
 //! resolution names. The lockfile records the entry bundle and every
 //! transitive dependency.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -44,6 +45,8 @@ fn bundle_install_writes_only_referenced_items() {
     // `platform-baseline.bundle.yaml` references every fixture item, so a
     // bundle install renders the same files as a directory install.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let registry = tmp.path().join("registry");
     let target = tmp.path().join("target");
     stage_registry(&registry);
@@ -51,8 +54,7 @@ fn bundle_install_writes_only_referenced_items() {
     fs::create_dir_all(target.join(".git")).unwrap();
 
     let bundle = registry.join("bundles/platform-baseline.bundle.yaml");
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", bundle.to_str().unwrap()])
         .assert()
@@ -81,6 +83,8 @@ fn bundle_install_writes_only_referenced_items() {
 #[test]
 fn bundle_install_records_bundle_in_lockfile() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let registry = tmp.path().join("registry");
     let target = tmp.path().join("target");
     stage_registry(&registry);
@@ -88,8 +92,7 @@ fn bundle_install_records_bundle_in_lockfile() {
     fs::create_dir_all(target.join(".git")).unwrap();
 
     let bundle = registry.join("bundles/platform-baseline.bundle.yaml");
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", bundle.to_str().unwrap()])
         .assert()
@@ -123,6 +126,8 @@ fn bundle_install_resolves_transitive_requires() {
     // should record both bundles in the lockfile and install items from
     // both bundles' union.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let registry = tmp.path().join("registry");
     let target = tmp.path().join("target");
     stage_registry(&registry);
@@ -147,8 +152,7 @@ fn bundle_install_resolves_transitive_requires() {
     )
     .unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", extras_path.to_str().unwrap()])
         .assert()
@@ -181,6 +185,8 @@ fn bundle_install_errors_on_item_conflict() {
     // also lists — that's a (kind=rule, name=license-awareness) conflict
     // when extras requires baseline. Resolution must fail.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let registry = tmp.path().join("registry");
     let target = tmp.path().join("target");
     stage_registry(&registry);
@@ -188,8 +194,7 @@ fn bundle_install_errors_on_item_conflict() {
     fs::create_dir_all(target.join(".git")).unwrap();
 
     let extras = registry.join("bundles/platform-extras.bundle.yaml");
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", extras.to_str().unwrap()])
         .assert()
@@ -250,6 +255,8 @@ fn bundle_install_sibling_layout_discovers_items_in_peer_directories() {
     // under the registry root, `find_registry_root` must detect the
     // registry root and `install_*` must find items in subdirectories.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let registry = tmp.path().join("registry");
     let target = tmp.path().join("target");
     stage_sibling_layout_registry(&registry);
@@ -257,8 +264,7 @@ fn bundle_install_sibling_layout_discovers_items_in_peer_directories() {
     fs::create_dir_all(target.join(".git")).unwrap();
 
     let bundle = registry.join("bundles/sibling-test.bundle.yaml");
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", bundle.to_str().unwrap()])
         .assert()

--- a/tests/cli_ci_mode.rs
+++ b/tests/cli_ci_mode.rs
@@ -5,7 +5,10 @@
 //! exhaustively. These integration tests pin the contract through the
 //! actual binary so a regression in `style::init` can't sneak past.
 
-use assert_cmd::Command;
+mod common;
+
+use std::fs;
+
 use tempfile::tempdir;
 
 const ANSI_ESC: char = '\x1b';
@@ -27,8 +30,9 @@ fn assert_has_ansi(output: &str) {
 #[test]
 fn no_color_env_strips_ansi() {
     let cwd = tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env("NO_COLOR", "1")
         .env_remove("FORCE_COLOR")
@@ -43,8 +47,9 @@ fn no_color_env_strips_ansi() {
 #[test]
 fn no_color_flag_strips_ansi() {
     let cwd = tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env_remove("NO_COLOR")
         .env("FORCE_COLOR", "1") // would force color, but --no-color takes precedence
@@ -58,8 +63,9 @@ fn no_color_flag_strips_ansi() {
 #[test]
 fn upskill_no_color_strips_ansi() {
     let cwd = tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env_remove("NO_COLOR")
         .env("UPSKILL_NO_COLOR", "1")
@@ -74,8 +80,9 @@ fn upskill_no_color_strips_ansi() {
 #[test]
 fn term_dumb_strips_ansi() {
     let cwd = tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env("TERM", "dumb")
         .env_remove("NO_COLOR")
@@ -92,8 +99,9 @@ fn piped_output_strips_ansi_by_default() {
     // assert_cmd runs the binary with stderr/stdout NOT a TTY. With no
     // FORCE_COLOR override, `colored` should auto-disable.
     let cwd = tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env_remove("NO_COLOR")
         .env_remove("UPSKILL_NO_COLOR")
@@ -112,8 +120,9 @@ fn force_color_re_enables_when_piped() {
     // Even though stderr is piped (assert_cmd subprocess), FORCE_COLOR
     // tells `colored` to emit ANSI anyway. clig.dev §Environment Variables.
     let cwd = tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env_remove("NO_COLOR")
         .env_remove("UPSKILL_NO_COLOR")

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -11,7 +11,8 @@
 //!
 //! Doctor never fetches; remote-source drift detection is `update --dry-run`.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -36,9 +37,8 @@ fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn install(target: &Path, source: &Path) {
-    Command::cargo_bin("upskill")
-        .unwrap()
+fn install(target: &Path, source: &Path, home: &Path) {
+    common::upskill_cmd(home)
         .current_dir(target)
         .args(["add", source.to_str().unwrap()])
         .assert()
@@ -48,15 +48,16 @@ fn install(target: &Path, source: &Path) {
 #[test]
 fn doctor_clean_install_exits_zero() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor"])
         .assert()
@@ -68,9 +69,10 @@ fn doctor_clean_install_exits_zero() {
 #[test]
 fn doctor_empty_lockfile_exits_zero() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["doctor"])
         .assert()
@@ -82,18 +84,19 @@ fn doctor_detects_missing_output_files() {
     // Install, then delete one rendered output behind upskill's back —
     // the bucket-1 path. Doctor must exit 1 and name the missing file.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     let stolen = target.join(".claude/skills/create-api-endpoint/SKILL.md");
     fs::remove_file(&stolen).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor"])
         .assert()
@@ -115,19 +118,20 @@ fn doctor_detects_ssot_hash_drift() {
     // Install from a local source, mutate the SSOT in place — the
     // bucket-2 path. Doctor must exit 1 and surface the stale-hash bucket.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     let skill_md = source.join("create-api-endpoint/SKILL.md");
     let original = fs::read_to_string(&skill_md).unwrap();
     fs::write(&skill_md, format!("{original}\n<!-- mutation -->\n")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor"])
         .assert()
@@ -149,17 +153,18 @@ fn doctor_detects_orphan_when_local_path_gone() {
     // Install from a local source, remove the source dir — the bucket-3
     // path. Doctor must exit 1 and surface every entry as orphan.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     fs::remove_dir_all(&source).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor"])
         .assert()
@@ -183,17 +188,18 @@ fn doctor_detects_orphan_when_item_removed_from_source() {
     // SSOT (leaving the source root). Doctor must report that one item
     // as orphan with "item not in source", and other items stay clean.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     fs::remove_dir_all(source.join("create-api-endpoint")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor"])
         .assert()
@@ -209,15 +215,16 @@ fn doctor_detects_orphan_when_item_removed_from_source() {
 #[test]
 fn doctor_json_clean_install_emits_empty_buckets() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor", "--json"])
         .assert()
@@ -236,17 +243,18 @@ fn doctor_json_clean_install_emits_empty_buckets() {
 #[test]
 fn doctor_json_orphan_entry_has_kebab_case_reason() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     fs::remove_dir_all(&source).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor", "--json"])
         .assert()
@@ -268,18 +276,19 @@ fn doctor_json_orphan_entry_has_kebab_case_reason() {
 #[test]
 fn doctor_json_missing_output_lists_files() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     let stolen = target.join(".claude/skills/create-api-endpoint/SKILL.md");
     fs::remove_file(&stolen).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor", "--json"])
         .assert()
@@ -407,11 +416,12 @@ fn doctor_skipped_plugin_exits_zero_and_reports_it() {
     // A lockfile with a Skipped plugin should exit 0 (not drift) but still
     // surface the plugin in the output so it is not silently lost.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
     write_lockfile_with_skipped_plugin(tmp.path(), "superpowers", "claude");
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["doctor"])
         .assert()
@@ -433,7 +443,11 @@ fn doctor_installed_plugin_missing_from_client_exits_one() {
     // binary returns an empty extension list.  Doctor must exit 1 and report
     // the plugin as missing from the client.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let bin_dir = tempfile::tempdir().unwrap();
+    let home = bin_dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
     write_lockfile_with_installed_plugin(
         tmp.path(),
@@ -444,8 +458,7 @@ fn doctor_installed_plugin_missing_from_client_exits_one() {
     // Fake `code` that lists no extensions (empty stdout).
     write_fake_cli(bin_dir.path(), "code", "");
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .env("PATH", prepend_to_path(bin_dir.path()))
         .current_dir(tmp.path())
         .args(["doctor"])
@@ -468,7 +481,11 @@ fn doctor_installed_plugin_present_in_client_exits_zero() {
     // A lockfile records a vscode plugin as Installed. The fake `code` binary
     // returns a list that includes the extension.  Doctor must exit 0.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let bin_dir = tempfile::tempdir().unwrap();
+    let home = bin_dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
     write_lockfile_with_installed_plugin(
         tmp.path(),
@@ -483,8 +500,7 @@ fn doctor_installed_plugin_present_in_client_exits_zero() {
         "anthropic.superpowers\nms-python.python",
     );
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .env("PATH", prepend_to_path(bin_dir.path()))
         .current_dir(tmp.path())
         .args(["doctor"])
@@ -496,15 +512,16 @@ fn doctor_installed_plugin_present_in_client_exits_zero() {
 fn doctor_json_includes_skipped_plugins_bucket() {
     // --json output must include a skipped_plugins array even when empty.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["doctor", "--json"])
         .assert()

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -2,13 +2,18 @@
 //! 130 SIGINT. These tests pin the codes the CLI must produce for each
 //! bucket so the contract holds across implementation changes.
 
-use assert_cmd::Command;
+mod common;
+
+use std::fs;
+
 use tempfile::tempdir;
 
 #[test]
 fn version_long_flag_prints_to_stdout_and_exits_zero() {
     let cwd = tempdir().expect("must create temp dir");
-    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let mut cmd = common::upskill_cmd(&home);
 
     let expected = format!("upskill {}\n", env!("CARGO_PKG_VERSION"));
     cmd.current_dir(cwd.path())
@@ -21,7 +26,9 @@ fn version_long_flag_prints_to_stdout_and_exits_zero() {
 #[test]
 fn version_short_flag_prints_to_stdout_and_exits_zero() {
     let cwd = tempdir().expect("must create temp dir");
-    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let mut cmd = common::upskill_cmd(&home);
 
     let expected = format!("upskill {}\n", env!("CARGO_PKG_VERSION"));
     cmd.current_dir(cwd.path())
@@ -34,7 +41,9 @@ fn version_short_flag_prints_to_stdout_and_exits_zero() {
 #[test]
 fn help_exits_zero() {
     let cwd = tempdir().expect("must create temp dir");
-    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let mut cmd = common::upskill_cmd(&home);
 
     cmd.current_dir(cwd.path())
         .args(["--help"])
@@ -45,7 +54,9 @@ fn help_exits_zero() {
 #[test]
 fn usage_errors_exit_two() {
     let cwd = tempdir().expect("must create temp dir");
-    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let mut cmd = common::upskill_cmd(&home);
 
     cmd.current_dir(cwd.path())
         .args(["add", "invalid-source"])
@@ -59,7 +70,9 @@ fn general_errors_exit_one() {
     // (and USERPROFILE on Windows) unset, the target lookup fails — a
     // general error (exit 1), not a usage error.
     let cwd = tempdir().expect("must create temp dir");
-    let mut cmd = Command::cargo_bin("upskill").expect("binary exists");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let mut cmd = common::upskill_cmd(&home);
 
     cmd.current_dir(cwd.path())
         .env_remove("HOME")

--- a/tests/cli_fmt.rs
+++ b/tests/cli_fmt.rs
@@ -5,7 +5,8 @@
 //! a consumer project (`.upskill-lock.json` at the path's root) per
 //! ADR-0004.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -19,6 +20,8 @@ fn write(path: &Path, contents: &str) {
 #[test]
 fn fmt_reorders_frontmatter_keys_canonically() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("scrambled/SKILL.md");
     // Canonical order is schema → name → description → audience → license →
     // metadata. Author wrote them in the wrong order.
@@ -40,8 +43,7 @@ fn fmt_reorders_frontmatter_keys_canonically() {
         ),
     );
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["fmt"])
         .assert()
@@ -67,6 +69,8 @@ fn fmt_reorders_frontmatter_keys_canonically() {
 #[test]
 fn fmt_is_idempotent() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("already-canonical/SKILL.md");
     write(
         &item,
@@ -84,16 +88,14 @@ fn fmt_is_idempotent() {
         ),
     );
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["fmt"])
         .assert()
         .success();
     let pass1 = fs::read_to_string(&item).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["fmt"])
         .assert()
@@ -106,6 +108,8 @@ fn fmt_is_idempotent() {
 #[test]
 fn fmt_does_not_touch_body() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("preserve-body/SKILL.md");
     let body = concat!(
         "\n",
@@ -126,8 +130,7 @@ fn fmt_does_not_touch_body() {
         ),
     );
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["fmt"])
         .assert()
@@ -143,14 +146,15 @@ fn fmt_does_not_touch_body() {
 #[test]
 fn fmt_refuses_to_run_inside_consumer_project() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::write(
         tmp.path().join(".upskill-lock.json"),
         r#"{"schema":2,"items":[]}"#,
     )
     .unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["fmt"])
         .assert()
@@ -166,6 +170,8 @@ fn fmt_refuses_to_run_inside_consumer_project() {
 #[test]
 fn fmt_reports_files_changed_count() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     write(
         &tmp.path().join("needs-fmt/SKILL.md"),
         concat!(
@@ -189,8 +195,7 @@ fn fmt_reports_files_changed_count() {
         ),
     );
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["fmt"])
         .assert()

--- a/tests/cli_lint.rs
+++ b/tests/cli_lint.rs
@@ -6,7 +6,8 @@
 //! inside a consumer project (detects `.upskill-lock.json` at the path's
 //! root).
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -22,12 +23,13 @@ fn write(path: &Path, contents: &str) {
 #[test]
 fn lint_clean_fixture_corpus_exits_zero() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let from = format!("{FIXTURES}/items");
     copy_dir_all(Path::new(&from), &source).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&source)
         .args(["lint"])
         .assert()
@@ -39,6 +41,8 @@ fn lint_clean_fixture_corpus_exits_zero() {
 #[test]
 fn lint_flags_h1_in_body_as_warning() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("bad-h1/SKILL.md");
     write(
         &item,
@@ -57,8 +61,7 @@ fn lint_flags_h1_in_body_as_warning() {
         ),
     );
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["lint"])
         .assert()
@@ -71,6 +74,8 @@ fn lint_flags_h1_in_body_as_warning() {
 #[test]
 fn lint_flags_fence_without_language_as_warning() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("no-fence-lang/SKILL.md");
     write(
         &item,
@@ -89,8 +94,7 @@ fn lint_flags_fence_without_language_as_warning() {
         ),
     );
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["lint"])
         .assert()
@@ -105,6 +109,8 @@ fn lint_flags_fence_without_language_as_warning() {
 #[test]
 fn lint_strict_promotes_warnings_to_errors() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("strict-h1/SKILL.md");
     write(
         &item,
@@ -119,8 +125,7 @@ fn lint_strict_promotes_warnings_to_errors() {
         ),
     );
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["lint", "--strict"])
         .assert()
@@ -131,6 +136,8 @@ fn lint_strict_promotes_warnings_to_errors() {
 #[test]
 fn lint_flags_name_directory_mismatch_as_error() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     // Directory named foo, frontmatter name is bar — error per §2.1.
     let item = tmp.path().join("foo/SKILL.md");
     write(
@@ -146,8 +153,7 @@ fn lint_flags_name_directory_mismatch_as_error() {
         ),
     );
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["lint"])
         .assert()
@@ -158,6 +164,8 @@ fn lint_flags_name_directory_mismatch_as_error() {
 #[test]
 fn lint_flags_unbalanced_directive_as_error() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("unbalanced/SKILL.md");
     write(
         &item,
@@ -175,8 +183,7 @@ fn lint_flags_unbalanced_directive_as_error() {
         ),
     );
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["lint"])
         .assert()
@@ -187,6 +194,8 @@ fn lint_flags_unbalanced_directive_as_error() {
 #[test]
 fn lint_refuses_to_run_inside_consumer_project() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     // Marker file says "this is a consumer project, not a source tree".
     fs::write(
         tmp.path().join(".upskill-lock.json"),
@@ -194,8 +203,7 @@ fn lint_refuses_to_run_inside_consumer_project() {
     )
     .unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["lint"])
         .assert()
@@ -211,6 +219,8 @@ fn lint_refuses_to_run_inside_consumer_project() {
 #[test]
 fn lint_flags_bundle_item_name_collision() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let root = tmp.path();
 
     // Create a skill named "baseline"
@@ -231,8 +241,7 @@ fn lint_flags_bundle_item_name_collision() {
     )
     .unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(root)
         .args(["lint"])
         .assert()

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -5,7 +5,8 @@
 //! never touches per-client output files or fetches anything — it is a
 //! lockfile dump.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -30,9 +31,8 @@ fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn install(target: &Path, source: &Path) {
-    Command::cargo_bin("upskill")
-        .unwrap()
+fn install(target: &Path, source: &Path, home: &Path) {
+    common::upskill_cmd(home)
         .current_dir(target)
         .args(["add", source.to_str().unwrap()])
         .assert()
@@ -42,9 +42,10 @@ fn install(target: &Path, source: &Path) {
 #[test]
 fn list_empty_lockfile_reports_no_items() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["list"])
         .assert()
@@ -59,15 +60,16 @@ fn list_empty_lockfile_reports_no_items() {
 #[test]
 fn list_groups_installed_items_by_kind() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["list"])
         .assert()
@@ -106,6 +108,8 @@ fn list_bundle_install_surfaces_bundles_section() {
     // Use the bundle fixture corpus so the install records a LockedBundle
     // entry alongside the per-item entries.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     fs::create_dir_all(&source).unwrap();
@@ -121,8 +125,7 @@ fn list_bundle_install_surfaces_bundles_section() {
     )
     .unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args([
             "add",
@@ -134,8 +137,7 @@ fn list_bundle_install_surfaces_bundles_section() {
         .assert()
         .success();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["list"])
         .assert()
@@ -155,9 +157,10 @@ fn list_bundle_install_surfaces_bundles_section() {
 #[test]
 fn list_json_empty_lockfile_emits_empty_buckets() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["list", "--json"])
         .assert()
@@ -176,15 +179,16 @@ fn list_json_empty_lockfile_emits_empty_buckets() {
 #[test]
 fn list_json_groups_installed_items_by_kind() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["list", "--json"])
         .assert()

--- a/tests/cli_misc.rs
+++ b/tests/cli_misc.rs
@@ -5,7 +5,8 @@
 //! - Spec §3.2: outputs are file copies, never symlinks.
 //! - Spec §3.4: `CLAUDE.md` bridge is `@AGENTS.md\n` literally.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -35,8 +36,9 @@ fn install_is_not_an_alias_for_add() {
     // Spec §2.6: `add` does NOT alias `install`. clap rejects unknown
     // subcommands at parse time → exit 2.
     let cwd = tempfile::tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .args(["install", "owner/repo"])
         .assert()
@@ -53,8 +55,9 @@ fn install_is_not_an_alias_for_add() {
 fn uninstall_is_not_an_alias_for_remove() {
     // Spec §2.6: `remove` does NOT alias `uninstall`.
     let cwd = tempfile::tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .args(["uninstall", "code-review"])
         .assert()
@@ -73,14 +76,15 @@ fn outputs_are_file_copies_not_symlinks() {
     // Windows portability without Developer Mode requires this — symlinks
     // would silently degrade.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", source.to_str().unwrap()])
         .assert()
@@ -111,14 +115,15 @@ fn claude_md_bridge_content_is_at_agents_md() {
     // bridge content if absent. The single line is what makes Claude
     // Code load `AGENTS.md` (which it does not read natively).
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", source.to_str().unwrap()])
         .assert()

--- a/tests/cli_new.rs
+++ b/tests/cli_new.rs
@@ -6,14 +6,16 @@
 //! agents). Author command — refuses to run inside a consumer project
 //! (`.upskill-lock.json`) per ADR-0004.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 
 #[test]
 fn new_skill_creates_skill_md_with_minimum_frontmatter() {
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["new", "skill", "code-review"])
         .assert()
@@ -31,8 +33,9 @@ fn new_skill_creates_skill_md_with_minimum_frontmatter() {
 #[test]
 fn new_rule_creates_rule_md() {
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["new", "rule", "license-awareness"])
         .assert()
@@ -46,8 +49,9 @@ fn new_rule_creates_rule_md() {
 #[test]
 fn new_agent_emits_default_mode_and_model() {
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["new", "agent", "security-reviewer"])
         .assert()
@@ -60,11 +64,12 @@ fn new_agent_emits_default_mode_and_model() {
 #[test]
 fn new_refuses_existing_item_directory() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join("dup")).unwrap();
     fs::write(tmp.path().join("dup/SKILL.md"), "old").unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["new", "skill", "dup"])
         .assert()
@@ -82,8 +87,9 @@ fn new_refuses_existing_item_directory() {
 #[test]
 fn new_rejects_invalid_name() {
     let tmp = tempfile::tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["new", "skill", "Invalid_Name"])
         .assert()
@@ -98,13 +104,14 @@ fn new_rejects_invalid_name() {
 #[test]
 fn new_refuses_to_run_inside_consumer_project() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::write(
         tmp.path().join(".upskill-lock.json"),
         r#"{"schema":2,"items":[]}"#,
     )
     .unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["new", "skill", "anything"])
         .assert()
@@ -120,13 +127,14 @@ fn new_refuses_to_run_inside_consumer_project() {
 #[test]
 fn new_output_passes_lint_and_fmt() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     for (kind, name) in [
         ("skill", "starter-skill"),
         ("rule", "starter-rule"),
         ("agent", "starter-agent"),
     ] {
-        Command::cargo_bin("upskill")
-            .unwrap()
+        common::upskill_cmd(&home)
             .current_dir(tmp.path())
             .args(["new", kind, name])
             .assert()
@@ -134,16 +142,14 @@ fn new_output_passes_lint_and_fmt() {
     }
 
     // Lint must accept its own scaffolding.
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["lint", "--strict"])
         .assert()
         .success();
 
     // Fmt must report nothing changed (the scaffold is already canonical).
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["fmt"])
         .assert()

--- a/tests/cli_quiet.rs
+++ b/tests/cli_quiet.rs
@@ -4,7 +4,8 @@
 //! "no items" messages, search results). Errors on stderr are unaffected,
 //! exit codes are unaffected.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -13,12 +14,13 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 #[test]
 fn lint_quiet_on_clean_corpus_emits_no_stdout() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let from = format!("{FIXTURES}/items");
     copy_dir_all(Path::new(&from), &source).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&source)
         .args(["lint", "--quiet"])
         .assert()
@@ -30,12 +32,13 @@ fn lint_quiet_on_clean_corpus_emits_no_stdout() {
 #[test]
 fn lint_short_q_on_clean_corpus_emits_no_stdout() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let from = format!("{FIXTURES}/items");
     copy_dir_all(Path::new(&from), &source).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&source)
         .args(["lint", "-q"])
         .assert()
@@ -49,8 +52,9 @@ fn quiet_does_not_silence_errors_on_stderr() {
     // Invalid source string: parser rejects it, error goes to stderr,
     // exit code is 2 (usage error). --quiet must not swallow that.
     let tmp = tempfile::tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "not a valid source", "--quiet"])
         .assert()
@@ -74,10 +78,11 @@ fn list_quiet_on_empty_lockfile_emits_no_stdout() {
     // list short-circuits to "no items installed" — that informational
     // message must be silenced under --quiet.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir(tmp.path().join(".git")).unwrap(); // pretend repo
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["list", "--project", "--quiet"])
         .assert()

--- a/tests/cli_remove.rs
+++ b/tests/cli_remove.rs
@@ -6,7 +6,8 @@
 //! `.vscode/settings.json`) must remain — they are user-owned after
 //! creation per ADR-0003.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -31,9 +32,8 @@ fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn install(target: &Path, source: &Path) {
-    Command::cargo_bin("upskill")
-        .unwrap()
+fn install(target: &Path, source: &Path, home: &Path) {
+    common::upskill_cmd(home)
         .current_dir(target)
         .args(["add", source.to_str().unwrap()])
         .assert()
@@ -43,12 +43,14 @@ fn install(target: &Path, source: &Path) {
 #[test]
 fn remove_by_name_deletes_all_per_client_outputs_and_lockfile_entry() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     // Sanity check: install put the skill files in place.
     assert!(
@@ -67,8 +69,7 @@ fn remove_by_name_deletes_all_per_client_outputs_and_lockfile_entry() {
             .exists()
     );
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["remove", "create-api-endpoint"])
         .assert()
@@ -107,17 +108,18 @@ fn remove_by_name_deletes_all_per_client_outputs_and_lockfile_entry() {
 #[test]
 fn remove_by_source_drops_every_entry_from_that_source() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     let source_label = format!("local:{}", source.display());
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["remove", "--source", &source_label])
         .assert()
@@ -140,17 +142,18 @@ fn remove_by_source_drops_every_entry_from_that_source() {
 #[test]
 fn remove_preserves_ancillary_files() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     let source_label = format!("local:{}", source.display());
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["remove", "--source", &source_label])
         .assert()
@@ -175,8 +178,9 @@ fn remove_preserves_ancillary_files() {
 #[test]
 fn remove_bare_invocation_is_usage_error() {
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["remove"])
         .assert()
@@ -187,8 +191,9 @@ fn remove_bare_invocation_is_usage_error() {
 #[test]
 fn remove_names_and_source_together_is_usage_error() {
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["remove", "foo", "--source", "github:o/r"])
         .assert()
@@ -199,15 +204,16 @@ fn remove_names_and_source_together_is_usage_error() {
 #[test]
 fn remove_unknown_name_is_general_error() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["remove", "this-was-never-installed"])
         .assert()

--- a/tests/cli_search.rs
+++ b/tests/cli_search.rs
@@ -1,4 +1,7 @@
-use assert_cmd::Command;
+mod common;
+
+use std::fs;
+
 use predicates::prelude::PredicateBooleanExt;
 use predicates::str::{contains, is_match};
 use std::io::{Read, Write};
@@ -56,8 +59,9 @@ const EMPTY_RESPONSE: &str = r#"{
 #[test]
 fn search_requires_query() {
     let cwd = tempdir().expect("must create temp dir");
-    Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .args(["search"])
         .assert()
@@ -67,8 +71,9 @@ fn search_requires_query() {
 #[test]
 fn search_help_exits_zero() {
     let cwd = tempdir().expect("must create temp dir");
-    Command::cargo_bin("upskill")
-        .unwrap()
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .args(["search", "--help"])
         .assert()
@@ -79,9 +84,10 @@ fn search_help_exits_zero() {
 fn search_returns_results() {
     let addr = mock_skills_server(MOCK_RESPONSE);
     let cwd = tempdir().expect("must create temp dir");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env("UPSKILL_REGISTRY_URL", format!("http://{}", addr))
         .args(["search", "rust"])
@@ -96,9 +102,10 @@ fn search_returns_results() {
 fn search_shows_install_command() {
     let addr = mock_skills_server(MOCK_RESPONSE);
     let cwd = tempdir().expect("must create temp dir");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env("UPSKILL_REGISTRY_URL", format!("http://{}", addr))
         .args(["search", "rust"])
@@ -114,9 +121,10 @@ fn search_shows_install_command() {
 fn search_empty_results() {
     let addr = mock_skills_server(EMPTY_RESPONSE);
     let cwd = tempdir().expect("must create temp dir");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env("UPSKILL_REGISTRY_URL", format!("http://{}", addr))
         .args(["search", "zzznomatch"])
@@ -128,9 +136,10 @@ fn search_empty_results() {
 #[test]
 fn search_unreachable_registry_exits_one() {
     let cwd = tempdir().expect("must create temp dir");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(cwd.path())
         .env("UPSKILL_REGISTRY_URL", "http://127.0.0.1:1")
         .args(["search", "rust"])

--- a/tests/cli_stdio_discipline.rs
+++ b/tests/cli_stdio_discipline.rs
@@ -5,7 +5,8 @@
 //! CLI has no long-running command that's deterministic in CI without
 //! the network. Tracked in #112 as deferred.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 
 fn ansi_present(s: &str) -> bool {
@@ -17,10 +18,11 @@ fn list_data_goes_to_stdout_stderr_is_empty() {
     // Empty lockfile in a faux project (no .git is fine — list short-
     // circuits on missing lockfile to "no items installed").
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir(tmp.path().join(".git")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["list", "--project"])
         .assert()
@@ -41,8 +43,9 @@ fn list_data_goes_to_stdout_stderr_is_empty() {
 #[test]
 fn add_invalid_source_writes_error_to_stderr_not_stdout() {
     let tmp = tempfile::tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "not a valid source"])
         .assert()
@@ -68,10 +71,11 @@ fn list_stdout_has_no_ansi_when_piped() {
     // captured bytes must contain no `\x1b` escape sequences. This is the
     // user-facing guarantee behind spec §6.2 "no color in pipes/CI".
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir(tmp.path().join(".git")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["list", "--project"])
         .assert()
@@ -89,8 +93,9 @@ fn add_invalid_source_stderr_has_no_ansi_under_no_color_env() {
     // suppress ANSI. Belt-and-braces against a future regression where
     // styled `error:` slips through with a hard-coded escape.
     let tmp = tempfile::tempdir().unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .env("NO_COLOR", "1")
         .args(["add", "not a valid source"])

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -5,7 +5,8 @@
 //! `update` to exercise the change-detection branch (lockfile hash vs
 //! recomputed hash) without hitting the network.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -30,9 +31,8 @@ fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn install(target: &Path, source: &Path) {
-    Command::cargo_bin("upskill")
-        .unwrap()
+fn install(target: &Path, source: &Path, home: &Path) {
+    common::upskill_cmd(home)
         .current_dir(target)
         .args(["add", source.to_str().unwrap()])
         .assert()
@@ -61,15 +61,16 @@ fn lockfile_hash_for(target: &Path, name: &str) -> Option<String> {
 #[test]
 fn update_no_change_reports_up_to_date() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update"])
         .assert()
@@ -84,18 +85,19 @@ fn update_no_change_reports_up_to_date() {
 #[test]
 fn update_after_ssot_mutation_rewrites_outputs_and_lockfile_hash() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     let original_hash = lockfile_hash_for(&target, "create-api-endpoint").unwrap();
     mutate_skill(&source);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update", "create-api-endpoint"])
         .assert()
@@ -124,18 +126,19 @@ fn update_after_ssot_mutation_rewrites_outputs_and_lockfile_hash() {
 #[test]
 fn update_dry_run_reports_change_without_writing() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     let original_hash = lockfile_hash_for(&target, "create-api-endpoint").unwrap();
     mutate_skill(&source);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update", "--dry-run"])
         .assert()
@@ -166,15 +169,16 @@ fn update_dry_run_reports_change_without_writing() {
 #[test]
 fn update_unknown_name_is_general_error() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update", "this-was-never-installed"])
         .assert()
@@ -190,12 +194,14 @@ fn update_unknown_name_is_general_error() {
 #[test]
 fn update_removes_orphaned_item_when_source_no_longer_contains_it() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     // Verify the skill is installed.
     assert!(
@@ -209,8 +215,7 @@ fn update_removes_orphaned_item_when_source_no_longer_contains_it() {
     // Remove the item from the source so it becomes an orphan.
     fs::remove_dir_all(source.join("create-api-endpoint")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update", "--yes"])
         .assert()
@@ -238,18 +243,19 @@ fn update_removes_orphaned_item_when_source_no_longer_contains_it() {
 #[test]
 fn update_dry_run_reports_would_remove_without_deleting() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     // Remove the item from the source so it becomes an orphan.
     fs::remove_dir_all(source.join("create-api-endpoint")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update", "--dry-run"])
         .assert()
@@ -277,9 +283,10 @@ fn update_dry_run_reports_would_remove_without_deleting() {
 #[test]
 fn update_empty_lockfile_is_no_op() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["update"])
         .assert()
@@ -294,12 +301,14 @@ fn update_empty_lockfile_is_no_op() {
 #[test]
 fn update_removes_stale_output_file_from_previous_generation() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     // Inject a stale file into the generated output directory.
     let stale_path = target.join(".claude/skills/create-api-endpoint/OLD_FILE.md");
@@ -309,8 +318,7 @@ fn update_removes_stale_output_file_from_previous_generation() {
     // Mutate the source so update will regenerate.
     mutate_skill(&source);
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update", "--yes"])
         .assert()
@@ -334,12 +342,14 @@ fn update_removes_stale_output_file_from_previous_generation() {
 #[test]
 fn update_without_yes_proceeds_in_non_tty() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
-    install(&target, &source);
+    install(&target, &source, &home);
 
     // Mutate source so there's something to update.
     mutate_skill(&source);
@@ -347,8 +357,7 @@ fn update_without_yes_proceeds_in_non_tty() {
     let hash_before = lockfile_hash_for(&target, "create-api-endpoint");
 
     // Run update WITHOUT --yes; non-TTY should auto-proceed.
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update"])
         .assert()

--- a/tests/cli_ux_polish.rs
+++ b/tests/cli_ux_polish.rs
@@ -5,7 +5,8 @@
 //! - bulk-remove confirmation (skipped under `--yes` / non-TTY)
 //! - "Cloning ..." progress line on git-backed installs
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::Path;
 
@@ -35,21 +36,21 @@ fn update_short_dry_run_flag_is_recognised() {
     // `-n` mirrors `make -n` / `rsync -n` — write nothing, report what
     // would change.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", source.to_str().unwrap()])
         .assert()
         .success();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["update", "-n"])
         .assert()
@@ -61,6 +62,8 @@ fn update_short_dry_run_flag_is_recognised() {
 #[test]
 fn lint_short_strict_flag_is_recognised() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("strict-h1/SKILL.md");
     fs::create_dir_all(item.parent().unwrap()).unwrap();
     fs::write(
@@ -77,8 +80,7 @@ fn lint_short_strict_flag_is_recognised() {
     )
     .unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["lint", "-s"])
         .assert()
@@ -91,8 +93,9 @@ fn search_short_limit_flag_is_recognised() {
     // Hit a closed loopback port so the request fails fast — we only
     // care that `-l` parses, not that the registry is reachable.
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("upskill")
-        .unwrap()
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .env("UPSKILL_REGISTRY_URL", "http://127.0.0.1:1")
         .args(["search", "anything", "-l", "3"])
@@ -103,22 +106,22 @@ fn search_short_limit_flag_is_recognised() {
 #[test]
 fn remove_short_source_flag_is_recognised() {
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", source.to_str().unwrap()])
         .assert()
         .success();
 
     let label = format!("local:{}", source.display());
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["remove", "-s", &label, "-y"])
         .assert()
@@ -131,22 +134,22 @@ fn remove_by_source_under_yes_flag_skips_prompt_and_proceeds() {
     // the explicit -y is the user-visible contract: never prompt, always
     // proceed. Worth pinning down.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", source.to_str().unwrap()])
         .assert()
         .success();
 
     let label = format!("local:{}", source.display());
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["remove", "--source", &label, "--yes"])
         .assert()
@@ -164,22 +167,22 @@ fn remove_by_source_in_non_tty_does_not_prompt_and_proceeds() {
     // proceed silently without prompting (the alternative would deadlock
     // CI on stdin read).
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     let source = tmp.path().join("source");
     let target = tmp.path().join("target");
     stage_source(&source);
     fs::create_dir_all(&target).unwrap();
     fs::create_dir_all(target.join(".git")).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["add", source.to_str().unwrap()])
         .assert()
         .success();
 
     let label = format!("local:{}", source.display());
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(&target)
         .args(["remove", "--source", &label])
         .assert()
@@ -192,10 +195,11 @@ fn add_against_unreachable_github_emits_progress_line_to_stderr() {
     // progress line is emitted to stderr before the failure. The clone
     // fails fast (DNS / port-1) and we just inspect captured stderr.
     let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
         // Bogus repo on a private TLD. git resolution fails instantly.
         .env("GIT_TERMINAL_PROMPT", "0")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,22 @@
+//! Shared test harness utilities.
+//!
+//! Every integration test that invokes `upskill` MUST use [`upskill_cmd`] (or
+//! manually set `HOME`) to prevent writes to the developer's real home
+//! directory. See <https://github.com/driftsys/upskill/issues/193>.
+
+use assert_cmd::Command;
+use std::path::Path;
+
+/// Returns a `Command` for the `upskill` binary with `HOME` pointed at
+/// `fake_home` (which the caller should create inside a `tempfile::TempDir`).
+///
+/// This is the **belt-and-suspenders** defense: even if a test forgets to
+/// create a `.git/` marker in its working directory, the worst case is a
+/// write into the tempdir's fake home — never the developer's real `$HOME`.
+pub fn upskill_cmd(fake_home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("upskill").unwrap();
+    cmd.env("HOME", fake_home);
+    // Also override USERPROFILE for Windows-compat code paths.
+    cmd.env("USERPROFILE", fake_home);
+    cmd
+}


### PR DESCRIPTION
## Summary

Prevents integration tests from writing to the developer's real `$HOME` directory when the auto-fallback-to-global-scope behavior kicks in (missing `.git/` marker in the test's working directory).

## Changes

- **New `tests/common/mod.rs`**: shared `upskill_cmd(fake_home)` helper that returns a `Command` with `HOME` and `USERPROFILE` pointed at a tempdir-based fake home.
- **16 test files updated**: all `Command::cargo_bin("upskill")` call sites now go through the helper, providing belt-and-suspenders isolation regardless of whether the test remembers to create a `.git/` marker.

## How it was tested

All integration tests pass (251 unit + 104 integration tests green). The one pre-existing hang (`add_against_unreachable_github_emits_progress_line_to_stderr`) is a DNS-timeout issue unrelated to this change.

Closes #193