### PR TITLE
fix(update): re-resolve bundle sources in dry-run; guard empty sources (#196)

### DIFF
--- a/src/pipeline/hash.rs
+++ b/src/pipeline/hash.rs
@@ -10,7 +10,10 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use anyhow::{Context, Result};
+
 use super::ItemKind;
+use super::discovery::{find_registry_root, is_bundle_file, iter_item_dirs};
 
 /// SHA-256 hash of every file under `dir`, with each file's path-relative
 /// name folded into the hash so renames register as drift. Recursive,
@@ -55,35 +58,71 @@ fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) {
     }
 }
 
-/// Hash every item directory under a SSOT root, keyed by `(kind, name)`.
-/// Used by `update --dry-run` to compute would-be hashes without
-/// installing. Mirrors the discovery of `install_from_local_path`: an
-/// item directory `<source_root>/<name>/` contributes one entry per
-/// kind for which it holds an entrypoint (so co-located multi-kind
-/// items contribute multiple entries, one per kind).
-pub(super) fn hash_source_items(
+/// Compute the `(kind, name) -> hash` map a source would install,
+/// mirroring `install::install_from_local_path`'s dispatch (bundle-aware)
+/// but without writing any output. Backs `update --dry-run` so its plan
+/// matches what an `Apply` run — which reinstalls through the real
+/// pipeline — produces.
+///
+/// `root` is the resolved SSOT root from `git::fetch_ssot`: a directory
+/// for item-root and whole-repo sources, or a `*.bundle.yaml` file for
+/// bundle sources. For a bundle file the items are resolved through the
+/// same registry walk + dependency resolution the installer uses (issue
+/// #196); for a directory every discovered item is hashed.
+pub(super) fn planned_source_hashes(
+    root: &Path,
+) -> Result<BTreeMap<(ItemKind, String), Option<String>>> {
+    if is_bundle_file(root) {
+        let registry_root = find_registry_root(root).with_context(|| {
+            format!(
+                "find SSOT registry root containing skills/, rules/, agents/, or bundles/ \
+                 above {}",
+                root.display()
+            )
+        })?;
+        let entry = crate::parse::bundle::load(root)
+            .with_context(|| format!("load entry bundle {}", root.display()))?;
+        let available: Vec<crate::model::Bundle> = crate::parse::bundle::discover(&registry_root)
+            .with_context(|| {
+                format!(
+                    "discover sibling bundles under registry root {}",
+                    registry_root.display()
+                )
+            })?
+            .into_iter()
+            .map(|(_, b)| b)
+            .collect();
+        let resolved = crate::bundle::resolve(&entry, &available)?;
+        Ok(hash_items(&registry_root, Some(&resolved.items)))
+    } else {
+        Ok(hash_items(root, None))
+    }
+}
+
+/// Hash every item directory under `source_root`, keyed by `(kind, name)`,
+/// mirroring the discovery in `install::install_skills` / `install_rules`
+/// / `install_agents`: items are found via [`iter_item_dirs`] (which
+/// handles both the flat `<root>/<item>/` and the category
+/// `<root>/<category>/<item>/` layouts) and, when `filter` is `Some`,
+/// restricted to the resolved bundle set. A co-located multi-kind item
+/// contributes one entry per kind for which it holds an entrypoint.
+fn hash_items(
     source_root: &Path,
+    filter: Option<&crate::bundle::ResolvedItems>,
 ) -> BTreeMap<(ItemKind, String), Option<String>> {
     let mut out = BTreeMap::new();
-    let Ok(entries) = fs::read_dir(source_root) else {
+    let Ok(dirs) = iter_item_dirs(source_root) else {
         return out;
     };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        let hash = hash_item_dir(&path);
+    for (name, dir) in dirs {
+        let hash = hash_item_dir(&dir);
         for (entrypoint, kind) in [
             ("RULE.md", ItemKind::Rule),
             ("SKILL.md", ItemKind::Skill),
             ("AGENT.md", ItemKind::Agent),
         ] {
-            if path.join(entrypoint).is_file() {
-                out.insert((kind, name.to_string()), hash.clone());
+            if dir.join(entrypoint).is_file() && filter.is_none_or(|f| f.contains(kind, &name)) {
+                out.insert((kind, name.clone()), hash.clone());
             }
         }
     }

--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::path::Path;
 
 use super::git::fetch_ssot;
-use super::hash::hash_source_items;
+use super::hash::planned_source_hashes;
 use super::output::{output_path, remove_item_outputs};
 use super::{
     ALL_CLIENTS, AddOptions, DoctorReport, ItemKind, ListReport, ListedBundle, ListedItem,
@@ -331,6 +331,7 @@ pub fn update(
                 for it in &install_report.items {
                     new_hashes.insert((it.kind, it.name.clone()), it.source_hash.clone());
                 }
+                guard_against_empty_source(&new_hashes, &source_entries, &source_label)?;
                 // Collect orphans first, then batch-remove from lockfile.
                 let mut orphans: Vec<(&crate::lockfile::LockedItem, ItemKind)> = Vec::new();
                 for entry in &source_entries {
@@ -380,7 +381,9 @@ pub fn update(
             }
             UpdateMode::DryRun => {
                 let (root, _guard) = fetch_ssot(&source)?;
-                let new_hashes = hash_source_items(&root);
+                let new_hashes = planned_source_hashes(&root)
+                    .with_context(|| format!("resolve items for source `{source_label}`"))?;
+                guard_against_empty_source(&new_hashes, &source_entries, &source_label)?;
                 for entry in &source_entries {
                     let kind = entry.kind;
                     let lookup_name = entry.source_name.as_deref().unwrap_or(&entry.name);
@@ -417,6 +420,32 @@ pub fn update(
     }
 
     Ok(report)
+}
+
+/// Guard against the data-loss footgun in issue #196: when re-resolving a
+/// source yields **no** items but the lockfile still records entries for
+/// it, treat that as a fetch/resolution anomaly and abort rather than
+/// scheduling every entry for removal. A source whose items were all
+/// genuinely deleted upstream is indistinguishable from a transient
+/// failure here, so erring toward "do not delete" is the safe default —
+/// the user can `upskill remove --source <label>` to clear such entries
+/// deliberately.
+fn guard_against_empty_source(
+    new_hashes: &std::collections::BTreeMap<(ItemKind, String), Option<String>>,
+    source_entries: &[crate::lockfile::LockedItem],
+    source_label: &str,
+) -> Result<()> {
+    if new_hashes.is_empty() && !source_entries.is_empty() {
+        let count = source_entries.len();
+        let noun = if count == 1 { "item" } else { "items" };
+        anyhow::bail!(
+            "source `{source_label}` resolved to no items, but the lockfile records \
+             {count} {noun} from it — refusing to remove them (the source may be \
+             unreachable or its layout changed). Re-check the source, or run \
+             `upskill remove --source {source_label}` to clear these entries deliberately."
+        );
+    }
+    Ok(())
 }
 
 /// List installed content from `<target>/.upskill-lock.json`. No

--- a/tests/cli_update_bundle.rs
+++ b/tests/cli_update_bundle.rs
@@ -1,0 +1,128 @@
+//! Regression tests for issue #196: `upskill update` misfiring on
+//! bundle-sourced items.
+//!
+//! When content is installed from a `*.bundle.yaml` source, the lockfile
+//! records each item's source as the bundle file (e.g.
+//! `local:/abs/path/my-bundle.bundle.yaml`). `update` must re-resolve that
+//! bundle source the same way `add` did — through bundle resolution — and
+//! must NOT report the freshly-installed items as "would remove — no
+//! longer in source". These tests use a local-path bundle source so no
+//! network is involved, and pin every command to `--project` scope so the
+//! consumer tempdir is the only lockfile touched (never the real `$HOME`).
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn write_skill(root: &Path, name: &str) {
+    let body = format!(
+        "---\nschema: 1\nname: {name}\ndescription: bundle item {name} for the issue 196 regression.\n---\n\n## Body\n\nText for {name}.\n"
+    );
+    write(&root.join(name).join("SKILL.md"), &body);
+}
+
+/// Lay out a registry with two skills plus a bundle naming both. Returns
+/// the absolute path to the bundle manifest.
+fn setup_registry(registry: &Path) -> PathBuf {
+    write_skill(registry, "alpha");
+    write_skill(registry, "beta");
+    let bundle = registry.join("my-bundle.bundle.yaml");
+    write(
+        &bundle,
+        "schema: 1\nname: my-bundle\ndescription: bundle for the issue 196 regression.\nitems:\n  skills:\n    - alpha\n    - beta\n",
+    );
+    bundle
+}
+
+fn add_bundle(consumer: &Path, bundle: &Path) {
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(consumer)
+        .args(["add", bundle.to_str().unwrap(), "--project"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn update_dry_run_does_not_report_bundle_items_as_removed() {
+    let consumer = tempfile::tempdir().unwrap();
+    let registry = tempfile::tempdir().unwrap();
+    let bundle = setup_registry(registry.path());
+
+    add_bundle(consumer.path(), &bundle);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(consumer.path())
+        .args(["update", "--dry-run", "--project"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(
+        !out.contains("would remove") && !out.contains("no longer in source"),
+        "bundle items must not be scheduled for removal: {out}"
+    );
+    assert!(
+        out.contains("up to date") || out.contains("up-to-date"),
+        "freshly installed bundle items must read as up to date: {out}"
+    );
+}
+
+#[test]
+fn update_dry_run_named_bundle_item_is_not_removed() {
+    let consumer = tempfile::tempdir().unwrap();
+    let registry = tempfile::tempdir().unwrap();
+    let bundle = setup_registry(registry.path());
+
+    add_bundle(consumer.path(), &bundle);
+
+    let assert = Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(consumer.path())
+        .args(["update", "--dry-run", "--project", "alpha"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(
+        !out.contains("would remove") && !out.contains("no longer in source"),
+        "named bundle item must not be scheduled for removal: {out}"
+    );
+}
+
+#[test]
+fn update_apply_does_not_delete_bundle_items() {
+    let consumer = tempfile::tempdir().unwrap();
+    let registry = tempfile::tempdir().unwrap();
+    let bundle = setup_registry(registry.path());
+
+    add_bundle(consumer.path(), &bundle);
+
+    // A real (apply) update must reinstall the bundle, not delete its items.
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(consumer.path())
+        .args(["update", "--yes", "--project"])
+        .assert()
+        .success();
+
+    // Both items' generated Claude output must still be present.
+    for name in ["alpha", "beta"] {
+        let out = consumer
+            .path()
+            .join(format!(".claude/skills/{name}/SKILL.md"));
+        assert!(
+            out.exists(),
+            "bundle item {name} output must survive `update`: {}",
+            out.display()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #196.

## Problem

`upskill update` reported every bundle-installed item as **"would remove — no longer in source"**. On the interactive path (which builds its confirmation plan from a dry-run), this meant the tool would offer to delete all bundle-installed content — globally, every installed skill/rule/agent.

## Root cause

`update` had two divergent source-resolution paths:

- **Apply** calls the real installer → bundle-aware → correct.
- **`--dry-run`** recomputed hashes with `hash_source_items()`, a flat directory scan that never dispatched on bundles. For a `*.bundle.yaml` source, `fetch_ssot` resolves the subfolder to the **bundle file**, so `read_dir(file)` returned nothing → every lockfile entry fell into the `WouldRemove` branch.

Apply never actually deleted (it reinstalls correctly), but the dry-run output — and the interactive plan derived from it — was wrong and alarming.

## Fix

- Dry-run now resolves a source the same way the installer does, via `planned_source_hashes`: bundle files go through registry-root discovery + dependency resolution; directories are walked with `iter_item_dirs`, so nested `<root>/<category>/<item>/` layouts also match install. This removes the dry-run/apply divergence (and a latent flat-vs-nested-layout divergence for non-bundle sources too).
- **Defense in depth** (per the issue's suggested guard): `guard_against_empty_source` aborts *both* apply and dry-run when a source resolves to zero items while the lockfile still records entries for it — a fetch/resolution glitch is indistinguishable from a real full removal, so the safe default is to refuse and point at `upskill remove --source <label>`.

## Tests

New `tests/cli_update_bundle.rs` (RED before the fix, GREEN after): dry-run all, dry-run named item, and apply — all against a local-path bundle source. Full suite green; `just verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
