### PR TITLE
feat: coupling redesign slice 1 — optional naming, ignore, same-source requires

### DIFF
--- a/docs/adr/0009-coupling-tiers-and-dependencies.md
+++ b/docs/adr/0009-coupling-tiers-and-dependencies.md
@@ -1,0 +1,187 @@
+# Coupling tiers and directed dependencies
+
+**Status**: Proposed (2026-06-03). Amends [ADR-0006](./0006-flat-item-layout.md).
+
+## Context
+
+Co-location — multiple entrypoints in one item directory sharing the directory
+name ([ADR-0006](./0006-flat-item-layout.md),
+[format-spec §2.1](../format-spec.md)) — is currently the only mechanism for
+"install a rule + skill + agent together." Using co-location for that purpose
+causes three failures (see the
+[coupling redesign design](../superpowers/specs/2026-06-03-coupling-redesign-design.md)
+§1):
+
+- **Forced shared name.** All co-located kinds must share the folder name, even
+  when their natural identities differ.
+- **No copy scoping.** An item's whole supporting tree is copied with no way to
+  exclude build artifacts, fixtures, or test scripts.
+- **Ecosystem-invisible coupling.** Rules and agents do not exist in the Agent
+  Skills standard, so a "these travel together" intent encoded by co-location
+  cannot survive a round-trip through standard-only tooling.
+
+Co-location is the right primitive for a _symmetric, inseparable_ unit. It is
+the wrong primitive for a _directed_ "A needs B" relationship or a _curated,
+optional_ set. This decision repositions co-location and adds the two missing
+coupling tiers.
+
+## Decision
+
+### Three coupling tiers
+
+upskill recognizes three non-overlapping coupling tiers:
+
+| Tier                                 | Mechanism                                     | For                                           |
+| ------------------------------------ | --------------------------------------------- | --------------------------------------------- |
+| Symmetric unit (inseparable, mutual) | **co-location** — the folder _is_ the unit    | a mutual rule↔skill that must travel together |
+| Directed prerequisite (A needs B)    | **`requires` / `preload-skills`** frontmatter | an item that needs an item in another unit    |
+| Curated / optional set               | **bundles** (already exist)                   | a-la-carte packs                              |
+
+A mutual dependency is expressed by **co-locating** (the folder is the
+symmetric set), **never** by mutual `requires` — a `requires` cycle is an
+error.
+
+### Relaxed + optional naming
+
+The model field `name` becomes optional for `Skill`, `Rule`, and `Agent`. The
+**effective name** is resolved at discovery/parse time:
+
+- **Skill**: `name` is optional. When present it MUST equal the folder name
+  (the Agent Skills standard mandate). When absent, the effective name is the
+  folder name.
+- **Rule / Agent**: `name` comes from frontmatter and **MAY diverge** from the
+  folder name. When absent, the effective name is the folder name.
+
+Identity is `(kind, effective-name)` — layout-independent, never a path. The
+folder name is the fallback default and the co-location grouping key; it
+governs the skill when a skill is present, and otherwise serves only those two
+roles. A co-located folder MAY hold **independently-named kinds** (e.g.
+`markspec-trace/` with a skill named `markspec-trace` and a rule named
+`markspec-trace-syntax`). A solo rule/agent whose frontmatter name diverges
+from its folder is legal and emits **no lint diagnostic** — divergence is
+silent, because identity is layout-independent.
+
+### `requires` — directed dependencies
+
+`requires` is a per-entrypoint frontmatter field common to all kinds (each item
+owns its own edges — not a folder manifest, not skill-only). It mirrors the
+bundle `items` vocabulary:
+
+```yaml
+requires:
+  rules: [security-baseline]
+  skills: [sarif-formatting]
+  agents: []
+```
+
+- Dependencies are **hard** (auto-installed) and **acyclic** (a cycle is an
+  error).
+- Each `requires.<kind>` entry is a **bare string** (same-source, resolved by
+  name) or a `{ name, source }` **map** (cross-source; `source` reuses the
+  `upskill add` source DSL — `owner/repo@ref`, https, `gitlab:`, local).
+- Resolution is by `(kind, name)`.
+- **`preload-skills`** (agent) implies `requires.skills` for each listed skill:
+  the skill is required for install AND preloaded at agent startup.
+
+### `ignore` — copy scoping
+
+`ignore` is a per-entrypoint frontmatter field common to all kinds. It is
+`.gitignore`-style and **subtractive only** — there is no `include`/allowlist
+form, because an allowlist re-opens the under-copy footgun. A file matching any
+`ignore` pattern is not copied; absent `ignore` means copy everything.
+`ignore` is stripped from generated output.
+
+```yaml
+ignore: ["scripts/**", "fixtures/**"]
+```
+
+### Cross-source contract
+
+- **`source`** reuses the `upskill add` DSL verbatim, parsed by the existing
+  source machinery.
+- **Conflict.** The same `(kind, name)` resolving to a different source/ref is
+  an **error** — this reuses the existing same-name-different-source rule
+  ([format-spec §3.7](../format-spec.md)). No version-range solving, no SAT.
+- **Cycle detection** is keyed by `(canonical-source-label, kind, name)`.
+- **Provenance.** A dependency-pulled item is recorded with its **own** source
+  plus a **`required_by`** provenance list.
+- **Removal never cascades** (the #196 "never auto-delete" ethos). `doctor`
+  flags an item that is now present only as a removed item's dependency as an
+  "orphaned dependency."
+- **Staging.** Cross-source resolution ships in a follow-up release (Slice 2);
+  same-source resolution ships now (Slice 1).
+
+### Inherent limit
+
+Co-located rules/agents are invisible to standard-only tooling: the Agent
+Skills standard has no concept of rules or agents. The cross-kind "install
+together" guarantee holds **only inside upskill** and cannot survive a
+round-trip through the standard ecosystem. This is a property of the standard,
+not a defect to engineer around.
+
+## Consequences
+
+**Positive.**
+
+- The three co-location failures are resolved: directed coupling no longer
+  forces a shared name (`requires` resolves by `(kind, name)` across folders);
+  copy scoping is available via `ignore`; and a directed "A needs B" intent is
+  carried by an explicit field rather than implied by folder membership.
+- Co-location stays the right primitive for a symmetric, inseparable unit —
+  repositioned, not removed.
+- Rule/agent identity becomes layout-independent, so authors can name kinds
+  naturally and group them in folders for convenience without coupling the two
+  concerns.
+- The cross-source contract reuses the established `add` DSL and the existing
+  same-name-different-source conflict rule, adding no new resolution machinery.
+
+**Negative / limits.**
+
+- The inherent-limit note stands: cross-kind coupling is an upskill-only
+  guarantee and does not survive a round-trip through standard-only tooling.
+- Cross-source resolution is staged to a later release, so the full transitive
+  closure across sources is not available in Slice 1.
+
+## Alternatives considered (Rejected — do not revisit)
+
+Lifted from the
+[design spec §4](../superpowers/specs/2026-06-03-coupling-redesign-design.md):
+
+- **Reference-aware / traced copy** — under-copies transitive deps hidden
+  inside scripts/binaries (validated against Vercel NFT and
+  vercel-labs/skills#810).
+- **`include`/allowlist form in `ignore`** — same under-copy footgun;
+  subtractive only.
+- **Folder-file dependency manifest** — overlaps bundles, is
+  ecosystem-invisible, and adds a third coupling construct.
+- **Dependencies declared only in the skill** — skill-less units exist, so the
+  skill is the wrong owner.
+- **Path-based item references** — layout-brittle and conflicts with
+  name-based identity.
+- **Dropping co-location entirely** — it is the right primitive for symmetric
+  units; reposition, don't delete.
+- **`repo#name` single-token selector** — `#` collides with git/npm ref
+  semantics and is a shell comment; positional name + `{ name, source }` cover
+  it.
+- **Naming the copy-scope field `resources`** — overloads the standard's
+  vocabulary; use `ignore`.
+- **Requiring rule/agent name to match the folder** — contradicts
+  independently-named co-located kinds.
+- **Lint warning on solo rule/agent name divergence** — identity is
+  layout-independent, so divergence is silent.
+
+## Migration
+
+Per [no back-compat until 1.0](../../AGENTS.md) and consistent with
+[ADR-0006](./0006-flat-item-layout.md)'s migration section, this is a pre-1.0
+hard cut. New SSOT-only fields (`requires`, `ignore`) and the relaxed naming
+rule are read by the new release only — no back-compat shim, no fallback
+fields, no dual-support window.
+
+## References
+
+- Amends: [ADR-0006](./0006-flat-item-layout.md) — flat item layout.
+- Authoritative spec: [`docs/format-spec.md`](../format-spec.md) §§2.1, 2.4,
+  3.1, 3.4, 3.7, 3.8, 11.
+- Design source:
+  [coupling redesign design](../superpowers/specs/2026-06-03-coupling-redesign-design.md).

--- a/docs/adr/0009-coupling-tiers-and-dependencies.md
+++ b/docs/adr/0009-coupling-tiers-and-dependencies.md
@@ -80,8 +80,12 @@ requires:
   name) or a `{ name, source }` **map** (cross-source; `source` reuses the
   `upskill add` source DSL — `owner/repo@ref`, https, `gitlab:`, local).
 - Resolution is by `(kind, name)`.
-- **`preload-skills`** (agent) implies `requires.skills` for each listed skill:
-  the skill is required for install AND preloaded at agent startup.
+- **`preload-skills`** (agent) is a soft implies of `requires.skills` for skills
+  **present in the same source**: those skills are auto-installed alongside the agent AND preloaded
+  at startup. A preloaded skill absent from the same source is a runtime hint — neither
+  auto-installed nor an error (unlike an explicit `requires` entry, which errors when missing).
+  For GitHub Copilot and opencode (no native preload mechanism), the implementation renders
+  the preload list as a prose `## Skills` section in the agent body.
 
 ### `ignore` — copy scoping
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@ Numbered sequentially. Status one of: Proposed | Accepted | Superseded.
 - [0006 — Flat item layout — drop kind subdirectories](0006-flat-item-layout.md)
 - [0007 — Bundle file format — YAML, not Markdown-with-frontmatter](0007-bundle-yaml-format.md)
 - [0008 — Plugin installation — extend Bundle, shell out to client CLIs](0008-plugin-install-shellout.md)
+- [0009 — Coupling tiers and directed dependencies](0009-coupling-tiers-and-dependencies.md)

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -359,12 +359,16 @@ intent explicit.
 
 **`preload-skills` is Claude-Code-primary.** Claude Code emits this list as `skills:` in agent
 frontmatter so the named skills are loaded at agent startup. GitHub Copilot and opencode have no
-equivalent and ignore the field. Implementations MUST emit `skills:` for Claude Code; they MUST
-NOT emit a corresponding field for clients without an equivalent.
+equivalent frontmatter field. Implementations MUST emit `skills:` for Claude Code; for GitHub
+Copilot and opencode, implementations SHOULD render the preloaded skills as a prose `## Skills`
+section appended to the agent body (no frontmatter field), so the agent is informed which skills it
+relies on.
 
-**`preload-skills` implies `requires.skills`.** Listing a skill in `preload-skills` also implies
-`requires.skills` for that skill (§3.7): the skill is required for install AND preloaded at agent
-startup.
+**`preload-skills` implies `requires.skills` (soft).** Listing a skill in `preload-skills` implies
+`requires.skills` for skills **present in the same source**: those skills are auto-installed
+alongside the agent. A preloaded skill absent from the same source is treated as a runtime hint
+and is neither auto-installed nor an error (this differs from an explicit `requires` entry, which
+errors when missing).
 
 **`model` aliases.** This specification guarantees the following short aliases:
 
@@ -387,11 +391,13 @@ generation rules (capability dropped with a warning when the target client has n
 Implementations map these fields to each client's agent definition format:
 
 - Claude Code: `.claude/agents/<name>.md` with `tools:` as capitalized names, `model:` as literal,
-  `skills:` from `preload-skills`.
+  `skills:` from `preload-skills`. `mode` is implicit by file location and not emitted.
 - GitHub Copilot: `.github/agents/<name>.agent.md` with `tools:` filtered per §4 mapping; `mode`
-  and `preload-skills` omitted.
+  omitted; `preload-skills` rendered as a prose `## Skills` section in the body (no frontmatter
+  field).
 - opencode: `.opencode/agents/<name>.md` with `mode:`, `permission:` map (per §7.3), and
-  passthrough fields. `preload-skills` omitted.
+  passthrough fields; `preload-skills` rendered as a prose `## Skills` section in the body (no
+  frontmatter field).
 
 ### 3.5 Client-specific passthrough blocks
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -93,23 +93,34 @@ entrypoint filename:
 ├── <name-c>/
 │   └── AGENT.md
 └── <name-d>/                # optional co-location: multiple kinds in one item directory
-    ├── SKILL.md             # name: <name-d>
-    └── AGENT.md             # name: <name-d>
+    ├── SKILL.md             # name omitted or name: <name-d> (skill must match the directory)
+    └── RULE.md              # name: <name-d> or a divergent name (rule/agent name MAY differ)
 ```
 
 Constraints:
 
 - An item directory MUST contain at least one entrypoint file (`RULE.md`, `SKILL.md`, or
   `AGENT.md`).
-- An item directory MAY contain more than one entrypoint when the entrypoints share a name and
-  represent a tightly-coupled set of kinds for one capability (for example, a skill paired
-  with its enforcing rule, or an agent paired with a skill it preloads). When multiple
-  entrypoints are present, every entrypoint's `name:` field MUST equal the directory name.
-  Co-location is optional; solo-kind item directories are the common case.
-- `<name>` MUST match the `name` field in every entrypoint within the directory.
-- `<name>` MUST consist of lowercase letters (`a-z`), digits (`0-9`), and hyphens (`-`).
-- `<name>` MUST NOT start or end with a hyphen.
-- `<name>` MUST be at most 64 characters.
+- An item directory MAY contain more than one entrypoint when the kinds represent a
+  tightly-coupled set for one capability (for example, a skill paired with its enforcing rule,
+  or an agent paired with a skill it preloads). Co-location is optional; solo-kind item
+  directories are the common case. Co-location expresses a _symmetric, inseparable_ unit; a
+  _directed_ "A needs B" relationship is expressed with `requires` (§3.7) instead. See
+  [ADR-0009](./adr/0009-coupling-tiers-and-dependencies.md).
+- **Effective name and relaxed naming.** Each entrypoint resolves to an **effective name**:
+  - A **skill** `name:` is optional. When present it MUST equal the directory name (the Agent
+    Skills standard mandate). When absent, the skill's effective name is the directory name.
+  - A **rule** or **agent** `name:` comes from frontmatter and MAY differ from the directory
+    name. When absent, the effective name is the directory name. A divergent rule/agent name is
+    legal and is not a diagnostic.
+- **Identity is `(kind, effective-name)`** — layout-independent, never a path. A directory MAY
+  hold independently-named kinds (for example, a skill named after the directory alongside a
+  rule whose name diverges). The directory name is the **co-location grouping key** and the
+  fallback default for any entrypoint that omits `name:`.
+- The **effective name** MUST consist of lowercase letters (`a-z`), digits (`0-9`), and hyphens
+  (`-`).
+- The **effective name** MUST NOT start or end with a hyphen.
+- The **effective name** MUST be at most 64 characters.
 - Kind is determined by the entrypoint filename: `RULE.md` for a rule, `SKILL.md` for a skill,
   `AGENT.md` for an agent. Implementations MUST NOT infer kind from any other source (parent
   directory name, frontmatter field, etc.).
@@ -206,6 +217,10 @@ Items MAY contain supporting files in their directory:
 - Supporting files are referenced from the entrypoint body using standard markdown relative links.
 - Implementations MUST preserve supporting files and their directory structure during generation
   (copy them alongside the generated entrypoint into the client-expected location).
+- An item MAY declare an `ignore` list (§3.1) to scope which supporting files are copied. The
+  list is `.gitignore`-style and **subtractive only** — there is no `include`/allowlist form. A
+  file matching any `ignore` pattern is not copied into the client-expected location. `ignore`
+  is author-declared and is stripped from generated output.
 - When an item directory holds multiple kinds (§2.1), supporting resources are shared: any
   entrypoint in the directory MAY reference them via relative links, and implementations MUST
   copy them alongside each generated entrypoint that references them.
@@ -229,6 +244,8 @@ Item entrypoint files (RULE.md, SKILL.md, AGENT.md) begin with YAML frontmatter 
 | `license`     | string   | no       | SPDX identifier or custom (`proprietary`, `LicenseRef-*`).                                                                                                           |
 | `audience`    | string[] | no       | Target clients (`claude`, `copilot`, `opencode`). When present, implementations MUST generate output only for listed clients. When absent, all clients are targeted. |
 | `metadata`    | map      | no       | Free-form governance block. See §3.6.                                                                                                                                |
+| `requires`    | map      | no       | Directed item dependencies (rules/skills/agents). See §3.7. Stripped from output.                                                                                    |
+| `ignore`      | string[] | no       | `.gitignore`-style subtractive copy-scope (§2.4). Stripped from output.                                                                                              |
 
 Example:
 
@@ -261,6 +278,13 @@ Field semantics:
   to scope body content within an emitted item, and passthrough blocks to add client-specific
   frontmatter to an emitted item.
 - `metadata`: see §3.6. Implementations MUST preserve unknown keys within `metadata`.
+- `requires`: directed prerequisite items. Each `requires.<kind>` entry is either a bare name
+  (same source, resolved by `(kind, name)`) or a `{ name, source }` map for a cross-source
+  dependency, where `source` reuses the `upskill add` source DSL. See §3.7 for resolution,
+  cycle, and conflict rules.
+- `ignore`: `.gitignore`-style subtractive copy-scope (§2.4). Both `requires` and `ignore` are
+  SSOT-only authoring fields and are stripped from every client output (the same treatment as
+  `schema`, `metadata`, and `license`).
 
 ### 3.2 Rule-specific fields
 
@@ -336,6 +360,10 @@ intent explicit.
 frontmatter so the named skills are loaded at agent startup. GitHub Copilot and opencode have no
 equivalent and ignore the field. Implementations MUST emit `skills:` for Claude Code; they MUST
 NOT emit a corresponding field for clients without an equivalent.
+
+**`preload-skills` implies `requires.skills`.** Listing a skill in `preload-skills` also implies
+`requires.skills` for that skill (§3.7): the skill is required for install AND preloaded at agent
+startup.
 
 **`model` aliases.** This specification guarantees the following short aliases:
 
@@ -639,6 +667,27 @@ Implementations:
 - MUST use warn-skip when the target client CLI is not found (`ErrorKind::NotFound`).
 - MUST NOT fail the entire bundle install when a single plugin install fails or is skipped.
 
+#### Item `requires` resolution
+
+Items (rules, skills, agents) MAY declare directed dependencies in their `requires` field
+(§3.1). This is distinct from bundle `requires`, which links bundles: item `requires` links
+individual items. See [ADR-0009](./adr/0009-coupling-tiers-and-dependencies.md).
+
+Implementations:
+
+- MUST install an item's transitive `requires` closure: installing an item implies installing
+  every item reachable through `requires`.
+- MUST resolve each `requires.<kind>` entry by `(kind, name)`.
+- MUST reject circular item `requires` chains as errors.
+- MUST report the same `(kind, name)` resolving to a different source or ref as an error (the
+  same rule already stated above for bundle item-level conflicts).
+
+Each `requires.<kind>` entry is a bare name (same source) or a `{ name, source }` map
+(cross-source), where `source` reuses the `upskill add` source DSL. Same-source resolution
+(bare-name entries against the entry item's own already-fetched source) is implemented in the
+initial release; cross-source resolution (`{ name, source }` entries) is specified here but
+lands in a later release.
+
 ### 3.8 Frontmatter canonicalisation
 
 An implementation MAY provide a formatting command (e.g., `upskill fmt`) that canonicalises SSOT
@@ -648,12 +697,12 @@ reducing merge conflicts.
 **Canonical key order.** When canonicalising frontmatter, implementations MUST emit keys in the
 following order (unlisted keys appear at the end in their original relative order):
 
-| Kind   | Key order                                                                                                                                                 |
-| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Rule   | `schema`, `name`, `description`, `audience`, `license`, `scope`, `metadata`, `claude`, `copilot`, `opencode`, `extras`                                    |
-| Skill  | `schema`, `name`, `description`, `audience`, `license`, `tools`, `preload-skills`, `metadata`, `claude`, `copilot`, `opencode`, `extras`                  |
-| Agent  | `schema`, `name`, `description`, `audience`, `license`, `mode`, `model`, `tools`, `preload-skills`, `metadata`, `claude`, `copilot`, `opencode`, `extras` |
-| Bundle | `schema`, `name`, `description`, `license`, `items`, `requires`, `plugins`, `metadata`, `extras`                                                          |
+| Kind   | Key order                                                                                                                                                                       |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rule   | `schema`, `name`, `description`, `audience`, `license`, `scope`, `metadata`, `requires`, `ignore`, `claude`, `copilot`, `opencode`, `extras`                                    |
+| Skill  | `schema`, `name`, `description`, `audience`, `license`, `tools`, `preload-skills`, `metadata`, `requires`, `ignore`, `claude`, `copilot`, `opencode`, `extras`                  |
+| Agent  | `schema`, `name`, `description`, `audience`, `license`, `mode`, `model`, `tools`, `preload-skills`, `metadata`, `requires`, `ignore`, `claude`, `copilot`, `opencode`, `extras` |
+| Bundle | `schema`, `name`, `description`, `license`, `items`, `requires`, `plugins`, `metadata`, `extras`                                                                                |
 
 **Comment preservation.** Canonicalisation:
 
@@ -985,8 +1034,12 @@ The following topics are explicitly deferred and tracked for future specificatio
    (replacing only a specific heading's content) rather than full-body replacement.
 6. **Skill activation control**: whether `disable-model-invocation` and `user-invocable` from
    the Agent Skills standard should be surfaced as neutral fields or remain client passthroughs.
-7. **Multi-repo item sources**: whether the specification should define a source-resolution
-   protocol or leave it entirely to implementations.
+7. **Multi-repo item sources** (RESOLVED): the item `requires` field with a `{ name, source }`
+   locator (§3.7) defines the cross-source resolution contract — `source` reuses the `upskill
+   add` source DSL, conflicts reuse the same-name-different-source rule, and cycles are keyed by
+   `(canonical-source-label, kind, name)`. Same-source resolution is implemented; cross-source
+   resolution is staged to a later release. See
+   [ADR-0009](./adr/0009-coupling-tiers-and-dependencies.md).
 8. **Content hashing**: whether items should carry a content hash for integrity verification
    during distribution, independent of `metadata.version`.
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -239,7 +239,7 @@ Item entrypoint files (RULE.md, SKILL.md, AGENT.md) begin with YAML frontmatter 
 | Field         | Type     | Required | Description                                                                                                                                                          |
 | ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `schema`      | integer  | YES      | Protocol version of this specification. Current: `1`.                                                                                                                |
-| `name`        | string   | YES      | Stable identifier. See §2.1 for format constraints.                                                                                                                  |
+| `name`        | string   | varies   | Stable identifier. Required for bundles; optional for items (effective name defaults to the directory name). See §2.1.                                               |
 | `description` | string   | YES      | What this item does and when to use it. Max 1024 characters. Skill-specific guidance: see §3.3.                                                                      |
 | `license`     | string   | no       | SPDX identifier or custom (`proprietary`, `LicenseRef-*`).                                                                                                           |
 | `audience`    | string[] | no       | Target clients (`claude`, `copilot`, `opencode`). When present, implementations MUST generate output only for listed clients. When absent, all clients are targeted. |
@@ -265,8 +265,9 @@ Field semantics:
 
 - `schema`: implementations MUST reject files with `schema` greater than the highest version they
   support and SHOULD report a clear upgrade message. See §8 for evolution rules.
-- `name`: used as the `/slash-command` name in clients that support it, as the directory name, and
-  as the identifier in bundle manifests.
+- `name`: the effective name (§2.1) is used as the `/slash-command` name in clients that support it
+  and as the identifier in bundle manifests. When `name` is omitted on an item, the directory name
+  is the effective name; a rule or agent `name` MAY differ from its directory.
 - `description`: for skills, this is the activation hint — the model reads it during discovery and
   decides whether to load the full body. For rules and agents, it serves as documentation. Front-load
   the key use case. Convention: start with "Use when…" for skills and agents.

--- a/docs/superpowers/plans/2026-06-03-coupling-redesign-slice1.md
+++ b/docs/superpowers/plans/2026-06-03-coupling-redesign-slice1.md
@@ -1,0 +1,1482 @@
+# Coupling Redesign — Slice 1 (same-source) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reposition co-location as the "symmetric unit" primitive and add the directed-dependency tier: optional/relaxed item naming, `ignore` copy-scoping, and same-source `requires` auto-install — plus the lockfile/doctor bookkeeping that makes co-located units removable and orphaned dependencies visible.
+
+**Architecture:** SSOT models gain two stripped-from-output fields (`requires`, `ignore`) and an optional `name`. Item _identity_ becomes `(kind, effective-name)` where the effective name is the frontmatter `name` for rules/agents (may diverge from the folder) or the folder name for skills (Agent Skills standard mandate) and as a fallback. The install pipeline resolves the same-source `requires` transitive closure before conflict detection, copies resources minus `ignore` globs, and records co-location grouping + `required_by` provenance in the lockfile.
+
+**Tech Stack:** Rust (edition 2024, MSRV 1.85), `serde` + `serde_yaml_ng`, `anyhow`, `assert_cmd` + `tempfile` for integration tests. No new dependencies (the `ignore` glob matcher is hand-rolled to protect the ~3 MB binary target).
+
+**Reference spec:** [docs/superpowers/specs/2026-06-03-coupling-redesign-design.md](../specs/2026-06-03-coupling-redesign-design.md)
+
+**Out of scope (Slice 2, separate plan):** cross-source `requires` resolution (`{ name, source }` fetched via `fetch_ssot`), cross-source cycle/conflict keyed by canonical source label. Slice 1 parses the `{ name, source }` form but errors clearly when asked to resolve one.
+
+---
+
+## Conventions for every task
+
+- **Worktree:** all work happens in `.claude/worktrees/feat-coupling-redesign/` (branch `feat/coupling-redesign`, already bootstrapped, off `origin/main`). Use full worktree-prefixed absolute paths for every Write/Edit.
+- **TDD:** write the failing test, run it red, implement, run it green, commit. One Conventional Commit per task (or per sub-behavior).
+- **Test isolation (issue #193 — has bitten twice):** integration tests MUST use `tests/common::upskill_cmd(fake_home)` and create a `.git` marker dir in the project dir, or `upskill add` defaults to global `$HOME` scope and pollutes the real `~`. Inspect `tests/common/mod.rs` before writing the first integration test and follow the existing pattern.
+- **Before the PR:** `just fmt` then `just verify`. Squash-merge.
+- **Pre-1.0:** no back-compat shims. Lockfile field additions are additive (`#[serde(default)]`), no schema bump.
+
+---
+
+## File structure
+
+**Docs (Task 1):**
+
+- Create: `docs/adr/0009-coupling-tiers-and-dependencies.md`
+- Modify: `docs/format-spec.md` (§2.1, §2.4, §3.1, §3.4, §3.7, §3.8, §11)
+
+**Model (Tasks 2, 4):**
+
+- Create: `src/model/requires.rs` — `ItemRequires` + `RequireRef`
+- Modify: `src/model/mod.rs` — re-export the new types
+- Modify: `src/model/skill.rs`, `src/model/rule.rs`, `src/model/agent.rs` — `name: Option<String>`, add `requires`, `ignore`
+
+**Generation (Task 4):**
+
+- Modify: `src/generate/mod.rs` — `render_*` and `build_skill_frontmatter` take `name: &str`
+- Modify: `src/generate/claude.rs`, `src/generate/copilot.rs`, `src/generate/opencode.rs` — `rule_frontmatter`/`agent_frontmatter`/`skill_frontmatter` take `name: &str`
+
+**Resources (Task 3):**
+
+- Create: `src/pipeline/ignore.rs` — `filter_ignored` + the glob matcher
+- Modify: `src/pipeline/mod.rs` — `mod ignore;`
+- Modify: `src/pipeline/install.rs` — apply `ignore` before copy
+
+**Naming + discovery (Task 4):**
+
+- Modify: `src/pipeline/discovery.rs` — `effective_name`, `probe_effective_name`, `scan_source_items` returns effective names
+- Modify: `src/pipeline/install.rs` — compute + use effective name
+- Modify: `src/lint.rs` — relax `check_name_matches_dir`; `parse_kind` returns `Option<String>` name
+
+**Dependencies (Task 5):**
+
+- Modify: `src/pipeline/install.rs` — `resolve_requires_closure`
+- Modify: `src/pipeline/mod.rs` — wire closure into `install_with_lockfile`
+- Modify: `src/lockfile.rs` — `LockedItem.required_by`, `items_from_report` takes a provenance map
+
+**Grouping + lifecycle (Tasks 6, 7):**
+
+- Modify: `src/lockfile.rs` — `LockedItem.group`
+- Modify: `src/pipeline/install.rs` / `src/pipeline/mod.rs` — record `group`
+- Modify: `src/pipeline/lifecycle.rs` — `remove` acts on the co-located unit; `doctor` orphaned-dependency flag
+- Modify: `src/pipeline/report.rs` — `OrphanedDependency` + `DoctorReport.orphaned_dependencies`
+
+**Integration tests:**
+
+- Create/extend: `tests/cli_requires.rs`, `tests/generate_*` (strip), `tests/pipeline_*` (grouping, doctor)
+
+---
+
+## Task 1: ADR-0009 + format-spec edits
+
+**Files:**
+
+- Create: `docs/adr/0009-coupling-tiers-and-dependencies.md`
+- Modify: `docs/format-spec.md`
+
+This task is documentation; its "test" is `just fmt` (markdownlint + dprint) passing and the internal links resolving. No Rust tests.
+
+- [ ] **Step 1: Write ADR-0009**
+
+Create `docs/adr/0009-coupling-tiers-and-dependencies.md` following the structure of `docs/adr/0006-flat-item-layout.md` (Status / Context / Decision / Consequences / Alternatives considered / References). Content, drawn verbatim in substance from the design spec:
+
+- **Status**: Proposed (2026-06-03). Amends ADR-0006.
+- **Context**: co-location is currently the only "install together" mechanism; the three failures (forced shared name, no copy scoping, ecosystem-invisible coupling). Reference the spec.
+- **Decision**:
+  - Three coupling tiers (co-location = symmetric unit; `requires`/`preload-skills` = directed; bundles = curated). A mutual dependency is co-location, never mutual `requires` (cycle = error).
+  - Relaxed + optional naming: skill `name` optional → folder fallback, must match folder if present; rule/agent `name` from frontmatter, may diverge, folder is fallback + grouping key only; identity is `(kind, name)`, layout-independent; no lint diagnostic on rule/agent divergence.
+  - `requires` (per-entrypoint, hard, acyclic, resolved by `(kind, name)`, string-or-`{name,source}`); `preload-skills` implies `requires.skills`. `ignore` (subtractive copy scope).
+  - Cross-source contract (source reuses `add` DSL; conflict = same `(kind,name)` different source/ref is an error reusing §3.7; cycle keyed by `(canonical-source, kind, name)`; `required_by` provenance; removal never cascades; doctor flags orphaned deps). Note that cross-source _resolution_ ships in a follow-up.
+  - Inherent limit: co-located rules/agents are invisible to standard-only tooling; the cross-kind guarantee holds only inside upskill.
+- **Consequences** and **Alternatives considered**: lift the "Rejected" list from the design spec §4.
+- **References**: ADR-0006, format-spec, design spec.
+
+- [ ] **Step 2: Edit format-spec §2.1 — relaxed/optional naming**
+
+In `docs/format-spec.md` §2.1, replace the constraint "`<name>` MUST match the `name` field in every entrypoint within the directory" and the co-location "every entrypoint's `name:` field MUST equal the directory name" with:
+
+> - A `SKILL.md`'s `name` field, **when present**, MUST equal the directory name (Agent Skills standard). When absent, the effective skill name is the directory name.
+> - A `RULE.md`'s or `AGENT.md`'s `name` field, when present, is that item's identity and MAY differ from the directory name. When absent, the effective name is the directory name.
+> - Item identity is `(kind, effective-name)` and is independent of on-disk layout.
+> - A directory MAY hold independently-named kinds (e.g. a skill named after the directory plus a rule with its own name). The directory name is the co-location grouping key.
+
+Keep the lowercase/hyphen/length constraints on the effective name. Keep the Agent Skills compatibility paragraph.
+
+- [ ] **Step 3: Edit format-spec §2.4 — `ignore` copy scope**
+
+In §2.4, after the "Implementations MUST preserve supporting files" bullet, add:
+
+> An item MAY declare an `ignore` list in its frontmatter (§3.1) to exclude supporting files from the copy. Patterns are `.gitignore`-style and **subtractive only** (there is no allowlist form). A file matching any `ignore` pattern is not copied to client output. `ignore` itself is stripped from generated output.
+
+- [ ] **Step 4: Edit format-spec §3.1 — `requires` + `ignore` common fields**
+
+Add two rows to the §3.1 common-fields table:
+
+| Field      | Type     | Required | Description                                                                             |
+| ---------- | -------- | -------- | --------------------------------------------------------------------------------------- |
+| `requires` | map      | no       | Directed item dependencies (`rules`/`skills`/`agents`). See §3.7. Stripped from output. |
+| `ignore`   | string[] | no       | `.gitignore`-style subtractive copy-scope patterns (§2.4). Stripped from output.        |
+
+Add field semantics prose: each `requires.<kind>` entry is a bare name (same source) or a `{ name, source }` map (cross-source; `source` uses the `add` source DSL). Both `requires` and `ignore` are stripped from every client output (like `schema`, `metadata`, `license`).
+
+- [ ] **Step 5: Edit format-spec §3.4 — `preload-skills` implies `requires`**
+
+In §3.4, add to the `preload-skills` description: "Listing a skill in `preload-skills` also implies `requires.skills` for that skill (it is both required for install and preloaded at agent startup)."
+
+- [ ] **Step 6: Edit format-spec §3.7 — item `requires` cycle + conflict**
+
+Add a subsection "Item `requires` resolution" stating: installing an item implies installing its transitive `requires` closure; resolution is by `(kind, name)`; circular item `requires` MUST be rejected as an error; the same `(kind, name)` resolving to a different source or ref MUST be an error (the same rule already stated for bundle item conflicts). Note cross-source resolution is specified here but lands in a later release.
+
+- [ ] **Step 7: Edit format-spec §3.8 — canonical key order**
+
+Add `requires` and `ignore` to each item kind's key order (after `metadata`, before the passthrough blocks). Rule/Skill/Agent rows get `…, metadata, requires, ignore, claude, copilot, opencode, extras`. Bundle row unchanged.
+
+- [ ] **Step 8: Edit format-spec §11 — mark multi-repo sources resolved**
+
+Change open-question 7 ("Multi-repo item sources") to RESOLVED, noting `requires` with a `source` locator (§3.7) defines the resolution contract; same-source resolution is implemented and cross-source resolution is staged.
+
+- [ ] **Step 9: Format and commit**
+
+```bash
+cd .claude/worktrees/feat-coupling-redesign
+just fmt
+git add docs/adr/0009-coupling-tiers-and-dependencies.md docs/format-spec.md
+git commit -m "docs(adr): ADR-0009 coupling tiers + dependencies; format-spec edits"
+```
+
+Expected: `just fmt` reports formatted/clean; commit succeeds (the `git std lint` commit-message hook passes for a Conventional Commit).
+
+---
+
+## Task 2: Model — `requires` + `ignore` fields (additive, stripped)
+
+**Files:**
+
+- Create: `src/model/requires.rs`
+- Modify: `src/model/mod.rs`
+- Modify: `src/model/skill.rs:7-33`, `src/model/rule.rs:14-39`, `src/model/agent.rs:31-68`
+- Test: unit tests in `src/model/requires.rs` + `src/parse/frontmatter.rs`; integration strip test in `tests/`
+
+`name` stays `String` in this task — only `requires`/`ignore` are added, so the build and all generation stay green. Optional `name` is Task 4.
+
+- [ ] **Step 1: Write the failing model test**
+
+Create `src/model/requires.rs` with the types and a unit test module:
+
+```rust
+//! Item-level `requires` (§3.7) — directed dependencies declared per
+//! entrypoint. Distinct from the bundle-level `Requires` (which pins a
+//! semver constraint); item requires resolve by `(kind, name)`.
+
+use serde::{Deserialize, Serialize};
+
+/// One `requires` reference. A bare string targets the same source by
+/// name; a `{ name, source }` map targets another source (the `source`
+/// uses the `upskill add` source DSL). Cross-source *resolution* ships in
+/// a later release; this type captures the stable on-disk form now.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RequireRef {
+    Name(String),
+    Detailed { name: String, source: String },
+}
+
+impl RequireRef {
+    pub fn name(&self) -> &str {
+        match self {
+            RequireRef::Name(n) => n,
+            RequireRef::Detailed { name, .. } => name,
+        }
+    }
+    /// The cross-source locator, if this is a `{ name, source }` entry.
+    pub fn source(&self) -> Option<&str> {
+        match self {
+            RequireRef::Name(_) => None,
+            RequireRef::Detailed { source, .. } => Some(source),
+        }
+    }
+}
+
+/// `requires:` block — mirrors the bundle `items` vocabulary.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ItemRequires {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<RequireRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<RequireRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<RequireRef>,
+}
+
+impl ItemRequires {
+    /// True when no dependency is declared. Used by `skip_serializing_if`.
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty() && self.skills.is_empty() && self.agents.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_string_and_map_entries() {
+        let yaml = "rules: [security-baseline]\nskills: [{ name: sarif, source: org/repo }]\n";
+        let req: ItemRequires = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(req.rules, vec![RequireRef::Name("security-baseline".into())]);
+        assert_eq!(req.skills[0].name(), "sarif");
+        assert_eq!(req.skills[0].source(), Some("org/repo"));
+        assert!(req.agents.is_empty());
+    }
+
+    #[test]
+    fn empty_when_no_kinds() {
+        assert!(ItemRequires::default().is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run it red**
+
+Run: `cargo test -p upskill model::requires`
+Expected: FAIL to compile — module not declared in `src/model/mod.rs`.
+
+- [ ] **Step 3: Declare and re-export the module**
+
+In `src/model/mod.rs`, add `pub mod requires;` (after `pub mod rule;`) and to the re-export block add:
+
+```rust
+pub use requires::{ItemRequires, RequireRef};
+```
+
+- [ ] **Step 4: Run it green**
+
+Run: `cargo test -p upskill model::requires`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Add `requires` + `ignore` to the three item models**
+
+In each of `src/model/skill.rs`, `src/model/rule.rs`, `src/model/agent.rs`, add these two fields immediately after the `metadata` field and before the passthrough blocks (`claude`/`copilot`/`opencode`). Add `ItemRequires` to the `use crate::model::...` import line in each file.
+
+```rust
+/// §3.7 directed dependencies. SSOT-only — stripped from output.
+#[serde(default, skip_serializing_if = "ItemRequires::is_empty")]
+pub requires: crate::model::ItemRequires,
+/// §2.4 subtractive copy-scope patterns. SSOT-only — stripped from output.
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub ignore: Vec<String>,
+```
+
+(Using the fully-qualified `crate::model::ItemRequires` avoids touching each file's `use` line if preferred; either form compiles.)
+
+- [ ] **Step 6: Confirm fields land outside `extra` (round-trip test)**
+
+Add to `src/parse/frontmatter.rs` tests:
+
+```rust
+#[test]
+fn requires_and_ignore_parse_into_typed_fields_not_extra() {
+    let input = concat!(
+        "---\n",
+        "schema: 1\n",
+        "name: code-review\n",
+        "description: x\n",
+        "requires:\n",
+        "  skills: [sarif-formatting]\n",
+        "ignore:\n",
+        "  - \"scripts/**\"\n",
+        "---\nbody\n",
+    );
+    let (skill, _) = parse::<Skill>(input).unwrap();
+    assert_eq!(skill.requires.skills[0].name(), "sarif-formatting");
+    assert_eq!(skill.ignore, vec!["scripts/**".to_string()]);
+    // They must NOT have leaked into the pass-through `extra` map (which
+    // skills emit verbatim into output).
+    assert!(!skill.extra.contains_key("requires"));
+    assert!(!skill.extra.contains_key("ignore"));
+}
+```
+
+Run: `cargo test -p upskill requires_and_ignore_parse_into_typed_fields_not_extra`
+Expected: PASS.
+
+- [ ] **Step 7: Write the failing generation-strip integration test**
+
+Skills emit their `extra` map verbatim, so this guards the real regression. Add `tests/generate_strip_ssot_fields.rs`:
+
+```rust
+use std::fs;
+use std::process::Command;
+
+mod common;
+
+#[test]
+fn requires_and_ignore_are_stripped_from_skill_output() {
+    let env = common::TestEnv::new(); // adapt to tests/common API (see existing tests)
+    let src = env.project.join("src-registry/code-review");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("SKILL.md"),
+        "---\nschema: 1\nname: code-review\ndescription: x\nrequires:\n  skills: [other]\nignore:\n  - \"scripts/**\"\n---\n\n## Body\n\ntext\n",
+    )
+    .unwrap();
+    // Also create the required item so install does not fail on resolution.
+    let other = env.project.join("src-registry/other");
+    fs::create_dir_all(&other).unwrap();
+    fs::write(other.join("SKILL.md"), "---\nschema: 1\nname: other\ndescription: y\n---\n\n## B\n\nt\n").unwrap();
+
+    common::upskill_cmd(&env)
+        .args(["add", "./src-registry", "--claude"])
+        .assert()
+        .success();
+
+    let out = fs::read_to_string(env.project.join(".claude/skills/code-review/SKILL.md")).unwrap();
+    assert!(!out.contains("requires"), "requires must be stripped:\n{out}");
+    assert!(!out.contains("ignore"), "ignore must be stripped:\n{out}");
+}
+```
+
+NOTE: adapt the `common::` helper calls to the actual `tests/common/mod.rs` surface (read it first). The behavioral asserts are what matter.
+
+- [ ] **Step 8: Run it — verify it already passes**
+
+Run: `cargo test --test generate_strip_ssot_fields`
+Expected: PASS without any generation change — because the typed fields are not in `extra` and the builders never insert them. If it FAILS, the fields leaked into `extra` (revisit Step 5). This test is a regression guard, not a driver for new code.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd .claude/worktrees/feat-coupling-redesign
+just fmt
+git add src/model tests/generate_strip_ssot_fields.rs src/parse/frontmatter.rs
+git commit -m "feat(model): add item requires + ignore fields, stripped from output"
+```
+
+---
+
+## Task 3: `ignore` copy-scope filter
+
+**Files:**
+
+- Create: `src/pipeline/ignore.rs`
+- Modify: `src/pipeline/mod.rs:31-37` (add `mod ignore;`)
+- Modify: `src/pipeline/install.rs:425-428` (filter resources before copy)
+
+- [ ] **Step 1: Write the failing matcher test**
+
+Create `src/pipeline/ignore.rs`:
+
+```rust
+//! `.gitignore`-style subtractive filtering of an item's supporting
+//! resources (format-spec §2.4). Hand-rolled to avoid a glob dependency
+//! (protects the ~3 MB binary target). Supports `*` (any run of
+//! non-`/` chars), `**` (any run including `/`), `?` (one non-`/` char),
+//! and literal segments. A pattern with no `/` matches the basename at any
+//! depth; a pattern with a `/` matches the full relative path. A trailing
+//! `/**` (or a bare directory-name pattern) matches everything under that
+//! directory.
+
+use std::path::PathBuf;
+
+/// Drop every resource (path relative to the item dir) that matches any
+/// `ignore` glob. Returns the kept resources, order preserved.
+pub(super) fn filter_ignored(resources: Vec<PathBuf>, patterns: &[String]) -> Vec<PathBuf> {
+    if patterns.is_empty() {
+        return resources;
+    }
+    resources
+        .into_iter()
+        .filter(|rel| {
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            !patterns.iter().any(|p| matches_pattern(&rel_str, p))
+        })
+        .collect()
+}
+
+fn matches_pattern(path: &str, pattern: &str) -> bool {
+    let pattern = pattern.trim_end_matches('/');
+    // A pattern with no slash matches the basename at any depth.
+    if !pattern.contains('/') {
+        let base = path.rsplit('/').next().unwrap_or(path);
+        return glob_match(base, pattern);
+    }
+    // Directory-prefix shorthand: `scripts` or `scripts/**` ignores the
+    // whole subtree.
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return path == prefix || path.starts_with(&format!("{prefix}/"));
+    }
+    glob_match(path, pattern)
+}
+
+/// Match `text` against a glob `pat` where `*`/`?` do not cross `/` and
+/// `**` does. Recursive backtracking — patterns are short and few.
+fn glob_match(text: &str, pat: &str) -> bool {
+    let t: Vec<char> = text.chars().collect();
+    let p: Vec<char> = pat.chars().collect();
+    m(&t, 0, &p, 0)
+}
+
+fn m(t: &[char], ti: usize, p: &[char], pi: usize) -> bool {
+    if pi == p.len() {
+        return ti == t.len();
+    }
+    match p[pi] {
+        '*' if pi + 1 < p.len() && p[pi + 1] == '*' => {
+            // `**` — consume any chars including `/`.
+            let mut k = ti;
+            loop {
+                if m(t, k, p, pi + 2) {
+                    return true;
+                }
+                if k == t.len() {
+                    return false;
+                }
+                k += 1;
+            }
+        }
+        '*' => {
+            let mut k = ti;
+            loop {
+                if m(t, k, p, pi + 1) {
+                    return true;
+                }
+                if k == t.len() || t[k] == '/' {
+                    return false;
+                }
+                k += 1;
+            }
+        }
+        '?' => ti < t.len() && t[ti] != '/' && m(t, ti + 1, p, pi + 1),
+        c => ti < t.len() && t[ti] == c && m(t, ti + 1, p, pi + 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn paths(v: &[&str]) -> Vec<PathBuf> {
+        v.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn empty_patterns_keep_everything() {
+        let r = paths(&["scripts/gate.sh", "refs/p.md"]);
+        assert_eq!(filter_ignored(r.clone(), &[]), r);
+    }
+
+    #[test]
+    fn double_star_prefix_drops_subtree() {
+        let kept = filter_ignored(
+            paths(&["scripts/gate.sh", "scripts/lib/x.sh", "refs/p.md"]),
+            &["scripts/**".to_string()],
+        );
+        assert_eq!(kept, paths(&["refs/p.md"]));
+    }
+
+    #[test]
+    fn bare_name_matches_basename_at_any_depth() {
+        let kept = filter_ignored(
+            paths(&["a/b/notes.log", "keep.md"]),
+            &["*.log".to_string()],
+        );
+        assert_eq!(kept, paths(&["keep.md"]));
+    }
+
+    #[test]
+    fn single_star_does_not_cross_slash() {
+        let kept = filter_ignored(
+            paths(&["a/x.txt", "a/b/x.txt"]),
+            &["a/*.txt".to_string()],
+        );
+        assert_eq!(kept, paths(&["a/b/x.txt"]));
+    }
+
+    #[test]
+    fn bare_dir_name_ignores_subtree() {
+        let kept = filter_ignored(
+            paths(&["fixtures/data.json", "main.md"]),
+            &["fixtures".to_string()],
+        );
+        assert_eq!(kept, paths(&["main.md"]));
+    }
+}
+```
+
+- [ ] **Step 2: Run it red**
+
+Run: `cargo test -p upskill pipeline::ignore`
+Expected: FAIL — `mod ignore;` not declared.
+
+- [ ] **Step 3: Declare the module**
+
+In `src/pipeline/mod.rs`, add `mod ignore;` alongside the other `mod` lines (around line 31-37).
+
+- [ ] **Step 4: Run it green**
+
+Run: `cargo test -p upskill pipeline::ignore`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Apply the filter in install**
+
+In `src/pipeline/install.rs`, the resource collection currently reads (around line 425-428):
+
+```rust
+let source_hash = hash_item_dir(&dir);
+let resources = iter_item_resources(&dir);
+```
+
+The `ignore` list lives on the parsed model. The parse happens inside the per-kind `match` (Step in Task 4 restructures this). For Task 3, capture the `ignore` list out of the match. Change the `match` block to also yield the `ignore` vec, e.g. extend the tuple it binds:
+
+```rust
+        let (audience, ignore, renders): (Option<Vec<Audience>>, Vec<String>, Vec<(Client, String)>) =
+            match kind {
+                ItemKind::Skill => {
+                    let (skill, body) = frontmatter::parse::<Skill>(&raw)
+                        .with_context(|| format!("parse {}", entry_path.display()))?;
+                    let aud = skill.audience.clone();
+                    let ign = skill.ignore.clone();
+                    let mut out = Vec::new();
+                    /* …existing render loop… */
+                    (aud, ign, out)
+                }
+                /* Rule, Agent arms: same shape, binding rule.ignore / agent.ignore */
+            };
+
+        let source_hash = hash_item_dir(&dir);
+        let resources = super::ignore::filter_ignored(iter_item_resources(&dir), &ignore);
+```
+
+Repeat the `ign = X.ignore.clone();` and the `(aud, ign, out)` return in all three arms (Rule binds `rule.ignore`, Agent binds `agent.ignore`).
+
+- [ ] **Step 6: Write the failing install integration test**
+
+Add `tests/pipeline_ignore.rs` — install an item with a `scripts/**` ignore and assert the script is NOT copied while a non-ignored resource IS. Use the `tests/common` helpers (read `tests/common/mod.rs` first). Skeleton:
+
+```rust
+mod common;
+use std::fs;
+
+#[test]
+fn ignored_resources_are_not_copied() {
+    let env = common::TestEnv::new();
+    let item = env.project.join("reg/demo");
+    fs::create_dir_all(item.join("scripts")).unwrap();
+    fs::create_dir_all(item.join("refs")).unwrap();
+    fs::write(item.join("SKILL.md"),
+        "---\nschema: 1\nname: demo\ndescription: x\nignore:\n  - \"scripts/**\"\n---\n\n## B\n\n[r](./refs/p.md)\n").unwrap();
+    fs::write(item.join("scripts/gate.sh"), "#!/bin/sh\n").unwrap();
+    fs::write(item.join("refs/p.md"), "p\n").unwrap();
+
+    common::upskill_cmd(&env).args(["add", "./reg", "--claude"]).assert().success();
+
+    let base = env.project.join(".claude/skills/demo");
+    assert!(base.join("refs/p.md").exists(), "non-ignored resource must be copied");
+    assert!(!base.join("scripts/gate.sh").exists(), "ignored resource must be skipped");
+}
+```
+
+Run: `cargo test --test pipeline_ignore`
+Expected: PASS (after Step 5).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd .claude/worktrees/feat-coupling-redesign
+just fmt
+git add src/pipeline/ignore.rs src/pipeline/mod.rs src/pipeline/install.rs tests/pipeline_ignore.rs
+git commit -m "feat(pipeline): subtractive ignore filter for item resources"
+```
+
+---
+
+## Task 4: Optional + relaxed naming (effective-name identity)
+
+**Files:**
+
+- Modify: `src/model/skill.rs`, `src/model/rule.rs`, `src/model/agent.rs` — `name: Option<String>`
+- Modify: `src/generate/mod.rs:51-146` — `render_*` + `build_skill_frontmatter` take `name: &str`
+- Modify: `src/generate/claude.rs:9-49`, `src/generate/copilot.rs:9-46`, `src/generate/opencode.rs:10-52`
+- Modify: `src/pipeline/discovery.rs` — `effective_name`, `probe_effective_name`, `scan_source_items`
+- Modify: `src/pipeline/install.rs` — compute + use effective name
+- Modify: `src/lint.rs:283`, `:331-372`, `parse_kind` — relax matching
+
+This is the largest task. The build only goes green at the end of Step 8, so commit once at the end.
+
+- [ ] **Step 1: Write the failing render test (effective name from folder)**
+
+Add to `src/generate/mod.rs` tests (create a `#[cfg(test)] mod tests` if absent) — but first the signature must change, so write the test against the target signature:
+
+```rust
+#[cfg(test)]
+mod name_tests {
+    use super::*;
+    use crate::model::{Rule, SchemaVersion};
+
+    fn minimal_rule(name: Option<&str>) -> Rule {
+        Rule {
+            schema: SchemaVersion::new(1).unwrap(),
+            name: name.map(str::to_string),
+            description: "d".into(),
+            audience: None,
+            license: None,
+            scope: None,
+            metadata: None,
+            requires: Default::default(),
+            ignore: vec![],
+            claude: None,
+            copilot: None,
+            opencode: None,
+            extra: Default::default(),
+        }
+    }
+
+    #[test]
+    fn rule_render_uses_passed_effective_name_not_frontmatter() {
+        let rule = minimal_rule(None); // name absent
+        let out = render_rule(&rule, "security-baseline", "## B\n\nt\n", Client::Claude).unwrap();
+        assert!(out.contains("name: security-baseline"));
+    }
+}
+```
+
+- [ ] **Step 2: Run it red**
+
+Run: `cargo test -p upskill name_tests`
+Expected: FAIL to compile — `render_rule` takes 3 args, `Rule.name` is `String`.
+
+- [ ] **Step 3: Make `name` optional in the three models**
+
+In `src/model/skill.rs`, `src/model/rule.rs`, `src/model/agent.rs`, change `pub name: String,` to:
+
+```rust
+/// Effective name resolution is layout-dependent (§2.1): absent means
+/// the directory name is used. Resolved by the pipeline/lint layer.
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub name: Option<String>,
+```
+
+- [ ] **Step 4: Thread `name: &str` through `generate/mod.rs`**
+
+Change the three `render_*` signatures and `build_skill_frontmatter`:
+
+```rust
+pub fn render_skill(skill: &Skill, name: &str, body: &str, client: Client) -> Result<String> {
+    let processed_body = directives::process(body, client)?;
+    let frontmatter = match client {
+        Client::Claude => claude::skill_frontmatter(skill, name)?,
+        Client::Copilot => copilot::skill_frontmatter(skill, name)?,
+        Client::OpenCode => opencode::skill_frontmatter(skill, name)?,
+    };
+    let combined = assemble(&frontmatter, &processed_body);
+    format::format_markdown(&combined)
+}
+
+pub fn render_rule(rule: &Rule, name: &str, body: &str, client: Client) -> Result<String> {
+    let processed_body = directives::process(body, client)?;
+    let frontmatter = match client {
+        Client::Claude => claude::rule_frontmatter(rule, name)?,
+        Client::Copilot => copilot::rule_frontmatter(rule, name)?,
+        Client::OpenCode => opencode::rule_frontmatter(rule, name)?,
+    };
+    let combined = assemble(&frontmatter, &processed_body);
+    format::format_markdown(&combined)
+}
+
+pub fn render_agent(agent: &Agent, name: &str, body: &str, client: Client) -> Result<String> {
+    let processed_body = directives::process(body, client)?;
+    let frontmatter = match client {
+        Client::Claude => claude::agent_frontmatter(agent, name)?,
+        Client::Copilot => copilot::agent_frontmatter(agent, name)?,
+        Client::OpenCode => opencode::agent_frontmatter(agent, name)?,
+    };
+    let combined = assemble(&frontmatter, &processed_body);
+    format::format_markdown(&combined)
+}
+```
+
+And `build_skill_frontmatter`:
+
+```rust
+pub(crate) fn build_skill_frontmatter(
+    skill: &Skill,
+    name: &str,
+    passthrough: Option<&Value>,
+) -> Result<String> {
+    let mut map = Mapping::new();
+    map.insert(Value::from("name"), Value::from(name.to_string()));
+    map.insert(Value::from("description"), Value::from(skill.description.clone()));
+    for (k, v) in &skill.extra {
+        map.insert(Value::from(k.clone()), v.clone());
+    }
+    if let Some(Value::Mapping(m)) = passthrough {
+        for (k, v) in m {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+    serde_yaml_ng::to_string(&map).context("serializing skill frontmatter")
+}
+```
+
+- [ ] **Step 5: Thread `name` through the three client builders**
+
+In `src/generate/claude.rs`:
+
+- `skill_frontmatter(skill: &Skill, name: &str)` → `super::build_skill_frontmatter(skill, name, skill.claude.as_ref())`
+- `rule_frontmatter(rule: &Rule, name: &str)` → replace `Value::from(rule.name.clone())` with `Value::from(name.to_string())`
+- `agent_frontmatter(agent: &Agent, name: &str)` → replace `Value::from(agent.name.clone())` with `Value::from(name.to_string())`
+
+Apply the identical change in `src/generate/copilot.rs` (`skill_frontmatter`/`rule_frontmatter`/`agent_frontmatter`, each gains `name: &str`; the `rule.name`/`agent.name` reads become `name.to_string()`) and in `src/generate/opencode.rs` (same three functions; `rule.name`→`name`, `agent.name`→`name`). These are mechanical: every `X.name.clone()` in a frontmatter builder becomes `name.to_string()`, and `skill_frontmatter` forwards `name`.
+
+- [ ] **Step 6: Run the render test green**
+
+Run: `cargo test -p upskill name_tests`
+Expected: PASS. (Library may still fail to build until install.rs is updated — if so, temporarily this test still compiles within the crate; proceed to Step 7 and run after.)
+
+- [ ] **Step 7: Add the effective-name resolver + restructure install**
+
+In `src/pipeline/discovery.rs`, add:
+
+```rust
+use super::ItemKind;
+use crate::parse::frontmatter;
+
+/// Effective identity name for an item (§2.1). Skills always take the
+/// folder name (Agent Skills standard mandates name == dir); rules/agents
+/// take their frontmatter name when present, else the folder name.
+pub(super) fn effective_name(kind: ItemKind, frontmatter_name: Option<&str>, folder: &str) -> String {
+    match kind {
+        ItemKind::Skill => folder.to_string(),
+        ItemKind::Rule | ItemKind::Agent => frontmatter_name.unwrap_or(folder).to_string(),
+    }
+}
+
+/// Probe an entrypoint's frontmatter `name` cheaply, falling back to the
+/// folder name on any read/parse failure (validation belongs to lint, not
+/// to discovery). Used so `(kind, name)` identity is consistent everywhere.
+pub(super) fn probe_effective_name(entry_path: &std::path::Path, kind: ItemKind, folder: &str) -> String {
+    if kind == ItemKind::Skill {
+        return folder.to_string();
+    }
+    #[derive(serde::Deserialize)]
+    struct NameProbe {
+        #[serde(default)]
+        name: Option<String>,
+    }
+    match std::fs::read_to_string(entry_path) {
+        Ok(raw) => match frontmatter::parse::<NameProbe>(&raw) {
+            Ok((p, _)) => p.name.unwrap_or_else(|| folder.to_string()),
+            Err(_) => folder.to_string(),
+        },
+        Err(_) => folder.to_string(),
+    }
+}
+```
+
+Update `scan_source_items` so each pushed pair uses the effective name (it currently pushes the folder name). For each detected entrypoint, compute:
+
+```rust
+if path.join("SKILL.md").is_file() {
+    items.push((ItemKind::Skill, name.to_string())); // skill == folder, unchanged
+}
+if path.join("RULE.md").is_file() {
+    let n = probe_effective_name(&path.join("RULE.md"), ItemKind::Rule, name);
+    items.push((ItemKind::Rule, n));
+}
+if path.join("AGENT.md").is_file() {
+    let n = probe_effective_name(&path.join("AGENT.md"), ItemKind::Agent, name);
+    items.push((ItemKind::Agent, n));
+}
+```
+
+Apply the same to the category-subdir branch.
+
+In `src/pipeline/install.rs` `install_items_of_kind`, rename the loop var `name` → `folder`, parse the model first, compute the effective name, filter on it, render with it, and use it for output path / resources / lockfile. The restructured loop body:
+
+```rust
+    for (folder, dir) in iter_item_dirs(source)? {
+        let entry_path = dir.join(entrypoint);
+        if !entry_path.exists() {
+            continue;
+        }
+        let raw = fs::read_to_string(&entry_path)
+            .with_context(|| format!("read {}", entry_path.display()))?;
+
+        // Parse, resolve the effective name, then filter on it.
+        let (name, audience, ignore, renders) = match kind {
+            ItemKind::Skill => {
+                let (skill, body) = frontmatter::parse::<Skill>(&raw)
+                    .with_context(|| format!("parse {}", entry_path.display()))?;
+                let name = super::discovery::effective_name(kind, skill.name.as_deref(), &folder);
+                let renders = render_all(|client| generate::render_skill(&skill, &name, body, client),
+                                         skill.audience.as_deref(), &name, kind)?;
+                (name, skill.audience.clone(), skill.ignore.clone(), renders)
+            }
+            ItemKind::Rule => {
+                let (rule, body) = frontmatter::parse::<Rule>(&raw)
+                    .with_context(|| format!("parse {}", entry_path.display()))?;
+                let name = super::discovery::effective_name(kind, rule.name.as_deref(), &folder);
+                let renders = render_all(|client| generate::render_rule(&rule, &name, body, client),
+                                         rule.audience.as_deref(), &name, kind)?;
+                (name, rule.audience.clone(), rule.ignore.clone(), renders)
+            }
+            ItemKind::Agent => {
+                let (agent, body) = frontmatter::parse::<Agent>(&raw)
+                    .with_context(|| format!("parse {}", entry_path.display()))?;
+                let name = super::discovery::effective_name(kind, agent.name.as_deref(), &folder);
+                let renders = render_all(|client| generate::render_agent(&agent, &name, body, client),
+                                         agent.audience.as_deref(), &name, kind)?;
+                (name, agent.audience.clone(), agent.ignore.clone(), renders)
+            }
+        };
+
+        if let Some(items) = filter
+            && !items.contains(kind, &name)
+        {
+            continue;
+        }
+
+        let source_hash = hash_item_dir(&dir);
+        let resources = super::ignore::filter_ignored(iter_item_resources(&dir), &ignore);
+        /* …unchanged from here: copied set, remove_item_outputs(target, kind, &name),
+           the render write loop, audience cleanup — all already keyed on `name`… */
+    }
+```
+
+Add the small `render_all` helper near the top of `install.rs` to avoid repeating the audience/render loop three times:
+
+```rust
+/// Render one item for every targeted client, returning `(client, body)`
+/// pairs. `render_one` is the per-client renderer closure.
+fn render_all(
+    mut render_one: impl FnMut(Client) -> Result<String>,
+    audience: Option<&[Audience]>,
+    name: &str,
+    kind: ItemKind,
+) -> Result<Vec<(Client, String)>> {
+    let mut out = Vec::new();
+    for client in ALL_CLIENTS {
+        if !targets(client, audience) {
+            continue;
+        }
+        out.push((
+            client,
+            render_one(client).with_context(|| format!("render {kind} {name} for {client:?}"))?,
+        ));
+    }
+    Ok(out)
+}
+```
+
+NOTE: the closure borrows the parsed model and `name` by reference; if the borrow checker objects to `name` moving into the tuple, clone `name` for the tuple and pass `&name` to `render_all`. Adjust as the compiler directs — the behavior (render per targeted client) is fixed.
+
+- [ ] **Step 8: Relax lint name-matching**
+
+In `src/lint.rs`, change `parse_kind` to return `(Option<String>, &str)`:
+
+```rust
+fn parse_kind(raw: &str, kind: FileKind) -> Result<(Option<String>, &str)> {
+    match kind {
+        FileKind::Skill => { let (i, b) = frontmatter::parse::<Skill>(raw)?; Ok((i.name, b)) }
+        FileKind::Rule => { let (i, b) = frontmatter::parse::<Rule>(raw)?; Ok((i.name, b)) }
+        FileKind::Agent => { let (i, b) = frontmatter::parse::<Agent>(raw)?; Ok((i.name, b)) }
+        FileKind::Bundle => { let b: crate::model::Bundle = serde_yaml_ng::from_str(raw)?; Ok((Some(b.name), "")) }
+    }
+}
+```
+
+Update the caller at `src/lint.rs:283` to pass the `Option<String>`:
+
+```rust
+Ok((parsed_name, body)) => {
+    check_name_matches_dir(file, parsed_name.as_deref(), kind, out);
+    body
+}
+```
+
+Rewrite `check_name_matches_dir(file, name: Option<&str>, kind, out)`:
+
+```rust
+fn check_name_matches_dir(file: &Path, name: Option<&str>, kind: FileKind, out: &mut Vec<Finding>) {
+    match kind {
+        // Bundles: filename stem must match the (required) name.
+        FileKind::Bundle => {
+            let Some(name) = name else { return };
+            let Some(stem) = file.file_name().and_then(|n| n.to_str())
+                .and_then(|n| n.strip_suffix(crate::parse::bundle::BUNDLE_SUFFIX)) else { return };
+            if stem != name {
+                out.push(Finding { rule_id: "name-matches-dir", severity: Severity::Error,
+                    path: file.to_path_buf(), line: None,
+                    message: format!("frontmatter `name: {name}` does not match filename stem `{stem}`") });
+            }
+        }
+        // Skills: name is optional, but if present MUST equal the directory
+        // (Agent Skills standard). Absent → folder name is used; OK.
+        FileKind::Skill => {
+            let (Some(name), Some(dir)) = (name, file.parent().and_then(|p| p.file_name()).and_then(|n| n.to_str())) else { return };
+            if dir != name {
+                out.push(Finding { rule_id: "name-matches-dir", severity: Severity::Error,
+                    path: file.to_path_buf(), line: None,
+                    message: format!("skill `name: {name}` must equal directory `{dir}` (Agent Skills standard)") });
+            }
+        }
+        // Rules/agents: name is free and layout-independent (§2.1). No check.
+        FileKind::Rule | FileKind::Agent => {}
+    }
+}
+```
+
+- [ ] **Step 9: Build and run the full suite green**
+
+Run: `just assemble && cargo test -p upskill`
+Expected: PASS. Fix any remaining call sites the compiler flags (e.g. other `render_*` callers, the `lint.rs:741` test that asserted solo `name-matches-dir` for a rule — update or delete that test since rule divergence is now legal and silent).
+
+- [ ] **Step 10: Add the relaxed-naming integration tests**
+
+Add `tests/cli_relaxed_naming.rs`:
+
+- A skill folder with no `name:` → output at `.claude/skills/<folder>/SKILL.md` with `name: <folder>`.
+- A rule folder `stuff/` whose `RULE.md` has `name: security-baseline` → output at `.claude/rules/security-baseline.md` containing `name: security-baseline` (folder name `stuff` absent from output path).
+- `upskill lint` on a skill whose `name` ≠ folder → exits non-zero with the standard-mandate message.
+- `upskill lint` on a rule whose `name` ≠ folder → exits zero (no finding).
+
+Use the `tests/common` helpers. Run: `cargo test --test cli_relaxed_naming` → PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd .claude/worktrees/feat-coupling-redesign
+just fmt
+git add -A
+git commit -m "feat(naming): optional + relaxed item naming with layout-independent identity"
+```
+
+---
+
+## Task 5: Same-source `requires` closure + `required_by` provenance
+
+**Files:**
+
+- Modify: `src/pipeline/install.rs` — `resolve_requires_closure`
+- Modify: `src/pipeline/mod.rs:139-349` — expand the install set before conflict detection; pass provenance to the lockfile
+- Modify: `src/lockfile.rs:37-59` — `LockedItem.required_by`; `items_from_report` signature
+- Test: `src/pipeline/install.rs` unit tests + `tests/cli_requires.rs`
+
+- [ ] **Step 1: Write the failing closure unit test**
+
+Add to `src/pipeline/install.rs` tests:
+
+```rust
+#[test]
+fn closure_pulls_same_source_dependency() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    // agent `code-review` requires skill `sarif`.
+    std::fs::create_dir_all(root.join("code-review")).unwrap();
+    std::fs::write(root.join("code-review/AGENT.md"),
+        "---\nschema: 1\nname: code-review\ndescription: a\nrequires:\n  skills: [sarif]\n---\n\n## B\n\nt\n").unwrap();
+    std::fs::create_dir_all(root.join("sarif")).unwrap();
+    std::fs::write(root.join("sarif/SKILL.md"),
+        "---\nschema: 1\nname: sarif\ndescription: s\n---\n\n## B\n\nt\n").unwrap();
+
+    let closure = resolve_requires_closure(root, &[(ItemKind::Agent, "code-review".into())]).unwrap();
+    assert!(closure.items.contains(ItemKind::Agent, "code-review"));
+    assert!(closure.items.contains(ItemKind::Skill, "sarif"));
+    assert_eq!(
+        closure.required_by.get(&(ItemKind::Skill, "sarif".into())).map(|s| s.iter().cloned().collect::<Vec<_>>()),
+        Some(vec!["agent:code-review".to_string()])
+    );
+}
+
+#[test]
+fn closure_rejects_cycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("a")).unwrap();
+    std::fs::write(root.join("a/RULE.md"),
+        "---\nschema: 1\nname: a\ndescription: a\nrequires:\n  rules: [b]\n---\n\n## B\n\nt\n").unwrap();
+    std::fs::create_dir_all(root.join("b")).unwrap();
+    std::fs::write(root.join("b/RULE.md"),
+        "---\nschema: 1\nname: b\ndescription: b\nrequires:\n  rules: [a]\n---\n\n## B\n\nt\n").unwrap();
+
+    let err = resolve_requires_closure(root, &[(ItemKind::Rule, "a".into())]).unwrap_err();
+    assert!(format!("{err:#}").contains("circular"), "{err:#}");
+}
+
+#[test]
+fn closure_errors_on_cross_source_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("a")).unwrap();
+    std::fs::write(root.join("a/RULE.md"),
+        "---\nschema: 1\nname: a\ndescription: a\nrequires:\n  skills: [{ name: x, source: org/repo }]\n---\n\n## B\n\nt\n").unwrap();
+
+    let err = resolve_requires_closure(root, &[(ItemKind::Rule, "a".into())]).unwrap_err();
+    assert!(format!("{err:#}").contains("cross-source"), "{err:#}");
+}
+```
+
+- [ ] **Step 2: Run red**
+
+Run: `cargo test -p upskill closure_`
+Expected: FAIL — `resolve_requires_closure`, `DependencyClosure` undefined.
+
+- [ ] **Step 3: Implement `resolve_requires_closure`**
+
+Add to `src/pipeline/install.rs`. It needs a `(kind, name) → (folder, entry_path)` index over the source (because a rule's name may diverge from its folder), built by scanning + probing:
+
+```rust
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use crate::model::{ItemRequires, RequireRef};
+
+/// Transitive same-source `requires` expansion of an initial item set.
+pub(super) struct DependencyClosure {
+    pub items: crate::bundle::ResolvedItems,
+    /// `(kind, name)` → set of `"kind:name"` requirers (provenance).
+    pub required_by: BTreeMap<(ItemKind, String), BTreeSet<String>>,
+}
+
+/// Build a `(kind, effective-name) → item directory` index for `source`.
+fn index_source(source: &Path) -> Result<BTreeMap<(ItemKind, String), PathBuf>> {
+    let mut idx = BTreeMap::new();
+    for (folder, dir) in iter_item_dirs(source)? {
+        for kind in [ItemKind::Skill, ItemKind::Rule, ItemKind::Agent] {
+            let entry = dir.join(kind.entrypoint_filename());
+            if entry.is_file() {
+                let name = super::discovery::probe_effective_name(&entry, kind, &folder);
+                idx.insert((kind, name), dir.clone());
+            }
+        }
+    }
+    Ok(idx)
+}
+
+/// Read an item's `requires` block by re-parsing its entrypoint.
+fn read_requires(dir: &Path, kind: ItemKind) -> Result<ItemRequires> {
+    let entry = dir.join(kind.entrypoint_filename());
+    let raw = fs::read_to_string(&entry).with_context(|| format!("read {}", entry.display()))?;
+    let req = match kind {
+        ItemKind::Skill => frontmatter::parse::<Skill>(&raw)?.0.requires,
+        ItemKind::Rule => frontmatter::parse::<Rule>(&raw)?.0.requires,
+        ItemKind::Agent => {
+            let agent = frontmatter::parse::<Agent>(&raw)?.0;
+            // preload-skills implies requires.skills (format-spec §3.4).
+            let mut req = agent.requires;
+            for s in &agent.preload_skills {
+                if !req.skills.iter().any(|r| r.name() == s) {
+                    req.skills.push(RequireRef::Name(s.clone()));
+                }
+            }
+            req
+        }
+    };
+    Ok(req)
+}
+
+pub(super) fn resolve_requires_closure(
+    source: &Path,
+    initial: &[(ItemKind, String)],
+) -> Result<DependencyClosure> {
+    let index = index_source(source)?;
+    let mut required_by: BTreeMap<(ItemKind, String), BTreeSet<String>> = BTreeMap::new();
+    let mut resolved: BTreeSet<(ItemKind, String)> = BTreeSet::new();
+    let mut on_path: BTreeSet<(ItemKind, String)> = BTreeSet::new();
+    let mut order: Vec<(ItemKind, String)> = Vec::new();
+
+    // Depth-first so a back-edge to an item already on the current path is
+    // a cycle. `initial` items have no requirer.
+    fn visit(
+        node: (ItemKind, String),
+        requirer: Option<&str>,
+        index: &BTreeMap<(ItemKind, String), PathBuf>,
+        required_by: &mut BTreeMap<(ItemKind, String), BTreeSet<String>>,
+        resolved: &mut BTreeSet<(ItemKind, String)>,
+        on_path: &mut BTreeSet<(ItemKind, String)>,
+        order: &mut Vec<(ItemKind, String)>,
+    ) -> Result<()> {
+        if let Some(r) = requirer {
+            required_by.entry(node.clone()).or_default().insert(r.to_string());
+        }
+        if resolved.contains(&node) {
+            return Ok(());
+        }
+        if !on_path.insert(node.clone()) {
+            anyhow::bail!("circular requires detected at {} `{}`", node.0, node.1);
+        }
+        let dir = index.get(&node).ok_or_else(|| anyhow::anyhow!(
+            "{} `{}` is required but not found in the source", node.0, node.1))?;
+        let req = read_requires(dir, node.0)?;
+        let label = format!("{}:{}", node.0, node.1);
+        for (kind, refs) in [
+            (ItemKind::Rule, &req.rules),
+            (ItemKind::Skill, &req.skills),
+            (ItemKind::Agent, &req.agents),
+        ] {
+            for r in refs {
+                if let Some(src) = r.source() {
+                    anyhow::bail!(
+                        "{} `{}` requires {} `{}` from cross-source `{}`: \
+                         cross-source dependency resolution is not yet available in this release",
+                        node.0, node.1, kind, r.name(), src);
+                }
+                visit((kind, r.name().to_string()), Some(&label), index, required_by, resolved, on_path, order)?;
+            }
+        }
+        on_path.remove(&node);
+        resolved.insert(node.clone());
+        order.push(node);
+        Ok(())
+    }
+
+    for item in initial {
+        visit(item.clone(), None, &index, &mut required_by, &mut resolved, &mut on_path, &mut order)?;
+    }
+
+    let mut items = crate::bundle::ResolvedItems::default();
+    for (kind, name) in order {
+        match kind {
+            ItemKind::Rule => items.rules.push(name),
+            ItemKind::Skill => items.skills.push(name),
+            ItemKind::Agent => items.agents.push(name),
+        }
+    }
+    Ok(DependencyClosure { items, required_by })
+}
+```
+
+(If `crate::bundle::ResolvedItems` does not derive `Default`, add `#[derive(Default)]` to it — confirm its definition in `src/bundle.rs` first.)
+
+- [ ] **Step 4: Run the closure tests green**
+
+Run: `cargo test -p upskill closure_`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Add `required_by` to the lockfile**
+
+In `src/lockfile.rs`, add to `LockedItem` (after `source_name`):
+
+```rust
+/// `"kind:name"` of every installed item that pulled this one in as a
+/// dependency. Empty for directly-requested items. Drives `doctor`'s
+/// orphaned-dependency check; never triggers auto-removal (#196).
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub required_by: Vec<String>,
+```
+
+Update every `LockedItem { … }` literal in the crate (the `conflict.rs` test helper, `lockfile.rs` tests, `pipeline/mod.rs`) to add `required_by: vec![]` — the compiler lists them.
+
+Change `items_from_report` to accept a provenance map and populate the field:
+
+```rust
+pub fn items_from_report(
+    report: &InstallReport,
+    source_label: &str,
+    git_ref: Option<&str>,
+    required_by: &std::collections::BTreeMap<(ItemKind, String), Vec<String>>,
+    mut hash_for: impl FnMut(ItemKind, &str) -> Option<String>,
+) -> Vec<LockedItem> {
+    /* …existing dedupe loop… */
+        out.push(LockedItem {
+            kind: entry.kind,
+            name: entry.name.clone(),
+            source: source_label.to_string(),
+            git_ref: git_ref.map(str::to_string),
+            hash: hash_for(entry.kind, &entry.name),
+            source_name: None,
+            required_by: required_by.get(&(entry.kind, entry.name.clone())).cloned().unwrap_or_default(),
+        });
+    /* … */
+}
+```
+
+Update the `items_from_report` unit test to pass `&BTreeMap::new()`.
+
+- [ ] **Step 6: Wire the closure into `install_with_lockfile`**
+
+In `src/pipeline/mod.rs`, after `scan_source_items` and before conflict detection, expand the requested set through the closure (skip when the source is a bundle file — bundles already resolve their own items):
+
+```rust
+let requested: Vec<(ItemKind, String)> = if items.is_empty() {
+    scanned_items.iter().filter(|(_, n)| !options.excludes.contains(n)).cloned().collect()
+} else {
+    scanned_items.iter()
+        .filter(|(_, n)| items.contains(n))
+        .filter(|(_, n)| !options.excludes.contains(n))
+        .cloned().collect()
+};
+let closure = if discovery::is_bundle_file(&local_source) {
+    None
+} else {
+    Some(install::resolve_requires_closure(&local_source, &requested)?)
+};
+```
+
+Use `closure`'s `items` as the install filter, and feed `required_by` to the lockfile. Where the code currently branches on `items.is_empty()` to call `install_from_local_path(.., None)` vs `install_with_name_resolution_from_local`, replace with a single filtered install when a closure exists:
+
+```rust
+let mut report = match &closure {
+    Some(c) => install_from_local_path(&local_source, target, Some(&c.items))?,
+    None => install_from_local_path(&local_source, target, None)?, // bundle path
+};
+```
+
+(For the bundle-file branch the existing `install_bundle_file` dispatch inside `install_from_local_path` still runs.) Build the provenance map for the lockfile:
+
+```rust
+let required_by: std::collections::BTreeMap<(ItemKind, String), Vec<String>> = closure
+    .as_ref()
+    .map(|c| c.required_by.iter()
+        .map(|(k, v)| (k.clone(), v.iter().cloned().collect()))
+        .collect())
+    .unwrap_or_default();
+```
+
+and pass `&required_by` to `items_from_report`.
+
+Conflict detection: build `incoming` from `closure.items` (so a pulled dependency conflicting with an existing different-source install is also caught) instead of the current `scanned_items` filter. Keep the existing `--as`/alias handling intact for the directly-named items.
+
+- [ ] **Step 7: Add the requires integration test**
+
+Add `tests/cli_requires.rs`:
+
+- Registry with agent `code-review` (`requires.skills: [sarif]`) and skill `sarif`. `upskill add ./reg code-review --claude` installs BOTH; the lockfile records `sarif` with `required_by: ["agent:code-review"]`.
+- `preload-skills: [sarif]` on the agent (no explicit `requires`) also pulls `sarif`.
+- A cross-source `{ name, source }` requires entry → `upskill add` exits non-zero mentioning "cross-source".
+
+Use `tests/common` helpers and read the lockfile JSON to assert `required_by`. Run: `cargo test --test cli_requires` → PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd .claude/worktrees/feat-coupling-redesign
+just fmt
+git add -A
+git commit -m "feat(pipeline): same-source requires closure with required_by provenance"
+```
+
+---
+
+## Task 6: Co-location grouping + unit removal
+
+**Files:**
+
+- Modify: `src/lockfile.rs` — `LockedItem.group`
+- Modify: `src/pipeline/install.rs` / `src/pipeline/mod.rs` — record `group` (source folder)
+- Modify: `src/pipeline/lifecycle.rs:32-120` — `remove` acts on the co-located unit
+
+- [ ] **Step 1: Write the failing removal integration test**
+
+Add `tests/cli_colocation_remove.rs`: a single folder `markspec-trace/` holding `SKILL.md` (`name: markspec-trace`) and `RULE.md` (`name: markspec-trace-syntax`). `upskill add ./reg --claude` installs both. `upskill remove markspec-trace` removes BOTH the skill and the co-located rule (same source + folder group), and the lockfile is empty afterwards.
+
+```rust
+mod common;
+use std::fs;
+
+#[test]
+fn remove_acts_on_colocated_unit() {
+    let env = common::TestEnv::new();
+    let item = env.project.join("reg/markspec-trace");
+    fs::create_dir_all(&item).unwrap();
+    fs::write(item.join("SKILL.md"),
+        "---\nschema: 1\nname: markspec-trace\ndescription: s\n---\n\n## B\n\nt\n").unwrap();
+    fs::write(item.join("RULE.md"),
+        "---\nschema: 1\nname: markspec-trace-syntax\ndescription: r\n---\n\n## B\n\nt\n").unwrap();
+
+    common::upskill_cmd(&env).args(["add", "./reg", "--claude"]).assert().success();
+    common::upskill_cmd(&env).args(["remove", "markspec-trace"]).assert().success();
+
+    assert!(!env.project.join(".claude/skills/markspec-trace/SKILL.md").exists());
+    assert!(!env.project.join(".claude/rules/markspec-trace-syntax.md").exists(),
+        "co-located rule must be removed with the unit");
+}
+```
+
+Run: `cargo test --test cli_colocation_remove` → FAIL (only the named skill is removed).
+
+- [ ] **Step 2: Add `group` to the lockfile**
+
+In `src/lockfile.rs` `LockedItem`, add:
+
+```rust
+/// Source folder this item was discovered in — the co-location
+/// grouping key (§2.1). `remove <name>` removes every item sharing the
+/// same `(source, group)` so a co-located unit travels as one.
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub group: Option<String>,
+```
+
+Add `group: None` (or the folder) to every `LockedItem` literal the compiler flags.
+
+- [ ] **Step 3: Thread the folder through install → report → lockfile**
+
+`InstalledItem` (in `report.rs`) needs the source folder. Add `pub group: Option<String>` to `InstalledItem`, set it in `install_items_of_kind` to `Some(folder.clone())`. In `items_from_report`, set `group` from the first report entry for each `(kind, name)` (capture it alongside the hash). Simplest: extend the dedupe loop to read `entry.group`.
+
+- [ ] **Step 4: Make `remove` expand to the unit**
+
+In `src/pipeline/lifecycle.rs` `remove`, after computing `to_remove` for `RemoveFilter::ByNames`, expand it to include every lockfile item sharing a `(source, group)` with a matched item:
+
+```rust
+if let RemoveFilter::ByNames(_) = &filter {
+    let groups: std::collections::BTreeSet<(String, String)> = to_remove.iter()
+        .filter_map(|i| i.group.clone().map(|g| (i.source.clone(), g)))
+        .collect();
+    for it in &lock.items {
+        if let Some(g) = &it.group {
+            if groups.contains(&(it.source.clone(), g.clone()))
+                && !to_remove.iter().any(|r| r.kind == it.kind && r.name == it.name)
+            {
+                to_remove.push(it.clone());
+            }
+        }
+    }
+}
+```
+
+(Make `to_remove` `mut`. Keep the existing unknown-name error check on the _originally_ matched names, before expansion.)
+
+- [ ] **Step 5: Run green**
+
+Run: `cargo test --test cli_colocation_remove && cargo test -p upskill`
+Expected: PASS. Fix any `LockedItem`/`InstalledItem` literal sites the compiler flags.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .claude/worktrees/feat-coupling-redesign
+just fmt
+git add -A
+git commit -m "feat(pipeline): track co-location group; remove acts on the unit"
+```
+
+---
+
+## Task 7: `doctor` orphaned-dependency flag
+
+**Files:**
+
+- Modify: `src/pipeline/report.rs` — `OrphanedDependency` + `DoctorReport.orphaned_dependencies`
+- Modify: `src/pipeline/lifecycle.rs:135-252` — populate it
+- Modify: `src/main.rs` — print the new bucket (find the existing doctor printer)
+
+- [ ] **Step 1: Write the failing doctor test**
+
+Add `tests/cli_doctor_orphan.rs`: install agent `code-review` + its required skill `sarif`; `upskill remove code-review` (the requirer) leaving `sarif` (whose `required_by: ["agent:code-review"]` now points at an absent item); `upskill doctor` reports `sarif` as an orphaned dependency. Assert via doctor's stdout (read `main.rs`'s doctor output format first). The orphaned-dependency bucket is **advisory** — like `skipped_plugins` it does NOT flip the exit code, so assert `doctor` still exits 0 but the message names `sarif`.
+
+(Note: removing `code-review`, which is co-located only with itself, does not cascade to `sarif` because `sarif` lives in its own folder — §2.5 "removal never cascades". That is exactly the state doctor surfaces.)
+
+- [ ] **Step 2: Add the report type**
+
+In `src/pipeline/report.rs`:
+
+```rust
+/// A dependency-pulled item whose every requirer is no longer installed.
+/// Advisory only — upskill never auto-removes (#196); the user decides.
+#[derive(Debug, Clone, Serialize)]
+pub struct OrphanedDependency {
+    pub kind: ItemKind,
+    pub name: String,
+    /// The now-absent requirers (`"kind:name"`) recorded at install time.
+    pub former_requirers: Vec<String>,
+}
+```
+
+Add to `DoctorReport`:
+
+```rust
+/// Items present only as a dependency of an item that is no longer
+/// installed. Advisory — does NOT affect `is_clean()`.
+pub orphaned_dependencies: Vec<OrphanedDependency>,
+```
+
+`is_clean()` is unchanged (the new bucket is informational, like `skipped_plugins`). Re-export `OrphanedDependency` from `pipeline/mod.rs` if `report::*` is re-exported (it is — line 45 `pub use report::*;`).
+
+- [ ] **Step 3: Populate it in `doctor`**
+
+In `src/pipeline/lifecycle.rs` `doctor`, after the per-item loop, build the set of installed `(kind, name)` and flag any item whose `required_by` is non-empty and whose every requirer is absent:
+
+```rust
+let installed: std::collections::BTreeSet<String> = lock.items.iter()
+    .map(|i| format!("{}:{}", i.kind, i.name)).collect();
+for entry in &lock.items {
+    if entry.required_by.is_empty() {
+        continue;
+    }
+    if entry.required_by.iter().all(|r| !installed.contains(r)) {
+        report.orphaned_dependencies.push(OrphanedDependency {
+            kind: entry.kind,
+            name: entry.name.clone(),
+            former_requirers: entry.required_by.clone(),
+        });
+    }
+}
+```
+
+Import `OrphanedDependency` in the `use super::{…}` list.
+
+- [ ] **Step 4: Print the bucket in `main.rs`**
+
+Find the doctor-report printer in `src/main.rs` (search for `orphan_entries` / `skipped_plugins`). Add a section that, when `!report.orphaned_dependencies.is_empty()`, prints each as e.g.:
+
+```text
+orphaned dependency: skill `sarif` (was required by agent:code-review, now absent)
+  remove with `upskill remove sarif` if no longer needed
+```
+
+Keep it under the advisory (non-failing) part of the output, matching how `skipped_plugins` is presented.
+
+- [ ] **Step 5: Run green**
+
+Run: `cargo test --test cli_doctor_orphan && cargo test -p upskill`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .claude/worktrees/feat-coupling-redesign
+just fmt
+git add -A
+git commit -m "feat(doctor): flag orphaned dependencies (advisory, never auto-removes)"
+```
+
+---
+
+## Final: verify + PR
+
+- [ ] **Step 1: Full verification**
+
+```bash
+cd .claude/worktrees/feat-coupling-redesign
+just fmt
+just verify
+```
+
+Expected: clean — zero warnings (compiler + clippy), all tests pass, docs tooling clean.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+git push -u origin feat/coupling-redesign
+gh pr create --base main --title "feat: coupling redesign slice 1 — optional naming, ignore, same-source requires" \
+  --body "Implements ADR-0009 (amends ADR-0006): three-tier coupling model. Slice 1 = same-source. Adds optional/relaxed item naming (layout-independent identity), \`ignore\` copy-scope, same-source \`requires\` auto-install with \`required_by\` provenance, co-location grouping + unit removal, and a \`doctor\` orphaned-dependency flag. Cross-source resolution is Slice 2 (separate plan). See docs/superpowers/specs/2026-06-03-coupling-redesign-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 3: After opening — fix CI first, then review comments.** Per AGENTS.md: K0 findings fixed in-PR; K1/K2 tracked as debt issues.
+
+---
+
+## Self-review (completed by plan author)
+
+**Spec coverage:** §2.1 relaxed/optional naming → Tasks 1, 4. §2.2 three tiers → Tasks 1, 5 (+ co-location grouping Task 6). §2.3 `requires` → Tasks 1, 2, 5. §2.4 `ignore` → Tasks 1, 2, 3. §2.5 cross-source contract → Task 1 (doc) + Task 5 (errors on cross-source; resolution deferred to Slice 2 by design). §2.6 identity → Task 4. §3 inherent limit → Task 1 (ADR/spec). Lockfile `required_by` + group → Tasks 5, 6. doctor → Task 7. Strip-from-output → Task 2. **Slice 2 (cross-source resolution) is explicitly deferred to its own plan.**
+
+**Placeholder scan:** No "TBD"/"implement later". Two NOTE callouts (tests/common API surface; borrow-checker on `name`) point the executor at a real file to read rather than hiding work — the _behavior_ is fully specified in each.
+
+**Type consistency:** `effective_name`/`probe_effective_name` (discovery), `render_skill/rule/agent(item, name, body, client)`, `build_skill_frontmatter(skill, name, passthrough)`, `ItemRequires`/`RequireRef`, `DependencyClosure { items, required_by }`, `resolve_requires_closure(source, initial)`, `LockedItem.{required_by, group}`, `OrphanedDependency` — names used consistently across tasks.

--- a/docs/superpowers/specs/2026-06-03-coupling-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-03-coupling-redesign-design.md
@@ -1,0 +1,216 @@
+# Design — co-location → dependency redesign
+
+**Date**: 2026-06-03
+**Status**: Approved (brainstorming output) — implementation pending
+**Amends**: [ADR-0006](../../adr/0006-flat-item-layout.md)
+**Will produce**: ADR-0009 + `format-spec.md` edits + two implementation slices
+
+---
+
+## 1. Problem
+
+Co-location — multiple entrypoints in one folder sharing the directory name
+([format-spec §2.1](../../format-spec.md), [ADR-0006](../../adr/0006-flat-item-layout.md))
+— is currently the only way to "install a rule + skill + agent together."
+Using it for that purpose causes three failures:
+
+- **Forced shared name.** All co-located kinds must share the folder name, even
+  when their natural identities differ.
+- **Resource duplication / no copy scoping.** An item's whole supporting tree is
+  copied with no way to exclude build artifacts, fixtures, or test scripts.
+- **Ecosystem-invisible coupling.** Rules and agents do not exist in the Agent
+  Skills standard, so a "these travel together" intent encoded by co-location
+  cannot survive a round-trip through standard-only tooling.
+
+Co-location is the right primitive for a _symmetric, inseparable_ unit. It is
+the wrong primitive for a _directed_ "A needs B" relationship or a _curated_
+optional set. This redesign repositions co-location and adds the two missing
+tiers.
+
+## 2. Decided model
+
+### 2.1 Three non-overlapping coupling tiers
+
+| Tier                                 | Mechanism                                       | For                                         |
+| ------------------------------------ | ----------------------------------------------- | ------------------------------------------- |
+| Symmetric unit (inseparable, mutual) | **co-location** — the folder _is_ the unit      | mutual rule↔skill that must travel together |
+| Directed prerequisite (A needs B)    | **`requires:` / `preload-skills:`** frontmatter | an item needs an item in another unit       |
+| Curated / optional set               | **bundles** (already exist)                     | a-la-carte packs                            |
+
+A mutual dependency is expressed by **co-locating** (the folder is the symmetric
+set), **never** by mutual `requires` (which would be a cycle = error).
+
+### 2.2 Name resolution — relaxed + optional naming
+
+The model field `name` becomes optional for `Skill`, `Rule`, and `Agent`
+(`name: String` → `name: Option<String>`). The **effective name** is resolved
+at discovery/parse time:
+
+| Kind             | `name` present in frontmatter                                                | `name` absent                |
+| ---------------- | ---------------------------------------------------------------------------- | ---------------------------- |
+| **Skill**        | MUST equal the folder name (Agent Skills standard mandate) — else lint error | effective name = folder name |
+| **Rule / Agent** | effective name = the frontmatter name (**MAY diverge** from the folder)      | effective name = folder name |
+
+Consequences:
+
+- The **folder name** governs the **skill** when one is present, and otherwise
+  serves only as the **fallback default** and the **co-location grouping key**.
+- **Rule/agent identity is layout-independent.** A solo rule/agent whose
+  frontmatter name diverges from its folder is legal and emits **no lint
+  diagnostic** (decided: silent — identity is `(kind, name)`, never a path).
+- A co-located folder MAY hold **independently-named kinds**: e.g.
+  `markspec-trace/` with a skill named `markspec-trace` (folder fallback) and a
+  rule named `markspec-trace-syntax` (diverges).
+- **Generation always emits a complete name.** `build_skill_frontmatter` (and
+  the rule/agent equivalents) read the resolved effective name, so generated
+  client output is always standard-complete even when the SSOT omits `name`.
+- **Bundles are unchanged**: `name` stays **required** and matches the filename
+  stem. This relaxation does not apply to bundles.
+
+### 2.3 `requires:` — directed dependencies (common to all kinds)
+
+Per-entrypoint (each item owns its own edges — NOT a folder manifest, NOT
+skill-only). Mirrors the bundle `items` vocabulary. **Hard** (auto-installed),
+**acyclic** (cycle = error). Resolved by `(kind, name)`.
+
+```yaml
+requires:
+  rules: [security-baseline]
+  skills: [sarif-formatting]
+  agents: []
+```
+
+- Each entry is **string-or-map** (serde untagged):
+  - bare string → same source, by name;
+  - `{ name, source }` → cross-source (`source` reuses the `add` DSL).
+- **`preload-skills`** (agent) = `requires.skills` **plus** the Claude-Code
+  runtime `skills:` emission. Preload implies require.
+- **Same-source resolution** (decided): a same-source `requires` entry resolves
+  by `(kind, name)` against the **same already-fetched registry root** the
+  entry item came from (reusing `has_matching_items` / `iter_item_dirs`), then
+  auto-installs it. No second fetch. This mirrors how bundle `items` already
+  resolve.
+
+### 2.4 `ignore:` — copy scoping (common to all kinds)
+
+`.gitignore`-style, **subtractive only**. No `include`/allowlist form — an
+allowlist re-opens the under-copy footgun that reference-tracing also has.
+Default absent = copy everything. Author-declared, stripped from generated
+output.
+
+```yaml
+ignore: ["scripts/**", "fixtures/**"]
+```
+
+Filters the result of `iter_item_resources` before the copy step.
+
+### 2.5 Cross-source resolution (contract fixed now; slice 2)
+
+- `source` reuses the `add` DSL verbatim (`owner/repo@ref`, https, `gitlab:`,
+  local), parsed by `source.rs` (`InstallSource`), fetched by `fetch_ssot`
+  (same auth path).
+- The transitive closure MAY span sources.
+- **Cycle detection** keyed by `(canonical-source-label, kind, name)`.
+- **Conflict policy:** the same `(kind, name)` resolving to a different
+  source/ref is an **error**, reusing the existing `conflict.rs` rule
+  (format-spec §3.7). No version-range solving, no SAT.
+- Dependency-pulled items are recorded in the lockfile with their **own**
+  `source` plus a **`required_by`** provenance list.
+- **Removal does NOT auto-cascade** (the #196 "never auto-delete" ethos).
+  `doctor` flags items now installed only as a removed item's dependency
+  ("orphaned dependency").
+
+### 2.6 Identity
+
+`(kind, name)`, never a path. On `add`: name = the positional argument
+(`upskill add owner/repo code-review`); `:path` is only "where to scan"; `@ref`
+is the version. Cross-source = source-locator + name, never a foreign
+filesystem path.
+
+## 3. Inherent limit (document, do not fix)
+
+Co-located rules/agents are invisible to standard-only tooling (the Agent
+Skills standard has no concept of rules or agents). The "install
+together" / cross-kind-coupling guarantee holds **only inside upskill** and
+cannot survive a round-trip through the standard ecosystem. This is a property
+of the standard, not a defect to engineer around.
+
+## 4. Rejected alternatives (do not revisit)
+
+- **Reference-aware / traced copy** — under-copies transitive deps inside
+  scripts/binaries (validated against Vercel NFT + vercel-labs/skills#810).
+- **`include`/allowlist in `ignore`** — same under-copy footgun; subtractive
+  only.
+- **Folder-file manifest for deps** — overlaps bundles, ecosystem-invisible,
+  third construct.
+- **Deps "just in the skill"** — skill-less units exist; wrong owner.
+- **Path-based item references** — layout-brittle; conflicts with name identity.
+- **Dropping co-location entirely** — it is the right primitive for symmetric
+  units; reposition, don't delete.
+- **`repo#name` single-token selector** — `#` collides with git/npm ref
+  semantics and is a shell comment; positional name + `{name, source}` cover it.
+- **Naming the copy-scope field `resources`** — overloads the standard's
+  vocabulary; use `ignore`.
+- **Requiring rule/agent name to match the folder** — contradicts
+  independently-named co-located kinds (§2.2). Rejected in brainstorming.
+- **Lint warning on solo rule/agent name divergence** — rejected in
+  brainstorming; identity is layout-independent, so divergence is silent.
+
+## 5. Touch points in the current code (`origin/main`)
+
+- `src/model/{skill,rule,agent}.rs` — `name` → `Option<String>`; add `requires`,
+  `ignore` (skip-serialize-if-empty); strip both at generation.
+- `src/parse/frontmatter.rs` — unchanged mechanics; new fields ride the model.
+- `src/pipeline/discovery.rs` — `iter_item_dirs` keeps returning folder name;
+  add an effective-name resolver that reads the entrypoint frontmatter; track
+  folder-group membership.
+- `src/pipeline/install.rs` — use the **effective name** (not folder name) for
+  output paths, link-rewrite namespace, lockfile identity; apply the `ignore`
+  filter to `iter_item_resources`; resolve + install the same-source `requires`
+  closure; record `required_by`.
+- `src/generate/mod.rs` (+ `claude.rs`/`copilot.rs`/`opencode.rs`) — read the
+  effective name; strip `requires`/`ignore` (alongside `schema`/`metadata`/
+  `license`).
+- `src/lockfile.rs` — add folder-group membership + `required_by` provenance to
+  `LockedItem`.
+- `src/pipeline/lifecycle.rs` — `doctor` orphaned-dependency flag; `remove`
+  acts on the folder-group unit.
+- `src/conflict.rs` — reuse for cross-source `(kind, name)` conflict (slice 2).
+- `src/lint.rs` — relax `check_name_matches_dir`: skill keeps the match rule;
+  rule/agent name is free; folder is fallback when name is absent.
+
+## 6. Deliverables & staging
+
+1. **ADR-0009** amending ADR-0006: repositioning + relaxed/optional naming +
+   three-tier model + `requires`/`ignore` + cross-source + conflict/cycle +
+   the inherent-limit note. (Produced in Slice 1's PR.)
+2. **format-spec edits**: §2.1 (optional/relaxed naming for skill vs
+   rule/agent), §2.4 (`ignore` copy-scope), §3.1 (`requires` + `ignore` common
+   fields), §3.4 (`preload-skills` implies `requires`), §3.7 (item-`requires`
+   cycle + conflict, reusing the same-name-different-source rule), §3.8
+   (canonical key order: add `requires`, `ignore`), §11 (mark "multi-repo item
+   sources" RESOLVED). (Produced in Slice 1's PR.)
+3. **Implementation (TDD), two slices, one PR each, off `origin/main`:**
+   - **Slice 1 (same-source):** optional/relaxed naming + folder-group tracking
+     - `ignore` filter + same-source `requires` closure + lockfile
+       group/`required_by` + `doctor` orphaned-dependency flag. Ships the ADR +
+       format-spec edits.
+   - **Slice 2 (cross-source, additive):** wire `{name, source}` through
+     `fetch_ssot`; cross-source cycle/conflict keyed by the canonical source
+     label.
+
+## 7. Conventions
+
+- **Pre-1.0:** delete deprecated shapes outright — no back-compat, no migration
+  shims, no fallback fields.
+- All new SSOT-only fields (`requires`, `ignore`) stripped from generated client
+  output.
+- TDD (failing test first), Conventional Commits, `just fmt` then `just verify`
+  before PR, squash-merge.
+- **Test isolation:** integration tests MUST use `tests/common::upskill_cmd`
+  with an isolated fake `$HOME` + a `.git` marker in the project dir (issue
+  #193) — `upskill add` defaults to global `$HOME` scope outside a git repo and
+  will otherwise pollute the developer's real `~`.
+- Each branch in its own worktree under `.claude/worktrees/<branch>`; run
+  `./bootstrap` after `git worktree add`; use full worktree-prefixed paths for
+  edits.

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -89,6 +89,7 @@ mod tests {
                     hash: None,
                     source_name: None,
                     required_by: vec![],
+                    group: None,
                 })
                 .collect(),
             bundles: vec![],

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -88,6 +88,7 @@ mod tests {
                     git_ref: None,
                     hash: None,
                     source_name: None,
+                    required_by: vec![],
                 })
                 .collect(),
             bundles: vec![],

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -53,6 +53,8 @@ const SKILL_KEY_ORDER: &[&str] = &[
     "audience",
     "license",
     "metadata",
+    "requires",
+    "ignore",
     "claude",
     "copilot",
     "opencode",
@@ -66,6 +68,8 @@ const RULE_KEY_ORDER: &[&str] = &[
     "license",
     "scope",
     "metadata",
+    "requires",
+    "ignore",
     "claude",
     "copilot",
     "opencode",
@@ -82,6 +86,8 @@ const AGENT_KEY_ORDER: &[&str] = &[
     "tools",
     "preload-skills",
     "metadata",
+    "requires",
+    "ignore",
     "claude",
     "copilot",
     "opencode",
@@ -566,6 +572,41 @@ mod tests {
         let items_pos = out.find("items:").unwrap();
         assert!(items_pos < alpha_pos, "extras after known keys:\n{out}");
         assert!(alpha_pos < zebra_pos, "extras alphabetical:\n{out}");
+    }
+
+    #[test]
+    fn reorder_requires_ignore_after_metadata_before_claude() {
+        // requires/ignore deliberately scrambled: ignore before metadata,
+        // requires after a claude passthrough block.
+        let input = concat!(
+            "schema: 1\n",
+            "name: test\n",
+            "description: d.\n",
+            "ignore:\n",
+            "  - \"*.tmp\"\n",
+            "metadata:\n",
+            "  version: 0.1.0\n",
+            "claude:\n",
+            "  body: hi\n",
+            "requires:\n",
+            "  skills:\n",
+            "    - foo\n",
+        );
+        for key_order in [RULE_KEY_ORDER, SKILL_KEY_ORDER, AGENT_KEY_ORDER] {
+            let out = reorder_yaml_keys(input, key_order);
+            let metadata = out.find("metadata:").unwrap();
+            let requires = out.find("requires:").unwrap();
+            let ignore = out.find("ignore:").unwrap();
+            let claude = out.find("claude:").unwrap();
+            assert!(
+                metadata < requires && metadata < ignore,
+                "requires/ignore must come after metadata:\n{out}"
+            );
+            assert!(
+                requires < claude && ignore < claude,
+                "requires/ignore must come before claude:\n{out}"
+            );
+        }
     }
 
     #[test]

--- a/src/generate/claude.rs
+++ b/src/generate/claude.rs
@@ -6,15 +6,15 @@ use serde_yaml_ng::{Mapping, Value};
 
 /// Skill frontmatter per §7.1: `name`, `description`, Agent Skills
 /// extended fields pass through.
-pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
-    super::build_skill_frontmatter(skill, skill.claude.as_ref())
+pub fn skill_frontmatter(skill: &Skill, name: &str) -> Result<String> {
+    super::build_skill_frontmatter(skill, name, skill.claude.as_ref())
 }
 
 /// Rule frontmatter per §7.1: `name`, `description`, `paths:` (array)
 /// from `scope.paths` when present.
-pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
+pub fn rule_frontmatter(rule: &Rule, name: &str) -> Result<String> {
     let mut map = Mapping::new();
-    map.insert(Value::from("name"), Value::from(rule.name.clone()));
+    map.insert(Value::from("name"), Value::from(name.to_string()));
     map.insert(
         Value::from("description"),
         Value::from(rule.description.clone()),
@@ -40,9 +40,9 @@ pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
 /// `model:` (literal alias), `tools:` (capitalized), `skills:` (from
 /// `preload-skills`). `mode` is implicit by file location and not
 /// emitted.
-pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
+pub fn agent_frontmatter(agent: &Agent, name: &str) -> Result<String> {
     let mut map = Mapping::new();
-    map.insert(Value::from("name"), Value::from(agent.name.clone()));
+    map.insert(Value::from("name"), Value::from(name.to_string()));
     map.insert(
         Value::from("description"),
         Value::from(agent.description.clone()),

--- a/src/generate/copilot.rs
+++ b/src/generate/copilot.rs
@@ -6,15 +6,15 @@ use serde_yaml_ng::{Mapping, Value};
 
 /// Skill frontmatter per §7.2: `name`, `description`, follows Agent
 /// Skills open standard.
-pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
-    super::build_skill_frontmatter(skill, skill.copilot.as_ref())
+pub fn skill_frontmatter(skill: &Skill, name: &str) -> Result<String> {
+    super::build_skill_frontmatter(skill, name, skill.copilot.as_ref())
 }
 
 /// Rule frontmatter per §7.2: `name`, `description`, `applyTo:`
 /// (comma-joined from `scope.paths`, default `"**"`).
-pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
+pub fn rule_frontmatter(rule: &Rule, name: &str) -> Result<String> {
     let mut map = Mapping::new();
-    map.insert(Value::from("name"), Value::from(rule.name.clone()));
+    map.insert(Value::from("name"), Value::from(name.to_string()));
     map.insert(
         Value::from("description"),
         Value::from(rule.description.clone()),
@@ -38,9 +38,9 @@ pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
 /// Agent frontmatter per §7.2: `name`, `description`, `model`, `tools`.
 /// `preload-skills` has no Copilot equivalent and is dropped. `mode` is
 /// not emitted (not in the §7.2 field list).
-pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
+pub fn agent_frontmatter(agent: &Agent, name: &str) -> Result<String> {
     let mut map = Mapping::new();
-    map.insert(Value::from("name"), Value::from(agent.name.clone()));
+    map.insert(Value::from("name"), Value::from(name.to_string()));
     map.insert(
         Value::from("description"),
         Value::from(agent.description.clone()),

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -87,12 +87,19 @@ pub fn render_rule(rule: &Rule, name: &str, body: &str, client: Client) -> Resul
 ///   file location and not emitted.
 /// - Copilot: `name`, `description`, `model`, `tools` (per §4 mapping
 ///   where defined, else passthrough). `mode` not emitted.
-///   `preload-skills` dropped (no equivalent).
+///   `preload-skills` rendered as a prose `## Skills` section in the body.
 /// - opencode: `description`, `mode` (defaults to `subagent`), `model`,
 ///   `tools` (lowercase). `name` is in filename per Appendix B and not
-///   emitted. `preload-skills` dropped (no equivalent).
+///   emitted. `preload-skills` rendered as a prose `## Skills` section in
+///   the body.
 pub fn render_agent(agent: &Agent, name: &str, body: &str, client: Client) -> Result<String> {
     let processed_body = directives::process(body, client)?;
+    let processed_body = match client {
+        Client::Claude => processed_body,
+        Client::Copilot | Client::OpenCode => {
+            append_preload_skills_section(&processed_body, &agent.preload_skills)
+        }
+    };
     let frontmatter = match client {
         Client::Claude => claude::agent_frontmatter(agent, name)?,
         Client::Copilot => copilot::agent_frontmatter(agent, name)?,
@@ -100,6 +107,27 @@ pub fn render_agent(agent: &Agent, name: &str, body: &str, client: Client) -> Re
     };
     let combined = assemble(&frontmatter, &processed_body);
     format::format_markdown(&combined)
+}
+
+/// For clients without a native skill-preload mechanism (Copilot,
+/// opencode), surface an agent's `preload-skills` as a prose section in
+/// the body so the agent is told which skills it relies on. Claude Code
+/// emits the native `skills:` frontmatter field instead (see
+/// `claude::agent_frontmatter`) and does not get this section. Returns the
+/// body unchanged when there are no preload skills.
+fn append_preload_skills_section(body: &str, preload_skills: &[String]) -> String {
+    if preload_skills.is_empty() {
+        return body.to_string();
+    }
+    let mut out = body.trim_end().to_string();
+    if !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str("## Skills\n\nThis agent relies on the following skills, installed alongside it. Use them when relevant:\n\n");
+    for s in preload_skills {
+        out.push_str(&format!("- {s}\n"));
+    }
+    out
 }
 
 /// Combine YAML frontmatter and body into a single markdown string.
@@ -149,6 +177,7 @@ pub(crate) fn build_skill_frontmatter(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::Agent;
     use crate::model::common::SchemaVersion;
     use std::collections::BTreeMap;
 
@@ -174,5 +203,72 @@ mod tests {
             out.contains("name: security-baseline"),
             "expected passed name in output, got:\n{out}"
         );
+    }
+
+    fn make_agent_with_preload(preload_skills: Vec<String>) -> Agent {
+        Agent {
+            schema: SchemaVersion::new(1).unwrap(),
+            name: Some("test-agent".to_string()),
+            description: "Test agent.".to_string(),
+            audience: None,
+            license: None,
+            mode: None,
+            model: None,
+            tools: vec![],
+            preload_skills,
+            metadata: None,
+            requires: Default::default(),
+            ignore: vec![],
+            claude: None,
+            copilot: None,
+            opencode: None,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn preload_skills_rendered_as_prose_for_copilot_and_opencode() {
+        let agent = make_agent_with_preload(vec!["a-skill".to_string()]);
+        let body = "## Instructions\n\nDo stuff.\n";
+
+        for client in [Client::Copilot, Client::OpenCode] {
+            let out = render_agent(&agent, "test-agent", body, client).unwrap();
+            assert!(
+                out.contains("## Skills"),
+                "{client:?}: expected '## Skills' section, got:\n{out}"
+            );
+            assert!(
+                out.contains("- a-skill"),
+                "{client:?}: expected '- a-skill' in output, got:\n{out}"
+            );
+        }
+    }
+
+    #[test]
+    fn preload_skills_not_in_body_for_claude() {
+        let agent = make_agent_with_preload(vec!["a-skill".to_string()]);
+        let body = "## Instructions\n\nDo stuff.\n";
+        let out = render_agent(&agent, "test-agent", body, Client::Claude).unwrap();
+        assert!(
+            !out.contains("## Skills"),
+            "Claude: expected NO '## Skills' body section (uses native skills: field), got:\n{out}"
+        );
+        assert!(
+            out.contains("skills:"),
+            "Claude: expected native 'skills:' frontmatter field, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn empty_preload_skills_produces_no_skills_section() {
+        let agent = make_agent_with_preload(vec![]);
+        let body = "## Instructions\n\nDo stuff.\n";
+        for client in [Client::Claude, Client::Copilot, Client::OpenCode] {
+            let out = render_agent(&agent, "test-agent", body, client).unwrap();
+            assert!(
+                !out.contains("## Skills"),
+                "{client:?}: expected NO '## Skills' section for empty preload, got:\n{out}"
+            );
+        }
     }
 }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -48,12 +48,12 @@ impl std::str::FromStr for Client {
 /// Process directives in `body` for `client`, generate client-specific
 /// frontmatter from `skill`, concatenate, and run the result through the
 /// dprint formatter for §7.5 idempotence.
-pub fn render_skill(skill: &Skill, body: &str, client: Client) -> Result<String> {
+pub fn render_skill(skill: &Skill, name: &str, body: &str, client: Client) -> Result<String> {
     let processed_body = directives::process(body, client)?;
     let frontmatter = match client {
-        Client::Claude => claude::skill_frontmatter(skill)?,
-        Client::Copilot => copilot::skill_frontmatter(skill)?,
-        Client::OpenCode => opencode::skill_frontmatter(skill)?,
+        Client::Claude => claude::skill_frontmatter(skill, name)?,
+        Client::Copilot => copilot::skill_frontmatter(skill, name)?,
+        Client::OpenCode => opencode::skill_frontmatter(skill, name)?,
     };
     let combined = assemble(&frontmatter, &processed_body);
     format::format_markdown(&combined)
@@ -68,12 +68,12 @@ pub fn render_skill(skill: &Skill, body: &str, client: Client) -> Result<String>
 ///   path-scoping per spec §3.2). The renderer still produces a string
 ///   for API symmetry; the install layer (Phase 3) decides whether to
 ///   write it or just register the SSOT path in `opencode.json`.
-pub fn render_rule(rule: &Rule, body: &str, client: Client) -> Result<String> {
+pub fn render_rule(rule: &Rule, name: &str, body: &str, client: Client) -> Result<String> {
     let processed_body = directives::process(body, client)?;
     let frontmatter = match client {
-        Client::Claude => claude::rule_frontmatter(rule)?,
-        Client::Copilot => copilot::rule_frontmatter(rule)?,
-        Client::OpenCode => opencode::rule_frontmatter(rule)?,
+        Client::Claude => claude::rule_frontmatter(rule, name)?,
+        Client::Copilot => copilot::rule_frontmatter(rule, name)?,
+        Client::OpenCode => opencode::rule_frontmatter(rule, name)?,
     };
     let combined = assemble(&frontmatter, &processed_body);
     format::format_markdown(&combined)
@@ -91,12 +91,12 @@ pub fn render_rule(rule: &Rule, body: &str, client: Client) -> Result<String> {
 /// - opencode: `description`, `mode` (defaults to `subagent`), `model`,
 ///   `tools` (lowercase). `name` is in filename per Appendix B and not
 ///   emitted. `preload-skills` dropped (no equivalent).
-pub fn render_agent(agent: &Agent, body: &str, client: Client) -> Result<String> {
+pub fn render_agent(agent: &Agent, name: &str, body: &str, client: Client) -> Result<String> {
     let processed_body = directives::process(body, client)?;
     let frontmatter = match client {
-        Client::Claude => claude::agent_frontmatter(agent)?,
-        Client::Copilot => copilot::agent_frontmatter(agent)?,
-        Client::OpenCode => opencode::agent_frontmatter(agent)?,
+        Client::Claude => claude::agent_frontmatter(agent, name)?,
+        Client::Copilot => copilot::agent_frontmatter(agent, name)?,
+        Client::OpenCode => opencode::agent_frontmatter(agent, name)?,
     };
     let combined = assemble(&frontmatter, &processed_body);
     format::format_markdown(&combined)
@@ -123,10 +123,11 @@ fn assemble(frontmatter: &str, body: &str) -> String {
 /// Skills extended fields, and the matching passthrough survive.
 pub(crate) fn build_skill_frontmatter(
     skill: &Skill,
+    name: &str,
     passthrough: Option<&Value>,
 ) -> Result<String> {
     let mut map = Mapping::new();
-    map.insert(Value::from("name"), Value::from(skill.name.clone()));
+    map.insert(Value::from("name"), Value::from(name.to_string()));
     map.insert(
         Value::from("description"),
         Value::from(skill.description.clone()),
@@ -143,4 +144,35 @@ pub(crate) fn build_skill_frontmatter(
     }
 
     serde_yaml_ng::to_string(&map).context("serializing skill frontmatter")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::common::SchemaVersion;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn render_rule_uses_passed_name_not_frontmatter() {
+        let rule = Rule {
+            schema: SchemaVersion::new(1).unwrap(),
+            name: None,
+            description: "A baseline security ruleset.".to_string(),
+            audience: None,
+            license: None,
+            scope: None,
+            metadata: None,
+            requires: Default::default(),
+            ignore: vec![],
+            claude: None,
+            copilot: None,
+            opencode: None,
+            extra: BTreeMap::new(),
+        };
+        let out = render_rule(&rule, "security-baseline", "## Body\n", Client::Claude).unwrap();
+        assert!(
+            out.contains("name: security-baseline"),
+            "expected passed name in output, got:\n{out}"
+        );
+    }
 }

--- a/src/generate/opencode.rs
+++ b/src/generate/opencode.rs
@@ -7,8 +7,8 @@ use serde_yaml_ng::{Mapping, Value};
 /// Skill frontmatter per §7.3. opencode walks `.agents/skills/` natively;
 /// for the rendering layer we still produce the canonical content with
 /// the `opencode.*` passthrough merged.
-pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
-    super::build_skill_frontmatter(skill, skill.opencode.as_ref())
+pub fn skill_frontmatter(skill: &Skill, name: &str) -> Result<String> {
+    super::build_skill_frontmatter(skill, name, skill.opencode.as_ref())
 }
 
 /// Rule frontmatter per §7.3 / ADR-0003. opencode rules are referenced
@@ -19,9 +19,9 @@ pub fn skill_frontmatter(skill: &Skill) -> Result<String> {
 /// a string. The install layer (Phase 3) decides whether to write it or
 /// just register the SSOT path. `scope.paths` is silently dropped per
 /// spec §3.2 (opencode does not support per-rule path-scoping).
-pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
+pub fn rule_frontmatter(rule: &Rule, name: &str) -> Result<String> {
     let mut map = Mapping::new();
-    map.insert(Value::from("name"), Value::from(rule.name.clone()));
+    map.insert(Value::from("name"), Value::from(name.to_string()));
     map.insert(
         Value::from("description"),
         Value::from(rule.description.clone()),
@@ -43,9 +43,9 @@ pub fn rule_frontmatter(rule: &Rule) -> Result<String> {
 /// originally suggested filename-only; opencode tolerates the redundant
 /// field. `preload-skills` has no opencode equivalent and is dropped.
 /// `mode` defaults to `subagent` per spec §3.4 when absent.
-pub fn agent_frontmatter(agent: &Agent) -> Result<String> {
+pub fn agent_frontmatter(agent: &Agent, name: &str) -> Result<String> {
     let mut map = Mapping::new();
-    map.insert(Value::from("name"), Value::from(agent.name.clone()));
+    map.insert(Value::from("name"), Value::from(name.to_string()));
     map.insert(
         Value::from("description"),
         Value::from(agent.description.clone()),

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -280,7 +280,7 @@ fn check_file(file: &Path, out: &mut Vec<Finding>) -> Result<()> {
 
     let body = match parse_kind(&raw, kind) {
         Ok((parsed_name, body)) => {
-            check_name_matches_dir(file, &parsed_name, kind, out);
+            check_name_matches_dir(file, parsed_name.as_deref(), kind, out);
             body
         }
         Err(err) => {
@@ -307,7 +307,7 @@ fn check_file(file: &Path, out: &mut Vec<Finding>) -> Result<()> {
 /// are frontmatter+body; bundles are pure YAML with no body (§2.2,
 /// ADR-0007), so the bundle arm returns an empty body so the
 /// body-rules become no-ops.
-fn parse_kind(raw: &str, kind: FileKind) -> Result<(String, &str)> {
+fn parse_kind(raw: &str, kind: FileKind) -> Result<(Option<String>, &str)> {
     match kind {
         FileKind::Skill => {
             let (item, body) = frontmatter::parse::<Skill>(raw)?;
@@ -323,16 +323,25 @@ fn parse_kind(raw: &str, kind: FileKind) -> Result<(String, &str)> {
         }
         FileKind::Bundle => {
             let bundle: crate::model::Bundle = serde_yaml_ng::from_str(raw)?;
-            Ok((bundle.name, ""))
+            Ok((Some(bundle.name), ""))
         }
     }
 }
 
-fn check_name_matches_dir(file: &Path, name: &str, kind: FileKind, out: &mut Vec<Finding>) {
-    // Bundles match the filename stem (`<name>.bundle.yaml`); items
-    // match the parent directory name.
+/// Identity-name validation (§2.1, ADR-0006).
+///
+/// - Bundle: when `name` is present, the filename stem MUST equal it.
+/// - Skill: the Agent Skills standard mandates `name == dir`. When a
+///   `name` is present it MUST equal the directory; when absent the
+///   directory name is used and there is nothing to check.
+/// - Rule / Agent: identity is layout-independent — the frontmatter
+///   `name` may diverge from the folder, so no check is performed.
+fn check_name_matches_dir(file: &Path, name: Option<&str>, kind: FileKind, out: &mut Vec<Finding>) {
     match kind {
         FileKind::Bundle => {
+            let Some(name) = name else {
+                return;
+            };
             let Some(stem) = file
                 .file_name()
                 .and_then(|n| n.to_str())
@@ -352,7 +361,10 @@ fn check_name_matches_dir(file: &Path, name: &str, kind: FileKind, out: &mut Vec
                 });
             }
         }
-        _ => {
+        FileKind::Skill => {
+            let Some(name) = name else {
+                return;
+            };
             let Some(dir) = file
                 .parent()
                 .and_then(|p| p.file_name())
@@ -366,10 +378,13 @@ fn check_name_matches_dir(file: &Path, name: &str, kind: FileKind, out: &mut Vec
                     severity: Severity::Error,
                     path: file.to_path_buf(),
                     line: None,
-                    message: format!("frontmatter `name: {name}` does not match directory `{dir}`"),
+                    message: format!(
+                        "skill `name: {name}` must equal directory `{dir}` (Agent Skills standard)"
+                    ),
                 });
             }
         }
+        FileKind::Rule | FileKind::Agent => {}
     }
 }
 
@@ -735,53 +750,60 @@ mod tests {
     }
 
     #[test]
-    fn lint_flags_colocated_entrypoint_with_mismatched_name() {
-        // Format-spec §2.1, ADR-0006: when an item directory holds
-        // multiple entrypoints, every entrypoint's `name:` MUST equal
-        // the directory name. A solo per-file `name-matches-dir`
-        // check is sufficient — each mismatching entrypoint is
-        // flagged independently.
+    fn lint_skill_name_mismatch_is_flagged_but_rule_divergence_is_silent() {
+        // §2.1, ADR-0006: a skill's `name:` MUST equal its directory
+        // (Agent Skills standard). Rules and agents have
+        // layout-independent identity — their `name:` may diverge from
+        // the folder, which is legal and silent.
         let tmp = tempfile::tempdir().unwrap();
         write(
             &tmp.path().join("security/SKILL.md"),
             concat!(
                 "---\n",
                 "schema: 1\n",
-                "name: security\n",
-                "description: matches the directory.\n",
+                "name: wrong-name\n",
+                "description: skill name diverges from the directory.\n",
                 "---\n",
                 "\n## ok\n",
             ),
         );
         write(
-            &tmp.path().join("security/AGENT.md"),
+            &tmp.path().join("stuff/RULE.md"),
             concat!(
                 "---\n",
                 "schema: 1\n",
-                "name: wrong-name\n",
-                "description: does not match the directory.\n",
+                "name: security-baseline\n",
+                "description: rule name diverges from the directory.\n",
                 "---\n",
                 "\n## ok\n",
             ),
         );
         let report = lint(&[tmp.path().to_path_buf()], false).unwrap();
-        // The skill (matches) produces no finding; the agent (mismatch) does.
-        let agent_finding = report.findings.iter().find(|f| {
-            f.rule_id == "name-matches-dir"
-                && f.path.file_name().and_then(|n| n.to_str()) == Some("AGENT.md")
-        });
-        assert!(
-            agent_finding.is_some(),
-            "expected co-located AGENT.md name mismatch to be flagged: {:?}",
-            report.findings
-        );
+        // The skill (mismatch) is flagged; the rule (mismatch) is not.
         let skill_finding = report.findings.iter().find(|f| {
             f.rule_id == "name-matches-dir"
                 && f.path.file_name().and_then(|n| n.to_str()) == Some("SKILL.md")
         });
         assert!(
-            skill_finding.is_none(),
-            "matching co-located SKILL.md must not be flagged: {:?}",
+            skill_finding.is_some(),
+            "expected skill name mismatch to be flagged: {:?}",
+            report.findings
+        );
+        assert!(
+            skill_finding
+                .unwrap()
+                .message
+                .contains("Agent Skills standard"),
+            "skill mismatch message should reference the standard: {:?}",
+            skill_finding
+        );
+        let rule_finding = report.findings.iter().find(|f| {
+            f.rule_id == "name-matches-dir"
+                && f.path.file_name().and_then(|n| n.to_str()) == Some("RULE.md")
+        });
+        assert!(
+            rule_finding.is_none(),
+            "rule name divergence must be silent: {:?}",
             report.findings
         );
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -61,6 +61,11 @@ pub struct LockedItem {
     /// orphaned-dependency check; never triggers auto-removal (#196).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_by: Vec<String>,
+    /// Source folder this item was discovered in — the co-location
+    /// grouping key (§2.1). `remove <name>` removes every item sharing the
+    /// same `(source, group)` so a co-located unit travels as one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
 }
 
 /// Bundle entry recorded when an install resolves a `.bundle.yaml` file
@@ -268,6 +273,7 @@ pub fn items_from_report(
                 .get(&(entry.kind, entry.name.clone()))
                 .cloned()
                 .unwrap_or_default(),
+            group: entry.group.clone(),
         });
     }
     out
@@ -289,6 +295,7 @@ mod tests {
             hash: Some("sha256:deadbeef".to_string()),
             source_name: None,
             required_by: vec![],
+            group: None,
         }
     }
 
@@ -407,6 +414,7 @@ mod tests {
                     client: Client::Claude,
                     output_path: PathBuf::from(".claude/skills/code-review/SKILL.md"),
                     source_hash: Some("sha256:abc".into()),
+                    group: Some("code-review".into()),
                 },
                 InstalledItem {
                     kind: ItemKind::Skill,
@@ -414,6 +422,7 @@ mod tests {
                     client: Client::Copilot,
                     output_path: PathBuf::from(".github/skills/code-review/SKILL.md"),
                     source_hash: Some("sha256:abc".into()),
+                    group: Some("code-review".into()),
                 },
                 InstalledItem {
                     kind: ItemKind::Skill,
@@ -421,6 +430,7 @@ mod tests {
                     client: Client::OpenCode,
                     output_path: PathBuf::from(".agents/skills/code-review/SKILL.md"),
                     source_hash: Some("sha256:abc".into()),
+                    group: Some("code-review".into()),
                 },
             ],
         };
@@ -437,6 +447,8 @@ mod tests {
         assert_eq!(items[0].name, "code-review");
         assert_eq!(items[0].source, "local:./src");
         assert_eq!(items[0].hash, Some("sha256:abc".into()));
+        // The co-location group flows through from the report entry.
+        assert_eq!(items[0].group, Some("code-review".into()));
     }
 
     #[test]
@@ -579,6 +591,7 @@ mod tests {
             hash: None,
             source_name: Some("brainstorming".to_string()),
             required_by: vec![],
+            group: None,
         };
         let json = serde_json::to_string(&item).unwrap();
         assert!(json.contains("\"source_name\":\"brainstorming\""), "{json}");
@@ -594,6 +607,7 @@ mod tests {
             hash: None,
             source_name: None,
             required_by: vec![],
+            group: None,
         };
         let json = serde_json::to_string(&item).unwrap();
         assert!(!json.contains("source_name"), "{json}");

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -56,6 +56,11 @@ pub struct LockedItem {
     /// SSOT name. Used by `update` to locate the correct source file.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_name: Option<String>,
+    /// `"kind:name"` of every installed item that pulled this one in as a
+    /// dependency. Empty for directly-requested items. Drives `doctor`'s
+    /// orphaned-dependency check; never triggers auto-removal (#196).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_by: Vec<String>,
 }
 
 /// Bundle entry recorded when an install resolves a `.bundle.yaml` file
@@ -242,6 +247,7 @@ pub fn items_from_report(
     report: &InstallReport,
     source_label: &str,
     git_ref: Option<&str>,
+    required_by: &std::collections::BTreeMap<(ItemKind, String), Vec<String>>,
     mut hash_for: impl FnMut(ItemKind, &str) -> Option<String>,
 ) -> Vec<LockedItem> {
     use std::collections::BTreeSet;
@@ -258,6 +264,10 @@ pub fn items_from_report(
             git_ref: git_ref.map(str::to_string),
             hash: hash_for(entry.kind, &entry.name),
             source_name: None,
+            required_by: required_by
+                .get(&(entry.kind, entry.name.clone()))
+                .cloned()
+                .unwrap_or_default(),
         });
     }
     out
@@ -278,6 +288,7 @@ mod tests {
             git_ref: Some("v1.0.0".to_string()),
             hash: Some("sha256:deadbeef".to_string()),
             source_name: None,
+            required_by: vec![],
         }
     }
 
@@ -414,9 +425,13 @@ mod tests {
             ],
         };
 
-        let items = items_from_report(&report, "local:./src", None, |_, _| {
-            Some("sha256:abc".into())
-        });
+        let items = items_from_report(
+            &report,
+            "local:./src",
+            None,
+            &std::collections::BTreeMap::new(),
+            |_, _| Some("sha256:abc".into()),
+        );
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].kind, ItemKind::Skill);
         assert_eq!(items[0].name, "code-review");
@@ -563,6 +578,7 @@ mod tests {
             git_ref: None,
             hash: None,
             source_name: Some("brainstorming".to_string()),
+            required_by: vec![],
         };
         let json = serde_json::to_string(&item).unwrap();
         assert!(json.contains("\"source_name\":\"brainstorming\""), "{json}");
@@ -577,6 +593,7 @@ mod tests {
             git_ref: None,
             hash: None,
             source_name: None,
+            required_by: vec![],
         };
         let json = serde_json::to_string(&item).unwrap();
         assert!(!json.contains("source_name"), "{json}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -849,7 +849,34 @@ fn print_doctor_report(report: &DoctorReport) {
         }
     }
 
+    print_doctor_orphaned_dependencies(report);
     print_doctor_skipped_plugins(report);
+}
+
+fn print_doctor_orphaned_dependencies(report: &DoctorReport) {
+    if report.orphaned_dependencies.is_empty() {
+        return;
+    }
+    println!(
+        "{} {} orphaned dependency(ies) — every item that required them is no longer installed",
+        style::warn("doctor:"),
+        report.orphaned_dependencies.len()
+    );
+    for d in &report.orphaned_dependencies {
+        println!(
+            "  orphaned dependency: {} {} (was required by {}, now absent)",
+            style::dim(kind_label(d.kind)),
+            style::name(&d.name),
+            d.former_requirers.join(", "),
+        );
+        println!(
+            "    {}",
+            style::dim(&format!(
+                "remove with `upskill remove {}` if no longer needed",
+                d.name
+            ))
+        );
+    }
 }
 
 fn print_doctor_skipped_plugins(report: &DoctorReport) {

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -31,7 +31,10 @@ pub enum ToolCap {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Agent {
     pub schema: SchemaVersion,
-    pub name: String,
+    /// Effective name resolution is layout-dependent (§2.1): absent means
+    /// the directory name is used. Resolved by the pipeline/lint layer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub description: String,
 
     /// §3.1: top-level audience targeting.

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -56,6 +56,13 @@ pub struct Agent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
 
+    /// §3.7 directed dependencies. SSOT-only — stripped from output.
+    #[serde(default, skip_serializing_if = "crate::model::ItemRequires::is_empty")]
+    pub requires: crate::model::ItemRequires,
+    /// §2.4 subtractive copy-scope patterns. SSOT-only — stripped from output.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore: Vec<String>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claude: Option<serde_yaml_ng::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,6 +3,7 @@
 pub mod agent;
 pub mod bundle;
 pub mod common;
+pub mod requires;
 pub mod rule;
 pub mod skill;
 
@@ -12,5 +13,6 @@ pub use bundle::{
     PluginEntry, Requires, VscodePluginDescriptor,
 };
 pub use common::{Audience, CURRENT_SCHEMA, License, Metadata, SchemaVersion};
+pub use requires::{ItemRequires, RequireRef};
 pub use rule::{Rule, Scope};
 pub use skill::Skill;

--- a/src/model/requires.rs
+++ b/src/model/requires.rs
@@ -1,0 +1,73 @@
+//! Item-level `requires` (§3.7) — directed dependencies declared per
+//! entrypoint. Distinct from the bundle-level `Requires` (which pins a
+//! semver constraint); item requires resolve by `(kind, name)`.
+
+use serde::{Deserialize, Serialize};
+
+/// One `requires` reference. A bare string targets the same source by
+/// name; a `{ name, source }` map targets another source (the `source`
+/// uses the `upskill add` source DSL). Cross-source *resolution* ships in
+/// a later release; this type captures the stable on-disk form now.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RequireRef {
+    Name(String),
+    Detailed { name: String, source: String },
+}
+
+impl RequireRef {
+    pub fn name(&self) -> &str {
+        match self {
+            RequireRef::Name(n) => n,
+            RequireRef::Detailed { name, .. } => name,
+        }
+    }
+    /// The cross-source locator, if this is a `{ name, source }` entry.
+    pub fn source(&self) -> Option<&str> {
+        match self {
+            RequireRef::Name(_) => None,
+            RequireRef::Detailed { source, .. } => Some(source),
+        }
+    }
+}
+
+/// `requires:` block — mirrors the bundle `items` vocabulary.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ItemRequires {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<RequireRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<RequireRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<RequireRef>,
+}
+
+impl ItemRequires {
+    /// True when no dependency is declared. Used by `skip_serializing_if`.
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty() && self.skills.is_empty() && self.agents.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_string_and_map_entries() {
+        let yaml = "rules: [security-baseline]\nskills: [{ name: sarif, source: org/repo }]\n";
+        let req: ItemRequires = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(
+            req.rules,
+            vec![RequireRef::Name("security-baseline".into())]
+        );
+        assert_eq!(req.skills[0].name(), "sarif");
+        assert_eq!(req.skills[0].source(), Some("org/repo"));
+        assert!(req.agents.is_empty());
+    }
+
+    #[test]
+    fn empty_when_no_kinds() {
+        assert!(ItemRequires::default().is_empty());
+    }
+}

--- a/src/model/rule.rs
+++ b/src/model/rule.rs
@@ -27,6 +27,13 @@ pub struct Rule {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
 
+    /// §3.7 directed dependencies. SSOT-only — stripped from output.
+    #[serde(default, skip_serializing_if = "crate::model::ItemRequires::is_empty")]
+    pub requires: crate::model::ItemRequires,
+    /// §2.4 subtractive copy-scope patterns. SSOT-only — stripped from output.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore: Vec<String>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claude: Option<serde_yaml_ng::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/model/rule.rs
+++ b/src/model/rule.rs
@@ -14,7 +14,10 @@ pub struct Scope {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Rule {
     pub schema: SchemaVersion,
-    pub name: String,
+    /// Effective name resolution is layout-dependent (§2.1): absent means
+    /// the directory name is used. Resolved by the pipeline/lint layer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub description: String,
 
     /// §3.1: top-level audience targeting.

--- a/src/model/skill.rs
+++ b/src/model/skill.rs
@@ -19,6 +19,13 @@ pub struct Skill {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
 
+    /// §3.7 directed dependencies. SSOT-only — stripped from output.
+    #[serde(default, skip_serializing_if = "crate::model::ItemRequires::is_empty")]
+    pub requires: crate::model::ItemRequires,
+    /// §2.4 subtractive copy-scope patterns. SSOT-only — stripped from output.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore: Vec<String>,
+
     /// §3.5 client-specific passthrough block.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claude: Option<serde_yaml_ng::Value>,

--- a/src/model/skill.rs
+++ b/src/model/skill.rs
@@ -7,7 +7,10 @@ use std::collections::BTreeMap;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Skill {
     pub schema: SchemaVersion,
-    pub name: String,
+    /// Effective name resolution is layout-dependent (§2.1): absent means
+    /// the directory name is used. Resolved by the pipeline/lint layer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub description: String,
 
     /// §3.1: top-level audience targeting. When present, generation only

--- a/src/parse/frontmatter.rs
+++ b/src/parse/frontmatter.rs
@@ -129,7 +129,7 @@ mod tests {
         );
         let (skill, body) = parse::<Skill>(input).unwrap();
         assert_eq!(skill.schema.get(), 1);
-        assert_eq!(skill.name, "create-api-endpoint");
+        assert_eq!(skill.name.as_deref(), Some("create-api-endpoint"));
         assert_eq!(skill.license, Some(License("proprietary".into())));
         assert_eq!(body, "body\n");
         let metadata = skill.metadata.as_ref().unwrap();
@@ -159,7 +159,7 @@ mod tests {
             "body\n",
         );
         let (rule, _body) = parse::<Rule>(input).unwrap();
-        assert_eq!(rule.name, "api-conventions");
+        assert_eq!(rule.name.as_deref(), Some("api-conventions"));
         let scope = rule.scope.as_ref().unwrap();
         assert_eq!(scope.paths, vec!["src/api/**/*.ts", "src/handlers/**/*.ts"]);
         assert!(rule.copilot.is_some(), "copilot passthrough must be parsed");
@@ -197,7 +197,7 @@ mod tests {
             "body\n",
         );
         let (agent, _body) = parse::<Agent>(input).unwrap();
-        assert_eq!(agent.name, "security-reviewer");
+        assert_eq!(agent.name.as_deref(), Some("security-reviewer"));
         assert_eq!(agent.mode, Some(Mode::Subagent));
         assert_eq!(agent.model.as_deref(), Some("sonnet"));
         assert_eq!(

--- a/src/parse/frontmatter.rs
+++ b/src/parse/frontmatter.rs
@@ -236,6 +236,31 @@ mod tests {
         round_trip(&skill);
     }
 
+    #[test]
+    fn requires_and_ignore_parse_into_typed_fields_not_extra() {
+        let input = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: code-review\n",
+            "description: Use when reviewing changes\n",
+            "requires:\n",
+            "  skills:\n",
+            "    - sarif-formatting\n",
+            "ignore:\n",
+            "  - \"scripts/**\"\n",
+            "---\n",
+            "body\n",
+        );
+        let (skill, _) = parse::<Skill>(input).unwrap();
+        assert_eq!(skill.requires.skills[0].name(), "sarif-formatting");
+        assert_eq!(skill.ignore, vec!["scripts/**".to_string()]);
+        // Typed fields must NOT leak into the pass-through map (which
+        // skills emit verbatim into output).
+        assert!(!skill.extra.contains_key("requires"));
+        assert!(!skill.extra.contains_key("ignore"));
+        round_trip(&skill);
+    }
+
     fn round_trip<T>(value: &T)
     where
         T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,

--- a/src/pipeline/discovery.rs
+++ b/src/pipeline/discovery.rs
@@ -12,6 +12,42 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::ItemKind;
+use crate::parse::frontmatter;
+
+/// Effective identity name for an item (§2.1). Skills always take the
+/// folder name (Agent Skills standard mandates name == dir); rules/agents
+/// take their frontmatter name when present, else the folder name.
+pub(super) fn effective_name(
+    kind: ItemKind,
+    frontmatter_name: Option<&str>,
+    folder: &str,
+) -> String {
+    match kind {
+        ItemKind::Skill => folder.to_string(),
+        ItemKind::Rule | ItemKind::Agent => frontmatter_name.unwrap_or(folder).to_string(),
+    }
+}
+
+/// Probe an entrypoint's frontmatter `name` cheaply, falling back to the
+/// folder name on any read/parse failure (validation belongs to lint, not
+/// discovery). Keeps `(kind, name)` identity consistent everywhere.
+pub(super) fn probe_effective_name(entry_path: &Path, kind: ItemKind, folder: &str) -> String {
+    if kind == ItemKind::Skill {
+        return folder.to_string();
+    }
+    #[derive(serde::Deserialize)]
+    struct NameProbe {
+        #[serde(default)]
+        name: Option<String>,
+    }
+    match fs::read_to_string(entry_path) {
+        Ok(raw) => match frontmatter::parse::<NameProbe>(&raw) {
+            Ok((p, _)) => p.name.unwrap_or_else(|| folder.to_string()),
+            Err(_) => folder.to_string(),
+        },
+        Err(_) => folder.to_string(),
+    }
+}
 
 /// Returns true when the directory contains at least one SSOT entrypoint
 /// file (`RULE.md`, `SKILL.md`, or `AGENT.md`).
@@ -92,10 +128,16 @@ pub(super) fn scan_source_items(source: &Path) -> Vec<(ItemKind, String)> {
                 items.push((ItemKind::Skill, name.to_string()));
             }
             if path.join("RULE.md").is_file() {
-                items.push((ItemKind::Rule, name.to_string()));
+                items.push((
+                    ItemKind::Rule,
+                    probe_effective_name(&path.join("RULE.md"), ItemKind::Rule, name),
+                ));
             }
             if path.join("AGENT.md").is_file() {
-                items.push((ItemKind::Agent, name.to_string()));
+                items.push((
+                    ItemKind::Agent,
+                    probe_effective_name(&path.join("AGENT.md"), ItemKind::Agent, name),
+                ));
             }
         } else {
             // Category subdir: source/<category>/<item>/ENTRY.md
@@ -115,10 +157,24 @@ pub(super) fn scan_source_items(source: &Path) -> Vec<(ItemKind, String)> {
                         items.push((ItemKind::Skill, sub_name.to_string()));
                     }
                     if sub_path.join("RULE.md").is_file() {
-                        items.push((ItemKind::Rule, sub_name.to_string()));
+                        items.push((
+                            ItemKind::Rule,
+                            probe_effective_name(
+                                &sub_path.join("RULE.md"),
+                                ItemKind::Rule,
+                                sub_name,
+                            ),
+                        ));
                     }
                     if sub_path.join("AGENT.md").is_file() {
-                        items.push((ItemKind::Agent, sub_name.to_string()));
+                        items.push((
+                            ItemKind::Agent,
+                            probe_effective_name(
+                                &sub_path.join("AGENT.md"),
+                                ItemKind::Agent,
+                                sub_name,
+                            ),
+                        ));
                     }
                 }
             }

--- a/src/pipeline/ignore.rs
+++ b/src/pipeline/ignore.rs
@@ -1,0 +1,137 @@
+//! `.gitignore`-style subtractive filtering of an item's supporting
+//! resources (format-spec §2.4). Hand-rolled to avoid a glob dependency
+//! (protects the ~3 MB binary target). Supports `*` (any run of
+//! non-`/` chars), `**` (any run including `/`), `?` (one non-`/` char),
+//! and literal segments. A pattern with no `/` matches the basename at any
+//! depth; a pattern with a `/` matches the full relative path. A trailing
+//! `/**` (or a bare directory-name pattern) matches everything under that
+//! directory.
+
+use std::path::PathBuf;
+
+/// Drop every resource (path relative to the item dir) that matches any
+/// `ignore` glob. Returns the kept resources, order preserved.
+pub(super) fn filter_ignored(resources: Vec<PathBuf>, patterns: &[String]) -> Vec<PathBuf> {
+    if patterns.is_empty() {
+        return resources;
+    }
+    resources
+        .into_iter()
+        .filter(|rel| {
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            !patterns.iter().any(|p| matches_pattern(&rel_str, p))
+        })
+        .collect()
+}
+
+fn matches_pattern(path: &str, pattern: &str) -> bool {
+    let pattern = pattern.trim_end_matches('/');
+    // A literal pattern with no slash and no glob metacharacters is a
+    // directory-name shorthand: it matches that basename at any depth AND
+    // every path nested under such a directory (`fixtures` drops
+    // `fixtures/data.json`).
+    if !pattern.contains('/') {
+        let base = path.rsplit('/').next().unwrap_or(path);
+        if glob_match(base, pattern) {
+            return true;
+        }
+        if !pattern.contains(['*', '?']) && path.split('/').any(|seg| seg == pattern) {
+            return true;
+        }
+        return false;
+    }
+    // Directory-prefix shorthand: `scripts/**` ignores the whole subtree.
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return path == prefix || path.starts_with(&format!("{prefix}/"));
+    }
+    glob_match(path, pattern)
+}
+
+/// Match `text` against a glob `pat` where `*`/`?` do not cross `/` and
+/// `**` does. Recursive backtracking — patterns are short and few.
+fn glob_match(text: &str, pat: &str) -> bool {
+    let t: Vec<char> = text.chars().collect();
+    let p: Vec<char> = pat.chars().collect();
+    m(&t, 0, &p, 0)
+}
+
+fn m(t: &[char], ti: usize, p: &[char], pi: usize) -> bool {
+    if pi == p.len() {
+        return ti == t.len();
+    }
+    match p[pi] {
+        '*' if pi + 1 < p.len() && p[pi + 1] == '*' => {
+            // `**` — consume any chars including `/`.
+            let mut k = ti;
+            loop {
+                if m(t, k, p, pi + 2) {
+                    return true;
+                }
+                if k == t.len() {
+                    return false;
+                }
+                k += 1;
+            }
+        }
+        '*' => {
+            let mut k = ti;
+            loop {
+                if m(t, k, p, pi + 1) {
+                    return true;
+                }
+                if k == t.len() || t[k] == '/' {
+                    return false;
+                }
+                k += 1;
+            }
+        }
+        '?' => ti < t.len() && t[ti] != '/' && m(t, ti + 1, p, pi + 1),
+        c => ti < t.len() && t[ti] == c && m(t, ti + 1, p, pi + 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn paths(v: &[&str]) -> Vec<PathBuf> {
+        v.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn empty_patterns_keep_everything() {
+        let r = paths(&["scripts/gate.sh", "refs/p.md"]);
+        assert_eq!(filter_ignored(r.clone(), &[]), r);
+    }
+
+    #[test]
+    fn double_star_prefix_drops_subtree() {
+        let kept = filter_ignored(
+            paths(&["scripts/gate.sh", "scripts/lib/x.sh", "refs/p.md"]),
+            &["scripts/**".to_string()],
+        );
+        assert_eq!(kept, paths(&["refs/p.md"]));
+    }
+
+    #[test]
+    fn bare_name_matches_basename_at_any_depth() {
+        let kept = filter_ignored(paths(&["a/b/notes.log", "keep.md"]), &["*.log".to_string()]);
+        assert_eq!(kept, paths(&["keep.md"]));
+    }
+
+    #[test]
+    fn single_star_does_not_cross_slash() {
+        let kept = filter_ignored(paths(&["a/x.txt", "a/b/x.txt"]), &["a/*.txt".to_string()]);
+        assert_eq!(kept, paths(&["a/b/x.txt"]));
+    }
+
+    #[test]
+    fn bare_dir_name_ignores_subtree() {
+        let kept = filter_ignored(
+            paths(&["fixtures/data.json", "main.md"]),
+            &["fixtures".to_string()],
+        );
+        assert_eq!(kept, paths(&["main.md"]));
+    }
+}

--- a/src/pipeline/ignore.rs
+++ b/src/pipeline/ignore.rs
@@ -52,10 +52,11 @@ fn matches_pattern(path: &str, pattern: &str) -> bool {
 fn glob_match(text: &str, pat: &str) -> bool {
     let t: Vec<char> = text.chars().collect();
     let p: Vec<char> = pat.chars().collect();
-    m(&t, 0, &p, 0)
+    match_at(&t, 0, &p, 0)
 }
 
-fn m(t: &[char], ti: usize, p: &[char], pi: usize) -> bool {
+/// Match `t[ti..]` against pattern `p[pi..]`. `*`/`?` stay within a path segment; `**` spans `/`.
+fn match_at(t: &[char], ti: usize, p: &[char], pi: usize) -> bool {
     if pi == p.len() {
         return ti == t.len();
     }
@@ -64,7 +65,7 @@ fn m(t: &[char], ti: usize, p: &[char], pi: usize) -> bool {
             // `**` — consume any chars including `/`.
             let mut k = ti;
             loop {
-                if m(t, k, p, pi + 2) {
+                if match_at(t, k, p, pi + 2) {
                     return true;
                 }
                 if k == t.len() {
@@ -76,7 +77,7 @@ fn m(t: &[char], ti: usize, p: &[char], pi: usize) -> bool {
         '*' => {
             let mut k = ti;
             loop {
-                if m(t, k, p, pi + 1) {
+                if match_at(t, k, p, pi + 1) {
                     return true;
                 }
                 if k == t.len() || t[k] == '/' {
@@ -85,8 +86,8 @@ fn m(t: &[char], ti: usize, p: &[char], pi: usize) -> bool {
                 k += 1;
             }
         }
-        '?' => ti < t.len() && t[ti] != '/' && m(t, ti + 1, p, pi + 1),
-        c => ti < t.len() && t[ti] == c && m(t, ti + 1, p, pi + 1),
+        '?' => ti < t.len() && t[ti] != '/' && match_at(t, ti + 1, p, pi + 1),
+        c => ti < t.len() && t[ti] == c && match_at(t, ti + 1, p, pi + 1),
     }
 }
 
@@ -133,5 +134,21 @@ mod tests {
             &["fixtures".to_string()],
         );
         assert_eq!(kept, paths(&["main.md"]));
+    }
+
+    #[test]
+    fn question_mark_matches_single_char() {
+        assert_eq!(
+            filter_ignored(paths(&["a.md", "ab.md"]), &["?.md".to_string()]),
+            paths(&["ab.md"])
+        );
+    }
+
+    #[test]
+    fn non_matching_pattern_keeps_file() {
+        assert_eq!(
+            filter_ignored(paths(&["keep.md"]), &["*.log".to_string()]),
+            paths(&["keep.md"])
+        );
     }
 }

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -284,14 +284,13 @@ fn visit_requires(
 
     // Record provenance when reached via a requirer (even if already
     // resolved — multiple installed items may require the same dependency).
+    // Directly-requested items (no requirer) get no entry here; they appear
+    // in the map only if also pulled in elsewhere.
     if let Some((rk, rn)) = requirer {
         required_by
             .entry(node.clone())
             .or_default()
             .insert(format!("{rk}:{rn}"));
-    } else {
-        // Ensure directly-requested items appear in the map only if also
-        // pulled in elsewhere; do not create an empty entry here.
     }
 
     if resolved.contains(node) {
@@ -822,5 +821,28 @@ mod tests {
             .get(&(ItemKind::Skill, "sarif".to_string()))
             .expect("sarif provenance");
         assert!(prov.contains("agent:code-review"), "{prov:?}");
+    }
+
+    #[test]
+    fn closure_skips_absent_preload_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path();
+        write_item(
+            src,
+            ItemKind::Agent,
+            "reviewer",
+            "preload-skills: [missing-skill]\n",
+        );
+
+        let closure = resolve_requires_closure(src, &[(ItemKind::Agent, "reviewer".to_string())])
+            .expect("closure");
+
+        assert!(closure.items.contains(ItemKind::Agent, "reviewer"));
+        assert!(!closure.items.contains(ItemKind::Skill, "missing-skill"));
+        assert!(
+            !closure
+                .required_by
+                .contains_key(&(ItemKind::Skill, "missing-skill".to_string()))
+        );
     }
 }

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -10,8 +10,9 @@
 //! pipeline does for a bundle".
 
 use anyhow::{Context, Result};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::discovery::{
     detect_item_entrypoint, find_bundle_by_name, find_registry_root, has_matching_items,
@@ -23,7 +24,7 @@ use super::output::{
 };
 use super::{ALL_CLIENTS, InstallReport, InstalledItem, ItemKind, PluginResult};
 use crate::generate::{self, Client};
-use crate::model::{Agent, Audience, Rule, Skill};
+use crate::model::{Agent, Audience, RequireRef, Rule, Skill};
 use crate::parse::frontmatter;
 
 /// Install every item under `source` into `target`, generating per-client
@@ -153,6 +154,185 @@ pub(super) fn install_with_name_resolution_from_local(
     }
 
     Ok(report)
+}
+
+// ---------------------------------------------------------------------------
+// Same-source `requires` transitive closure
+// ---------------------------------------------------------------------------
+
+/// The set of items reached by expanding a requested item set along
+/// same-source `requires` edges, plus per-item provenance recording which
+/// installed item(s) pulled each dependency in.
+#[derive(Debug)]
+pub(super) struct DependencyClosure {
+    /// Every item to install: the requested set plus its transitive
+    /// same-source dependencies, deduplicated by `(kind, name)`.
+    pub items: crate::bundle::ResolvedItems,
+    /// `(kind, name) -> { "<requirer-kind>:<requirer-name>", .. }`. Empty
+    /// for directly-requested items; populated for items pulled in as a
+    /// dependency. Drives the lockfile's `required_by` provenance.
+    pub required_by: BTreeMap<(ItemKind, String), BTreeSet<String>>,
+}
+
+/// Index every item in `source` by its effective `(kind, name)` identity,
+/// mapping to the item directory that holds its entrypoint.
+fn index_source(source: &Path) -> Result<BTreeMap<(ItemKind, String), PathBuf>> {
+    let mut idx = BTreeMap::new();
+    for (folder, dir) in iter_item_dirs(source)? {
+        for kind in [ItemKind::Skill, ItemKind::Rule, ItemKind::Agent] {
+            let entry = dir.join(kind.entrypoint_filename());
+            if entry.is_file() {
+                let name = super::discovery::probe_effective_name(&entry, kind, &folder);
+                idx.insert((kind, name), dir.clone());
+            }
+        }
+    }
+    Ok(idx)
+}
+
+/// Parse an item's `requires` block. For agents, fold `preload_skills` into
+/// `requires.skills` (a preloaded skill is implicitly required).
+///
+/// A preloaded skill that is absent from the source index is treated as a
+/// runtime hint, not a hard SSOT dependency, and is NOT folded in: agents
+/// may preload built-in or separately-installed skills that this registry
+/// does not vend. Explicit `requires` entries remain strict and are never
+/// dropped — a missing one bails later in `visit_requires`.
+fn read_item_requires(
+    dir: &Path,
+    kind: ItemKind,
+    index: &BTreeMap<(ItemKind, String), PathBuf>,
+) -> Result<crate::model::ItemRequires> {
+    let entry = dir.join(kind.entrypoint_filename());
+    let raw = fs::read_to_string(&entry).with_context(|| format!("read {}", entry.display()))?;
+    let req = match kind {
+        ItemKind::Skill => frontmatter::parse::<Skill>(&raw)?.0.requires,
+        ItemKind::Rule => frontmatter::parse::<Rule>(&raw)?.0.requires,
+        ItemKind::Agent => {
+            let agent = frontmatter::parse::<Agent>(&raw)?.0;
+            let mut req = agent.requires;
+            for s in &agent.preload_skills {
+                let present = index.contains_key(&(ItemKind::Skill, s.clone()));
+                if present && !req.skills.iter().any(|r| r.name() == s) {
+                    req.skills.push(RequireRef::Name(s.clone()));
+                }
+            }
+            req
+        }
+    };
+    Ok(req)
+}
+
+/// Expand `initial` along same-source `requires` edges into the full set of
+/// items to install, recording dependency provenance.
+///
+/// Resolution identity is the effective `(kind, name)`. Cross-source
+/// `{ name, source }` requires entries are NOT resolved in this release —
+/// they bail with a clear error. Dependency cycles bail with a "circular"
+/// error. A required item missing from the source bails with a "not found"
+/// error.
+pub(super) fn resolve_requires_closure(
+    source: &Path,
+    initial: &[(ItemKind, String)],
+) -> Result<DependencyClosure> {
+    let index = index_source(source)?;
+
+    let mut required_by: BTreeMap<(ItemKind, String), BTreeSet<String>> = BTreeMap::new();
+    let mut resolved: BTreeSet<(ItemKind, String)> = BTreeSet::new();
+    let mut order: Vec<(ItemKind, String)> = Vec::new();
+    let mut on_path: BTreeSet<(ItemKind, String)> = BTreeSet::new();
+
+    for node in initial {
+        visit_requires(
+            &index,
+            node,
+            None,
+            &mut required_by,
+            &mut resolved,
+            &mut order,
+            &mut on_path,
+        )?;
+    }
+
+    let mut items = crate::bundle::ResolvedItems::default();
+    for (kind, name) in order {
+        match kind {
+            ItemKind::Rule => items.rules.push(name),
+            ItemKind::Skill => items.skills.push(name),
+            ItemKind::Agent => items.agents.push(name),
+        }
+    }
+
+    Ok(DependencyClosure { items, required_by })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn visit_requires(
+    index: &BTreeMap<(ItemKind, String), PathBuf>,
+    node: &(ItemKind, String),
+    requirer: Option<&(ItemKind, String)>,
+    required_by: &mut BTreeMap<(ItemKind, String), BTreeSet<String>>,
+    resolved: &mut BTreeSet<(ItemKind, String)>,
+    order: &mut Vec<(ItemKind, String)>,
+    on_path: &mut BTreeSet<(ItemKind, String)>,
+) -> Result<()> {
+    let (kind, name) = node;
+
+    let dir = index.get(node).ok_or_else(|| {
+        anyhow::anyhow!("{kind} `{name}` is required but not found in the source")
+    })?;
+
+    // Record provenance when reached via a requirer (even if already
+    // resolved — multiple installed items may require the same dependency).
+    if let Some((rk, rn)) = requirer {
+        required_by
+            .entry(node.clone())
+            .or_default()
+            .insert(format!("{rk}:{rn}"));
+    } else {
+        // Ensure directly-requested items appear in the map only if also
+        // pulled in elsewhere; do not create an empty entry here.
+    }
+
+    if resolved.contains(node) {
+        return Ok(());
+    }
+    if on_path.contains(node) {
+        anyhow::bail!("circular dependency detected including {kind} `{name}`");
+    }
+    on_path.insert(node.clone());
+
+    let requires = read_item_requires(dir, *kind, index)?;
+    for (dep_kind, refs) in [
+        (ItemKind::Rule, &requires.rules),
+        (ItemKind::Skill, &requires.skills),
+        (ItemKind::Agent, &requires.agents),
+    ] {
+        for r in refs {
+            if let Some(src) = r.source() {
+                let rname = r.name();
+                anyhow::bail!(
+                    "{kind} `{name}` requires {dep_kind} `{rname}` from cross-source `{src}`: \
+                     cross-source dependency resolution is not yet available in this release"
+                );
+            }
+            let dep = (dep_kind, r.name().to_string());
+            visit_requires(
+                index,
+                &dep,
+                Some(node),
+                required_by,
+                resolved,
+                order,
+                on_path,
+            )?;
+        }
+    }
+
+    on_path.remove(node);
+    resolved.insert(node.clone());
+    order.push(node.clone());
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -556,5 +736,91 @@ mod tests {
         assert!(targets(Client::Claude, Some(&only_claude)));
         assert!(!targets(Client::Copilot, Some(&only_claude)));
         assert!(!targets(Client::OpenCode, Some(&only_claude)));
+    }
+
+    fn write_item(root: &Path, kind: ItemKind, name: &str, frontmatter_extra: &str) {
+        let dir = root.join(name);
+        fs::create_dir_all(&dir).unwrap();
+        let body = format!(
+            "---\nschema: 1\nname: {name}\ndescription: test {name}\n{frontmatter_extra}---\n# {name}\n"
+        );
+        fs::write(dir.join(kind.entrypoint_filename()), body).unwrap();
+    }
+
+    #[test]
+    fn closure_pulls_same_source_dependency() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path();
+        write_item(
+            src,
+            ItemKind::Agent,
+            "code-review",
+            "requires:\n  skills: [sarif]\n",
+        );
+        write_item(src, ItemKind::Skill, "sarif", "");
+
+        let closure =
+            resolve_requires_closure(src, &[(ItemKind::Agent, "code-review".to_string())])
+                .expect("closure");
+
+        assert!(closure.items.contains(ItemKind::Agent, "code-review"));
+        assert!(closure.items.contains(ItemKind::Skill, "sarif"));
+        let prov = closure
+            .required_by
+            .get(&(ItemKind::Skill, "sarif".to_string()))
+            .expect("sarif provenance");
+        assert!(prov.contains("agent:code-review"), "{prov:?}");
+    }
+
+    #[test]
+    fn closure_rejects_cycle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path();
+        write_item(src, ItemKind::Rule, "a", "requires:\n  rules: [b]\n");
+        write_item(src, ItemKind::Rule, "b", "requires:\n  rules: [a]\n");
+
+        let err =
+            resolve_requires_closure(src, &[(ItemKind::Rule, "a".to_string())]).expect_err("cycle");
+        assert!(err.to_string().contains("circular"), "{err}");
+    }
+
+    #[test]
+    fn closure_errors_on_cross_source_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path();
+        write_item(
+            src,
+            ItemKind::Rule,
+            "a",
+            "requires:\n  skills: [{ name: x, source: org/repo }]\n",
+        );
+
+        let err = resolve_requires_closure(src, &[(ItemKind::Rule, "a".to_string())])
+            .expect_err("cross-source");
+        assert!(err.to_string().contains("cross-source"), "{err}");
+    }
+
+    #[test]
+    fn closure_folds_preload_skills() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path();
+        write_item(
+            src,
+            ItemKind::Agent,
+            "code-review",
+            "preload-skills: [sarif]\n",
+        );
+        write_item(src, ItemKind::Skill, "sarif", "");
+
+        let closure =
+            resolve_requires_closure(src, &[(ItemKind::Agent, "code-review".to_string())])
+                .expect("closure");
+
+        assert!(closure.items.contains(ItemKind::Skill, "sarif"));
+        let prov = closure
+            .required_by
+            .get(&(ItemKind::Skill, "sarif".to_string()))
+            .expect("sarif provenance");
+        assert!(prov.contains("agent:code-review"), "{prov:?}");
     }
 }

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -675,6 +675,7 @@ fn install_items_of_kind(
                 client: *client,
                 output_path: rel,
                 source_hash: source_hash.clone(),
+                group: Some(folder.clone()),
             });
         }
 

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -351,6 +351,15 @@ pub(super) fn install_plugins_from_bundles(
     results
 }
 
+/// The per-kind frontmatter fields the install loop needs after parsing,
+/// plus the rendered per-client output. Groups what would otherwise be a
+/// `clippy::type_complexity`-flagged tuple out of the `match kind` arms.
+struct ParsedItem {
+    audience: Option<Vec<Audience>>,
+    ignore: Vec<String>,
+    renders: Vec<(Client, String)>,
+}
+
 fn install_items_of_kind(
     kind: ItemKind,
     source: &Path,
@@ -372,13 +381,18 @@ fn install_items_of_kind(
         let raw = fs::read_to_string(&entry_path)
             .with_context(|| format!("read {}", entry_path.display()))?;
 
-        // Parse frontmatter, extract audience, and define a render helper.
-        // Each kind has its own model type, so we dispatch here.
-        let (audience, renders): (Option<Vec<Audience>>, Vec<(Client, String)>) = match kind {
+        // Parse frontmatter, extract audience + ignore, and render per
+        // client. Each kind has its own model type, so we dispatch here.
+        let ParsedItem {
+            audience,
+            ignore,
+            renders,
+        } = match kind {
             ItemKind::Skill => {
                 let (skill, body) = frontmatter::parse::<Skill>(&raw)
                     .with_context(|| format!("parse {}", entry_path.display()))?;
                 let aud = skill.audience.clone();
+                let ignore = skill.ignore.clone();
                 let mut out = Vec::new();
                 for client in ALL_CLIENTS {
                     if !targets(client, aud.as_deref()) {
@@ -388,12 +402,17 @@ fn install_items_of_kind(
                         .with_context(|| format!("render skill {} for {:?}", name, client))?;
                     out.push((client, rendered));
                 }
-                (aud, out)
+                ParsedItem {
+                    audience: aud,
+                    ignore,
+                    renders: out,
+                }
             }
             ItemKind::Rule => {
                 let (rule, body) = frontmatter::parse::<Rule>(&raw)
                     .with_context(|| format!("parse {}", entry_path.display()))?;
                 let aud = rule.audience.clone();
+                let ignore = rule.ignore.clone();
                 let mut out = Vec::new();
                 for client in ALL_CLIENTS {
                     if !targets(client, aud.as_deref()) {
@@ -403,12 +422,17 @@ fn install_items_of_kind(
                         .with_context(|| format!("render rule {} for {:?}", name, client))?;
                     out.push((client, rendered));
                 }
-                (aud, out)
+                ParsedItem {
+                    audience: aud,
+                    ignore,
+                    renders: out,
+                }
             }
             ItemKind::Agent => {
                 let (agent, body) = frontmatter::parse::<Agent>(&raw)
                     .with_context(|| format!("parse {}", entry_path.display()))?;
                 let aud = agent.audience.clone();
+                let ignore = agent.ignore.clone();
                 let mut out = Vec::new();
                 for client in ALL_CLIENTS {
                     if !targets(client, aud.as_deref()) {
@@ -418,12 +442,16 @@ fn install_items_of_kind(
                         .with_context(|| format!("render agent {} for {:?}", name, client))?;
                     out.push((client, rendered));
                 }
-                (aud, out)
+                ParsedItem {
+                    audience: aud,
+                    ignore,
+                    renders: out,
+                }
             }
         };
 
         let source_hash = hash_item_dir(&dir);
-        let resources = iter_item_resources(&dir);
+        let resources = super::ignore::filter_ignored(iter_item_resources(&dir), &ignore);
         let copied: std::collections::HashSet<std::path::PathBuf> =
             resources.iter().cloned().collect();
 

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -355,6 +355,10 @@ pub(super) fn install_plugins_from_bundles(
 /// plus the rendered per-client output. Groups what would otherwise be a
 /// `clippy::type_complexity`-flagged tuple out of the `match kind` arms.
 struct ParsedItem {
+    /// Effective identity name (§2.1): the folder for skills, the
+    /// frontmatter `name` (else folder) for rules/agents. Drives output
+    /// paths, link-rewrite namespace, and lockfile identity.
+    name: String,
     audience: Option<Vec<Audience>>,
     ignore: Vec<String>,
     renders: Vec<(Client, String)>,
@@ -368,12 +372,7 @@ fn install_items_of_kind(
     filter: Option<&crate::bundle::ResolvedItems>,
 ) -> Result<()> {
     let entrypoint = kind.entrypoint_filename();
-    for (name, dir) in iter_item_dirs(source)? {
-        if let Some(items) = filter
-            && !items.contains(kind, &name)
-        {
-            continue;
-        }
+    for (folder, dir) in iter_item_dirs(source)? {
         let entry_path = dir.join(entrypoint);
         if !entry_path.exists() {
             continue;
@@ -381,9 +380,11 @@ fn install_items_of_kind(
         let raw = fs::read_to_string(&entry_path)
             .with_context(|| format!("read {}", entry_path.display()))?;
 
-        // Parse frontmatter, extract audience + ignore, and render per
-        // client. Each kind has its own model type, so we dispatch here.
+        // Parse frontmatter, resolve the effective identity name, extract
+        // audience + ignore, and render per client. Each kind has its own
+        // model type, so we dispatch here.
         let ParsedItem {
+            name,
             audience,
             ignore,
             renders,
@@ -391,6 +392,7 @@ fn install_items_of_kind(
             ItemKind::Skill => {
                 let (skill, body) = frontmatter::parse::<Skill>(&raw)
                     .with_context(|| format!("parse {}", entry_path.display()))?;
+                let name = super::discovery::effective_name(kind, skill.name.as_deref(), &folder);
                 let aud = skill.audience.clone();
                 let ignore = skill.ignore.clone();
                 let mut out = Vec::new();
@@ -398,11 +400,12 @@ fn install_items_of_kind(
                     if !targets(client, aud.as_deref()) {
                         continue;
                     }
-                    let rendered = generate::render_skill(&skill, body, client)
+                    let rendered = generate::render_skill(&skill, &name, body, client)
                         .with_context(|| format!("render skill {} for {:?}", name, client))?;
                     out.push((client, rendered));
                 }
                 ParsedItem {
+                    name,
                     audience: aud,
                     ignore,
                     renders: out,
@@ -411,6 +414,7 @@ fn install_items_of_kind(
             ItemKind::Rule => {
                 let (rule, body) = frontmatter::parse::<Rule>(&raw)
                     .with_context(|| format!("parse {}", entry_path.display()))?;
+                let name = super::discovery::effective_name(kind, rule.name.as_deref(), &folder);
                 let aud = rule.audience.clone();
                 let ignore = rule.ignore.clone();
                 let mut out = Vec::new();
@@ -418,11 +422,12 @@ fn install_items_of_kind(
                     if !targets(client, aud.as_deref()) {
                         continue;
                     }
-                    let rendered = generate::render_rule(&rule, body, client)
+                    let rendered = generate::render_rule(&rule, &name, body, client)
                         .with_context(|| format!("render rule {} for {:?}", name, client))?;
                     out.push((client, rendered));
                 }
                 ParsedItem {
+                    name,
                     audience: aud,
                     ignore,
                     renders: out,
@@ -431,6 +436,7 @@ fn install_items_of_kind(
             ItemKind::Agent => {
                 let (agent, body) = frontmatter::parse::<Agent>(&raw)
                     .with_context(|| format!("parse {}", entry_path.display()))?;
+                let name = super::discovery::effective_name(kind, agent.name.as_deref(), &folder);
                 let aud = agent.audience.clone();
                 let ignore = agent.ignore.clone();
                 let mut out = Vec::new();
@@ -438,17 +444,27 @@ fn install_items_of_kind(
                     if !targets(client, aud.as_deref()) {
                         continue;
                     }
-                    let rendered = generate::render_agent(&agent, body, client)
+                    let rendered = generate::render_agent(&agent, &name, body, client)
                         .with_context(|| format!("render agent {} for {:?}", name, client))?;
                     out.push((client, rendered));
                 }
                 ParsedItem {
+                    name,
                     audience: aud,
                     ignore,
                     renders: out,
                 }
             }
         };
+
+        // Audience/identity filtering keys on the effective name, not the
+        // folder, so a filter referencing a divergent rule/agent name
+        // resolves correctly.
+        if let Some(items) = filter
+            && !items.contains(kind, &name)
+        {
+            continue;
+        }
 
         let source_hash = hash_item_dir(&dir);
         let resources = super::ignore::filter_ignored(iter_item_resources(&dir), &ignore);

--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -15,9 +15,9 @@ use super::hash::planned_source_hashes;
 use super::output::{output_path, remove_item_outputs};
 use super::{
     ALL_CLIENTS, AddOptions, DoctorReport, ItemKind, ListReport, ListedBundle, ListedItem,
-    MissingOutput, MissingPlugin, OrphanEntry, OrphanReason, RemoveFilter, RemoveReport,
-    RemovedItem, SkippedPlugin, StaleHash, UpdateMode, UpdateReport, UpdateStatus, UpdatedItem,
-    hash_item_dir, install_with_lockfile,
+    MissingOutput, MissingPlugin, OrphanEntry, OrphanReason, OrphanedDependency, RemoveFilter,
+    RemoveReport, RemovedItem, SkippedPlugin, StaleHash, UpdateMode, UpdateReport, UpdateStatus,
+    UpdatedItem, hash_item_dir, install_with_lockfile,
 };
 
 /// Remove installed content recorded in `<target>/.upskill-lock.json`,
@@ -210,6 +210,28 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
         // Non-local sources: doctor only validates per-client outputs.
         // Hash comparison would require a network fetch — out of scope
         // here, see `update --dry-run`.
+    }
+
+    // -- Orphaned dependencies (advisory, issue #196) --
+    // An item pulled in only as a dependency (`required_by` non-empty) whose
+    // every recorded requirer is no longer installed. Surfaced as advisory
+    // only — upskill never auto-removes; the user decides.
+    let installed: std::collections::BTreeSet<String> = lock
+        .items
+        .iter()
+        .map(|i| format!("{}:{}", i.kind, i.name))
+        .collect();
+    for entry in &lock.items {
+        if entry.required_by.is_empty() {
+            continue;
+        }
+        if entry.required_by.iter().all(|r| !installed.contains(r)) {
+            report.orphaned_dependencies.push(OrphanedDependency {
+                kind: entry.kind,
+                name: entry.name.clone(),
+                former_requirers: entry.required_by.clone(),
+            });
+        }
     }
 
     // -- Plugin reconciliation (ADR-0008 / issue #151) --

--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -32,7 +32,7 @@ use super::{
 pub fn remove(target: &Path, filter: RemoveFilter) -> Result<RemoveReport> {
     let mut lock = crate::lockfile::Lockfile::load(target)?;
 
-    let to_remove: Vec<crate::lockfile::LockedItem> = match &filter {
+    let mut to_remove: Vec<crate::lockfile::LockedItem> = match &filter {
         RemoveFilter::ByNames(names) => lock
             .items
             .iter()
@@ -57,6 +57,27 @@ pub fn remove(target: &Path, filter: RemoveFilter) -> Result<RemoveReport> {
             .collect();
         if !unknown.is_empty() {
             anyhow::bail!("not in lockfile: {}", unknown.join(", "));
+        }
+    }
+
+    // Co-location coupling (§2.1, Task 6): removing any named member of a
+    // `(source, group)` unit removes every other member, even when their
+    // effective names diverge. Expand AFTER the unknown-name check so a
+    // name absent from the lockfile still errors rather than being masked.
+    if let RemoveFilter::ByNames(_) = &filter {
+        let groups: std::collections::BTreeSet<(String, String)> = to_remove
+            .iter()
+            .filter_map(|i| i.group.clone().map(|g| (i.source.clone(), g)))
+            .collect();
+        for it in &lock.items {
+            if let Some(g) = &it.group
+                && groups.contains(&(it.source.clone(), g.clone()))
+                && !to_remove
+                    .iter()
+                    .any(|r| r.kind == it.kind && r.name == it.name)
+            {
+                to_remove.push(it.clone());
+            }
         }
     }
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -41,7 +41,9 @@ use discovery::scan_source_items;
 pub use git::{fetch_ssot, install_from_git_url, install_from_source};
 pub(crate) use hash::hash_item_dir;
 pub use install::install_from_local_path;
-use install::{install_plugins_from_bundles, install_with_name_resolution_from_local};
+use install::{
+    install_plugins_from_bundles, install_with_name_resolution_from_local, resolve_requires_closure,
+};
 pub use lifecycle::{doctor, list, remove, update};
 pub use report::*;
 
@@ -189,9 +191,69 @@ pub fn install_with_lockfile(
         }
     }
 
+    // -- Same-source `requires` closure --
+    // The directly-requested item set, keyed on effective names from
+    // `scan_source_items` and respecting the `items` filter and excludes.
+    // Bundle-file sources resolve their own items, so the item-level
+    // closure is skipped for them.
+    let requested: Vec<(ItemKind, String)> = {
+        let mut seen = std::collections::BTreeSet::new();
+        scanned_items
+            .iter()
+            .filter(|(_, n)| !options.excludes.contains(n))
+            .filter(|(_, n)| items.is_empty() || items.contains(n))
+            .filter(|(kind, name)| seen.insert((*kind, name.clone())))
+            .map(|(kind, name)| (*kind, name.clone()))
+            .collect()
+    };
+    // Defer to `install_with_name_resolution_from_local` (closure skipped)
+    // when positional names are given that the item closure cannot serve:
+    // a name referencing a bundle by name inside a directory source (the
+    // name-resolution branch detects item/bundle ambiguity and resolves
+    // bundles), or a name matching nothing (so that branch emits its
+    // "no matching items or bundles" error rather than silently installing
+    // zero items). Bundle-file sources own their own resolution too.
+    let defer_to_name_resolution = !items.is_empty()
+        && !discovery::is_bundle_file(&local_source)
+        && (requested.is_empty()
+            || items
+                .iter()
+                .any(|n| discovery::find_bundle_by_name(&local_source, n).is_some()));
+    let closure = if discovery::is_bundle_file(&local_source) || defer_to_name_resolution {
+        None
+    } else {
+        Some(resolve_requires_closure(&local_source, &requested)?)
+    };
+
     // -- Conflict detection (before any files are written) --
+    // When a closure is present, conflict detection runs over the closure's
+    // full item set so a pulled dependency that collides with an existing
+    // different-source install is caught. Directly-named items still honor
+    // `--as` aliasing; pulled dependencies are never aliased.
     let mut lock = crate::lockfile::Lockfile::load(target)?;
-    let incoming: Vec<(ItemKind, String)> = {
+    let incoming: Vec<(ItemKind, String)> = if let Some(closure) = &closure {
+        let mut seen = std::collections::BTreeSet::new();
+        let mut out = Vec::new();
+        for kind in [ItemKind::Rule, ItemKind::Skill, ItemKind::Agent] {
+            let names = match kind {
+                ItemKind::Rule => &closure.items.rules,
+                ItemKind::Skill => &closure.items.skills,
+                ItemKind::Agent => &closure.items.agents,
+            };
+            for name in names {
+                let effective_name = options
+                    .aliases
+                    .iter()
+                    .find(|(from, _)| from.is_empty() || *from == *name)
+                    .map(|(_, to)| to.clone())
+                    .unwrap_or_else(|| name.clone());
+                if seen.insert((kind, effective_name.clone())) {
+                    out.push((kind, effective_name));
+                }
+            }
+        }
+        out
+    } else {
         let mut seen = std::collections::BTreeSet::new();
         scanned_items
             .iter()
@@ -218,7 +280,12 @@ pub fn install_with_lockfile(
     }
 
     // -- Now proceed with generation (files are written here) --
-    let mut report = if items.is_empty() {
+    // With a closure, install exactly its resolved item set (requested
+    // items plus same-source dependencies). Without one (bundle file),
+    // keep the existing dispatch so the bundle branch runs.
+    let mut report = if let Some(closure) = &closure {
+        install_from_local_path(&local_source, target, Some(&closure.items))?
+    } else if items.is_empty() {
         install_from_local_path(&local_source, target, None)?
     } else {
         install_with_name_resolution_from_local(&local_source, target, items)?
@@ -282,9 +349,22 @@ pub fn install_with_lockfile(
         .iter()
         .map(|it| ((it.kind, it.name.clone()), it.source_hash.clone()))
         .collect();
-    let new_items = crate::lockfile::items_from_report(&report, &label, git_ref, |k, n| {
-        hashes.get(&(k, n.to_string())).cloned().flatten()
-    });
+    let provenance: std::collections::BTreeMap<(ItemKind, String), Vec<String>> =
+        if let Some(closure) = &closure {
+            closure
+                .required_by
+                .iter()
+                .map(|(key, requirers)| {
+                    (key.clone(), requirers.iter().cloned().collect::<Vec<_>>())
+                })
+                .collect()
+        } else {
+            std::collections::BTreeMap::new()
+        };
+    let new_items =
+        crate::lockfile::items_from_report(&report, &label, git_ref, &provenance, |k, n| {
+            hashes.get(&(k, n.to_string())).cloned().flatten()
+        });
 
     for mut item in new_items {
         if let Some(original) = aliased_names.get(&item.name) {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -31,6 +31,7 @@ use crate::source::InstallSource;
 mod discovery;
 mod git;
 mod hash;
+mod ignore;
 mod install;
 mod lifecycle;
 mod output;

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -23,6 +23,10 @@ pub struct InstalledItem {
     /// lockfile for drift detection. Repeated across the per-
     /// client entries for the same item — they share one SSOT input.
     pub source_hash: Option<String>,
+    /// Source folder this item was discovered in — the co-location
+    /// grouping key (§2.1). Threaded into the lockfile so `remove <name>`
+    /// can act on the whole `(source, group)` unit.
+    pub group: Option<String>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -161,11 +161,24 @@ pub struct SkippedPlugin {
     pub bundle: String,
 }
 
+/// A dependency-pulled item whose every requirer is no longer installed.
+/// Advisory only — upskill never auto-removes (#196); the user decides.
+#[derive(Debug, Clone, Serialize)]
+pub struct OrphanedDependency {
+    pub kind: ItemKind,
+    pub name: String,
+    /// The now-absent requirers (`"kind:name"`) recorded at install time.
+    pub former_requirers: Vec<String>,
+}
+
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct DoctorReport {
     pub missing_outputs: Vec<MissingOutput>,
     pub stale_hashes: Vec<StaleHash>,
     pub orphan_entries: Vec<OrphanEntry>,
+    /// Items present only as a dependency of an item that is no longer
+    /// installed. Advisory — does NOT affect `is_clean()`.
+    pub orphaned_dependencies: Vec<OrphanedDependency>,
     /// Plugins recorded in the lockfile as `installed` but absent from the
     /// client's installed list (uninstalled out-of-band).  Non-empty →
     /// `is_clean()` returns false → exit 1.

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -25,7 +25,10 @@ pub struct InstalledItem {
     pub source_hash: Option<String>,
     /// Source folder this item was discovered in — the co-location
     /// grouping key (§2.1). Threaded into the lockfile so `remove <name>`
-    /// can act on the whole `(source, group)` unit.
+    /// can act on the whole `(source, group)` unit. This is the folder
+    /// LEAF name (not a source-root-relative path), so two items with the
+    /// same leaf folder name under different category directories within
+    /// one source would share a group.
     pub group: Option<String>,
 }
 

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -136,8 +136,11 @@ fn validate_existing_item_dir_for_coloc(dir: &Path, name: &str) -> Result<()> {
         saw_entrypoint = true;
         let raw =
             std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
-        let existing_name = read_name_field(&raw, &path)?;
-        if existing_name != name {
+        // An absent `name:` falls back to the directory name (§2.1), so it
+        // can never conflict — only an explicit divergent name does.
+        if let Some(existing_name) = read_name_field(&raw, &path)?
+            && existing_name != name
+        {
             bail!(
                 "{}: existing entrypoint declares `name: {existing_name}` — co-located \
                  entrypoints must share the directory's name `{name}` (format-spec §2.1)",
@@ -157,7 +160,7 @@ fn validate_existing_item_dir_for_coloc(dir: &Path, name: &str) -> Result<()> {
 
 /// Pull the `name:` field out of an existing entrypoint's frontmatter
 /// — kind-agnostic, since all kinds share the field.
-fn read_name_field(raw: &str, path: &Path) -> Result<String> {
+fn read_name_field(raw: &str, path: &Path) -> Result<Option<String>> {
     let (skill, _) = crate::parse::frontmatter::parse::<crate::model::Skill>(raw)
         .with_context(|| format!("parse frontmatter of {}", path.display()))?;
     Ok(skill.name)
@@ -241,7 +244,7 @@ mod tests {
         // scaffold is shape-correct for a brand-new author.
         let (skill, _body) =
             crate::parse::frontmatter::parse::<crate::model::Skill>(&content).unwrap();
-        assert_eq!(skill.name, "code-review");
+        assert_eq!(skill.name.as_deref(), Some("code-review"));
     }
 
     #[test]

--- a/tests/cli_colocation_remove.rs
+++ b/tests/cli_colocation_remove.rs
@@ -106,6 +106,80 @@ fn remove_named_member_removes_the_whole_colocated_unit() {
 }
 
 #[test]
+fn remove_by_divergent_rule_name_removes_whole_unit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let source = tmp.path().join("reg");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // One folder, two co-located items with DIFFERENT effective names:
+    //   skill effective name -> folder = "markspec-trace"
+    //   rule effective name  -> frontmatter "markspec-trace-syntax"
+    write(
+        &source.join("markspec-trace/SKILL.md"),
+        "---\nschema: 1\nname: markspec-trace\ndescription: trace skill for markspec.\n---\n\n## Body\n\nText.\n",
+    );
+    write(
+        &source.join("markspec-trace/RULE.md"),
+        "---\nschema: 1\nname: markspec-trace-syntax\ndescription: trace syntax rule for markspec.\n---\n\n## Body\n\nText.\n",
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Both items installed.
+    assert!(
+        target
+            .join(".claude/skills/markspec-trace/SKILL.md")
+            .exists(),
+        "skill should be installed"
+    );
+    assert!(
+        target
+            .join(".claude/rules/markspec-trace-syntax.md")
+            .exists(),
+        "co-located rule should be installed"
+    );
+    assert_eq!(
+        lockfile_item_count(&target),
+        2,
+        "lockfile should record both items"
+    );
+
+    // Removing by the RULE's divergent name (NOT the folder/skill name)
+    // must also remove the co-located SKILL: removal-by-unit is symmetric.
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["remove", "markspec-trace-syntax"])
+        .assert()
+        .success();
+
+    assert!(
+        !target
+            .join(".claude/skills/markspec-trace/SKILL.md")
+            .exists(),
+        "co-located skill must be gone too (the whole unit travels together)"
+    );
+    assert!(
+        !target
+            .join(".claude/rules/markspec-trace-syntax.md")
+            .exists(),
+        "named rule must be gone"
+    );
+    assert_eq!(
+        lockfile_item_count(&target),
+        0,
+        "lockfile must have zero items after removing the unit"
+    );
+}
+
+#[test]
 fn remove_solo_item_leaves_independent_items_in_other_folders() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");

--- a/tests/cli_colocation_remove.rs
+++ b/tests/cli_colocation_remove.rs
@@ -1,0 +1,180 @@
+//! ATDD for co-location-aware `upskill remove` (Task 6).
+//!
+//! A single SSOT source folder may hold more than one item — e.g. a
+//! `SKILL.md` plus a `RULE.md`. After Task 4 relaxed naming, those
+//! co-located items may carry DIFFERENT effective names (the skill takes
+//! the folder name; the rule takes its frontmatter `name:`). They are
+//! nonetheless one logical unit and must travel together: removing any
+//! named member removes the whole `(source, folder)` group.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+/// Read the lockfile item count (`items` array length); 0 when absent.
+fn lockfile_item_count(target: &Path) -> usize {
+    let path = target.join(".upskill-lock.json");
+    let raw = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return 0,
+    };
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    v.get("items")
+        .and_then(|i| i.as_array())
+        .map_or(0, Vec::len)
+}
+
+#[test]
+fn remove_named_member_removes_the_whole_colocated_unit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let source = tmp.path().join("reg");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // One folder, two co-located items with DIFFERENT effective names:
+    //   skill effective name -> folder = "markspec-trace"
+    //   rule effective name  -> frontmatter "markspec-trace-syntax"
+    write(
+        &source.join("markspec-trace/SKILL.md"),
+        "---\nschema: 1\nname: markspec-trace\ndescription: trace skill for markspec.\n---\n\n## Body\n\nText.\n",
+    );
+    write(
+        &source.join("markspec-trace/RULE.md"),
+        "---\nschema: 1\nname: markspec-trace-syntax\ndescription: trace syntax rule for markspec.\n---\n\n## Body\n\nText.\n",
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Both items installed.
+    assert!(
+        target
+            .join(".claude/skills/markspec-trace/SKILL.md")
+            .exists(),
+        "skill should be installed"
+    );
+    assert!(
+        target
+            .join(".claude/rules/markspec-trace-syntax.md")
+            .exists(),
+        "co-located rule should be installed"
+    );
+    assert_eq!(
+        lockfile_item_count(&target),
+        2,
+        "lockfile should record both items"
+    );
+
+    // Removing the SKILL by name must also remove the co-located RULE.
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["remove", "markspec-trace"])
+        .assert()
+        .success();
+
+    assert!(
+        !target
+            .join(".claude/skills/markspec-trace/SKILL.md")
+            .exists(),
+        "named skill must be gone"
+    );
+    assert!(
+        !target
+            .join(".claude/rules/markspec-trace-syntax.md")
+            .exists(),
+        "co-located rule must be gone too (the whole unit travels together)"
+    );
+    assert_eq!(
+        lockfile_item_count(&target),
+        0,
+        "lockfile must have zero items after removing the unit"
+    );
+}
+
+#[test]
+fn remove_solo_item_leaves_independent_items_in_other_folders() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let source = tmp.path().join("reg");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // Two items in SEPARATE folders -> distinct groups, no coupling.
+    write(
+        &source.join("alpha/SKILL.md"),
+        "---\nschema: 1\nname: alpha\ndescription: alpha skill.\n---\n\n## Body\n\nText.\n",
+    );
+    write(
+        &source.join("beta/SKILL.md"),
+        "---\nschema: 1\nname: beta\ndescription: beta skill.\n---\n\n## Body\n\nText.\n",
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(target.join(".claude/skills/alpha/SKILL.md").exists());
+    assert!(target.join(".claude/skills/beta/SKILL.md").exists());
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["remove", "alpha"])
+        .assert()
+        .success();
+
+    assert!(
+        !target.join(".claude/skills/alpha/SKILL.md").exists(),
+        "alpha removed"
+    );
+    assert!(
+        target.join(".claude/skills/beta/SKILL.md").exists(),
+        "beta is in a different group and must survive"
+    );
+    assert_eq!(lockfile_item_count(&target), 1, "only beta should remain");
+}
+
+#[test]
+fn remove_unknown_name_still_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let source = tmp.path().join("reg");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    write(
+        &source.join("alpha/SKILL.md"),
+        "---\nschema: 1\nname: alpha\ndescription: alpha skill.\n---\n\n## Body\n\nText.\n",
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["remove", "does-not-exist"])
+        .assert()
+        .failure();
+}

--- a/tests/cli_doctor_orphan.rs
+++ b/tests/cli_doctor_orphan.rs
@@ -62,7 +62,11 @@ fn doctor_flags_orphaned_dependency_after_requirer_removed() {
         .args(["doctor"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("orphaned").and(predicates::str::contains("sarif")));
+        .stdout(
+            predicates::str::contains("orphaned")
+                .and(predicates::str::contains("sarif"))
+                .and(predicates::str::contains("upskill remove sarif")),
+        );
 }
 
 #[test]

--- a/tests/cli_doctor_orphan.rs
+++ b/tests/cli_doctor_orphan.rs
@@ -1,0 +1,97 @@
+//! ATDD tests for `doctor`'s orphaned-dependency advisory finding.
+//!
+//! An item pulled in only as a dependency (`required_by` non-empty) whose
+//! every requirer is no longer installed is surfaced as an ADVISORY finding:
+//! it does NOT affect the exit code (exactly like `skipped_plugins`). upskill
+//! NEVER auto-removes (#196) — doctor just tells the user.
+
+mod common;
+
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+
+/// Write an item entrypoint of `kind` (SKILL/AGENT) named `name` into its own
+/// `<root>/<name>/` directory (so items are NOT co-located and removal won't
+/// cascade across them).
+fn write_item(root: &Path, entrypoint: &str, name: &str, frontmatter_extra: &str) {
+    let dir = root.join(name);
+    fs::create_dir_all(&dir).unwrap();
+    let body = format!(
+        "---\nschema: 1\nname: {name}\ndescription: test {name}\n{frontmatter_extra}---\n# {name}\n"
+    );
+    fs::write(dir.join(entrypoint), body).unwrap();
+}
+
+#[test]
+fn doctor_flags_orphaned_dependency_after_requirer_removed() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    // Fake git repo so upskill uses project scope (lockfile in cwd).
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg = tmp.path().join("reg");
+    // Each item in its OWN folder — not co-located, so removing code-review
+    // will not sweep sarif.
+    write_item(
+        &reg,
+        "AGENT.md",
+        "code-review",
+        "requires:\n  skills: [sarif]\n",
+    );
+    write_item(&reg, "SKILL.md", "sarif", "");
+
+    // Install: pulls in sarif with required_by: ["agent:code-review"].
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg", "code-review"])
+        .assert()
+        .success();
+
+    // Remove only the requirer. sarif stays in the lockfile, now orphaned.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["remove", "code-review"])
+        .assert()
+        .success();
+
+    // doctor: advisory finding does NOT fail the exit code.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("orphaned").and(predicates::str::contains("sarif")));
+}
+
+#[test]
+fn doctor_does_not_flag_dependency_while_requirer_installed() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg = tmp.path().join("reg");
+    write_item(
+        &reg,
+        "AGENT.md",
+        "code-review",
+        "requires:\n  skills: [sarif]\n",
+    );
+    write_item(&reg, "SKILL.md", "sarif", "");
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg", "code-review"])
+        .assert()
+        .success();
+
+    // Requirer still installed — sarif is NOT orphaned.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("orphaned").not());
+}

--- a/tests/cli_relaxed_naming.rs
+++ b/tests/cli_relaxed_naming.rs
@@ -1,0 +1,132 @@
+//! ATDD for optional + relaxed item naming (layout-independent identity).
+//!
+//! - Skills: effective name is always the folder (Agent Skills standard);
+//!   an absent `name:` falls back to the folder.
+//! - Rules/agents: effective name is the frontmatter `name:` when present,
+//!   else the folder — it may diverge from the folder.
+//! - Lint: a skill whose `name:` diverges from its folder is an error; a
+//!   rule whose `name:` diverges is silent.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn skill_without_name_falls_back_to_folder() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // Skill folder `demo/` with NO `name:` in its SKILL.md.
+    write(
+        &source.join("demo/SKILL.md"),
+        "---\nschema: 1\ndescription: a demo skill with no name field.\n---\n\n## Body\n\nText.\n",
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let out = target.join(".claude/skills/demo/SKILL.md");
+    assert!(out.exists(), "expected {} to exist", out.display());
+    let content = fs::read_to_string(&out).unwrap();
+    assert!(
+        content.contains("name: demo"),
+        "skill frontmatter should carry the folder-derived name; got:\n{content}"
+    );
+}
+
+#[test]
+fn rule_name_diverges_from_folder() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // Rule folder `stuff/` whose RULE.md declares a divergent name.
+    write(
+        &source.join("stuff/RULE.md"),
+        "---\nschema: 1\nname: security-baseline\ndescription: a rule whose name diverges from its folder.\n---\n\n## Body\n\nText.\n",
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Output path + frontmatter follow the effective (frontmatter) name.
+    let out = target.join(".claude/rules/security-baseline.md");
+    assert!(out.exists(), "expected {} to exist", out.display());
+    let content = fs::read_to_string(&out).unwrap();
+    assert!(
+        content.contains("name: security-baseline"),
+        "rule frontmatter should carry the effective name; got:\n{content}"
+    );
+    // The folder name must NOT be used for the output path.
+    assert!(
+        !target.join(".claude/rules/stuff.md").exists(),
+        "rule output must not use the folder name"
+    );
+}
+
+#[test]
+fn lint_errors_on_skill_name_folder_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+
+    write(
+        &registry.join("demo/SKILL.md"),
+        "---\nschema: 1\nname: not-demo\ndescription: a skill whose name diverges from its folder.\n---\n\n## Body\n\nText.\n",
+    );
+
+    let assert = common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["lint", registry.to_str().unwrap()])
+        .assert()
+        .failure();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap()
+        + &String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        out.contains("Agent Skills standard") || out.contains("directory"),
+        "lint should mention the standard/directory; got:\n{out}"
+    );
+}
+
+#[test]
+fn lint_allows_rule_name_folder_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+
+    write(
+        &registry.join("stuff/RULE.md"),
+        "---\nschema: 1\nname: security-baseline\ndescription: a rule whose name diverges from its folder.\n---\n\n## Body\n\nText.\n",
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["lint", registry.to_str().unwrap()])
+        .assert()
+        .success();
+}

--- a/tests/cli_requires.rs
+++ b/tests/cli_requires.rs
@@ -1,0 +1,120 @@
+//! ATDD tests for the same-source `requires` transitive closure.
+//!
+//! Installing an item pulls in the items it requires from the SAME source.
+//! The lockfile records `required_by` provenance for each pulled-in
+//! dependency. Cross-source `{ name, source }` requires entries are not yet
+//! resolved and must error clearly.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+/// Write an item entrypoint of `kind` (SKILL/AGENT) named `name` into a
+/// `<root>/<name>/` directory with the given extra frontmatter lines.
+fn write_item(root: &Path, entrypoint: &str, name: &str, frontmatter_extra: &str) {
+    let dir = root.join(name);
+    fs::create_dir_all(&dir).unwrap();
+    let body = format!(
+        "---\nschema: 1\nname: {name}\ndescription: test {name}\n{frontmatter_extra}---\n# {name}\n"
+    );
+    fs::write(dir.join(entrypoint), body).unwrap();
+}
+
+#[test]
+fn add_pulls_same_source_requires_and_records_provenance() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    // Fake git repo so upskill uses project scope (lockfile in cwd).
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg = tmp.path().join("reg");
+    write_item(
+        &reg,
+        "AGENT.md",
+        "code-review",
+        "requires:\n  skills: [sarif]\n",
+    );
+    write_item(&reg, "SKILL.md", "sarif", "");
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg", "code-review"])
+        .assert()
+        .success();
+
+    let lock_path = tmp.path().join(".upskill-lock.json");
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&lock_path).unwrap()).unwrap();
+    let items = lock["items"].as_array().unwrap();
+
+    let has = |kind: &str, name: &str| items.iter().any(|i| i["kind"] == kind && i["name"] == name);
+    assert!(has("agent", "code-review"), "lockfile: {lock}");
+    assert!(has("skill", "sarif"), "lockfile: {lock}");
+
+    let sarif = items
+        .iter()
+        .find(|i| i["kind"] == "skill" && i["name"] == "sarif")
+        .unwrap();
+    let required_by = sarif["required_by"].as_array().unwrap();
+    assert!(
+        required_by.iter().any(|r| r == "agent:code-review"),
+        "sarif required_by must contain agent:code-review: {sarif}"
+    );
+}
+
+#[test]
+fn add_pulls_preload_skills_as_requires() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg = tmp.path().join("reg");
+    write_item(&reg, "AGENT.md", "code-review", "preload-skills: [sarif]\n");
+    write_item(&reg, "SKILL.md", "sarif", "");
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg", "code-review"])
+        .assert()
+        .success();
+
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap())
+            .unwrap();
+    let items = lock["items"].as_array().unwrap();
+    let sarif = items
+        .iter()
+        .find(|i| i["kind"] == "skill" && i["name"] == "sarif");
+    assert!(sarif.is_some(), "preload-skills must pull sarif: {lock}");
+    let required_by = sarif.unwrap()["required_by"].as_array().unwrap();
+    assert!(
+        required_by.iter().any(|r| r == "agent:code-review"),
+        "preloaded sarif required_by must contain agent:code-review: {lock}"
+    );
+}
+
+#[test]
+fn add_errors_on_cross_source_requires() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg = tmp.path().join("reg");
+    write_item(
+        &reg,
+        "AGENT.md",
+        "code-review",
+        "requires:\n  skills: [{ name: sarif, source: org/repo }]\n",
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg", "code-review"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("cross-source"));
+}

--- a/tests/fixtures/expected/copilot/security-reviewer.AGENT.md
+++ b/tests/fixtures/expected/copilot/security-reviewer.AGENT.md
@@ -16,3 +16,9 @@ You are a security-focused code reviewer. When invoked:
 4. Flag insecure data handling (unencrypted PII, weak cryptographic choices, improper logging of sensitive data).
 
 For each finding, report severity (critical/high/medium/low), file and line location, and a concrete remediation.
+
+## Skills
+
+This agent relies on the following skills, installed alongside it. Use them when relevant:
+
+- security-baseline

--- a/tests/fixtures/expected/opencode/security-reviewer.AGENT.md
+++ b/tests/fixtures/expected/opencode/security-reviewer.AGENT.md
@@ -21,3 +21,9 @@ You are a security-focused code reviewer. When invoked:
 4. Flag insecure data handling (unencrypted PII, weak cryptographic choices, improper logging of sensitive data).
 
 For each finding, report severity (critical/high/medium/low), file and line location, and a concrete remediation.
+
+## Skills
+
+This agent relies on the following skills, installed alongside it. Use them when relevant:
+
+- security-baseline

--- a/tests/generate_agents.rs
+++ b/tests/generate_agents.rs
@@ -10,11 +10,14 @@ use upskill::parse::frontmatter;
 
 const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
-fn load_agent(name: &str) -> (Agent, String) {
+/// Returns the parsed agent, its effective name (frontmatter `name`, else
+/// the fixture folder), and the body.
+fn load_agent(name: &str) -> (Agent, String, String) {
     let path = format!("{FIXTURES}/items/{name}/AGENT.md");
     let raw = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
     let (agent, body) = frontmatter::parse::<Agent>(&raw).expect("parse fixture");
-    (agent, body.to_string())
+    let effective = agent.name.clone().unwrap_or_else(|| name.to_string());
+    (agent, effective, body.to_string())
 }
 
 fn load_expected(client: &str, name: &str) -> String {
@@ -35,24 +38,24 @@ fn assert_byte_equal(actual: &str, expected: &str, label: &str) {
 
 #[test]
 fn security_reviewer_claude() {
-    let (agent, body) = load_agent("security-reviewer");
-    let actual = render_agent(&agent, &body, Client::Claude).expect("render");
+    let (agent, name, body) = load_agent("security-reviewer");
+    let actual = render_agent(&agent, &name, &body, Client::Claude).expect("render");
     let expected = load_expected("claude", "security-reviewer");
     assert_byte_equal(&actual, &expected, "claude/security-reviewer");
 }
 
 #[test]
 fn security_reviewer_copilot() {
-    let (agent, body) = load_agent("security-reviewer");
-    let actual = render_agent(&agent, &body, Client::Copilot).expect("render");
+    let (agent, name, body) = load_agent("security-reviewer");
+    let actual = render_agent(&agent, &name, &body, Client::Copilot).expect("render");
     let expected = load_expected("copilot", "security-reviewer");
     assert_byte_equal(&actual, &expected, "copilot/security-reviewer");
 }
 
 #[test]
 fn security_reviewer_opencode() {
-    let (agent, body) = load_agent("security-reviewer");
-    let actual = render_agent(&agent, &body, Client::OpenCode).expect("render");
+    let (agent, name, body) = load_agent("security-reviewer");
+    let actual = render_agent(&agent, &name, &body, Client::OpenCode).expect("render");
     let expected = load_expected("opencode", "security-reviewer");
     assert_byte_equal(&actual, &expected, "opencode/security-reviewer");
 }

--- a/tests/generate_rules.rs
+++ b/tests/generate_rules.rs
@@ -10,11 +10,12 @@ use upskill::parse::frontmatter;
 
 const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
-fn load_rule(name: &str) -> (Rule, String) {
+fn load_rule(name: &str) -> (Rule, String, String) {
     let path = format!("{FIXTURES}/items/{name}/RULE.md");
     let raw = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
     let (rule, body) = frontmatter::parse::<Rule>(&raw).expect("parse fixture");
-    (rule, body.to_string())
+    let effective = rule.name.clone().unwrap_or_else(|| name.to_string());
+    (rule, effective, body.to_string())
 }
 
 fn load_expected(client: &str, name: &str) -> String {
@@ -35,24 +36,24 @@ fn assert_byte_equal(actual: &str, expected: &str, label: &str) {
 
 #[test]
 fn license_awareness_claude() {
-    let (rule, body) = load_rule("license-awareness");
-    let actual = render_rule(&rule, &body, Client::Claude).expect("render");
+    let (rule, name, body) = load_rule("license-awareness");
+    let actual = render_rule(&rule, &name, &body, Client::Claude).expect("render");
     let expected = load_expected("claude", "license-awareness");
     assert_byte_equal(&actual, &expected, "claude/license-awareness");
 }
 
 #[test]
 fn license_awareness_copilot() {
-    let (rule, body) = load_rule("license-awareness");
-    let actual = render_rule(&rule, &body, Client::Copilot).expect("render");
+    let (rule, name, body) = load_rule("license-awareness");
+    let actual = render_rule(&rule, &name, &body, Client::Copilot).expect("render");
     let expected = load_expected("copilot", "license-awareness");
     assert_byte_equal(&actual, &expected, "copilot/license-awareness");
 }
 
 #[test]
 fn license_awareness_opencode() {
-    let (rule, body) = load_rule("license-awareness");
-    let actual = render_rule(&rule, &body, Client::OpenCode).expect("render");
+    let (rule, name, body) = load_rule("license-awareness");
+    let actual = render_rule(&rule, &name, &body, Client::OpenCode).expect("render");
     let expected = load_expected("opencode", "license-awareness");
     assert_byte_equal(&actual, &expected, "opencode/license-awareness");
 }
@@ -61,24 +62,24 @@ fn license_awareness_opencode() {
 
 #[test]
 fn api_conventions_claude() {
-    let (rule, body) = load_rule("api-conventions");
-    let actual = render_rule(&rule, &body, Client::Claude).expect("render");
+    let (rule, name, body) = load_rule("api-conventions");
+    let actual = render_rule(&rule, &name, &body, Client::Claude).expect("render");
     let expected = load_expected("claude", "api-conventions");
     assert_byte_equal(&actual, &expected, "claude/api-conventions");
 }
 
 #[test]
 fn api_conventions_copilot() {
-    let (rule, body) = load_rule("api-conventions");
-    let actual = render_rule(&rule, &body, Client::Copilot).expect("render");
+    let (rule, name, body) = load_rule("api-conventions");
+    let actual = render_rule(&rule, &name, &body, Client::Copilot).expect("render");
     let expected = load_expected("copilot", "api-conventions");
     assert_byte_equal(&actual, &expected, "copilot/api-conventions");
 }
 
 #[test]
 fn api_conventions_opencode() {
-    let (rule, body) = load_rule("api-conventions");
-    let actual = render_rule(&rule, &body, Client::OpenCode).expect("render");
+    let (rule, name, body) = load_rule("api-conventions");
+    let actual = render_rule(&rule, &name, &body, Client::OpenCode).expect("render");
     let expected = load_expected("opencode", "api-conventions");
     assert_byte_equal(&actual, &expected, "opencode/api-conventions");
 }

--- a/tests/generate_skills.rs
+++ b/tests/generate_skills.rs
@@ -34,7 +34,8 @@ fn assert_byte_equal(actual: &str, expected: &str, label: &str) {
 #[test]
 fn create_api_endpoint_claude() {
     let (skill, body) = load_skill("create-api-endpoint");
-    let actual = render_skill(&skill, &body, Client::Claude).expect("render");
+    let actual =
+        render_skill(&skill, "create-api-endpoint", &body, Client::Claude).expect("render");
     let expected = load_expected("claude", "create-api-endpoint");
     assert_byte_equal(&actual, &expected, "claude/create-api-endpoint");
 }
@@ -42,7 +43,8 @@ fn create_api_endpoint_claude() {
 #[test]
 fn create_api_endpoint_copilot() {
     let (skill, body) = load_skill("create-api-endpoint");
-    let actual = render_skill(&skill, &body, Client::Copilot).expect("render");
+    let actual =
+        render_skill(&skill, "create-api-endpoint", &body, Client::Copilot).expect("render");
     let expected = load_expected("copilot", "create-api-endpoint");
     assert_byte_equal(&actual, &expected, "copilot/create-api-endpoint");
 }
@@ -50,7 +52,8 @@ fn create_api_endpoint_copilot() {
 #[test]
 fn create_api_endpoint_opencode() {
     let (skill, body) = load_skill("create-api-endpoint");
-    let actual = render_skill(&skill, &body, Client::OpenCode).expect("render");
+    let actual =
+        render_skill(&skill, "create-api-endpoint", &body, Client::OpenCode).expect("render");
     let expected = load_expected("opencode", "create-api-endpoint");
     assert_byte_equal(&actual, &expected, "opencode/create-api-endpoint");
 }

--- a/tests/generate_strip_ssot_fields.rs
+++ b/tests/generate_strip_ssot_fields.rs
@@ -74,12 +74,40 @@ fn generated_skill_output_omits_requires_and_ignore() {
         generated.display()
     );
     let contents = fs::read_to_string(&generated).unwrap();
+
+    // Assert on parsed frontmatter keys, not whole-file substrings: the words
+    // "requires"/"ignore" are ordinary English and may legitimately appear in
+    // body or description prose. Only a leaked *key* is a defect.
+    let frontmatter = extract_frontmatter(&contents);
+    let map: serde_yaml_ng::Mapping = serde_yaml_ng::from_str(&frontmatter)
+        .unwrap_or_else(|e| panic!("frontmatter is not valid YAML mapping: {e}\n{frontmatter}"));
     assert!(
-        !contents.contains("requires"),
-        "SSOT-only `requires` leaked into generated output:\n{contents}"
+        !map.contains_key(serde_yaml_ng::Value::from("requires")),
+        "SSOT-only `requires` key leaked into generated frontmatter:\n{frontmatter}"
     );
     assert!(
-        !contents.contains("ignore"),
-        "SSOT-only `ignore` leaked into generated output:\n{contents}"
+        !map.contains_key(serde_yaml_ng::Value::from("ignore")),
+        "SSOT-only `ignore` key leaked into generated frontmatter:\n{frontmatter}"
     );
+}
+
+/// Extract the YAML frontmatter block — the text between the first `---` fence
+/// line and the next `---` line. Generated output always opens with a `---`
+/// fence.
+fn extract_frontmatter(contents: &str) -> String {
+    let mut lines = contents.lines();
+    assert_eq!(
+        lines.next().map(str::trim_end),
+        Some("---"),
+        "generated output does not open with a `---` frontmatter fence:\n{contents}"
+    );
+    let mut block = String::new();
+    for line in lines {
+        if line.trim_end() == "---" {
+            return block;
+        }
+        block.push_str(line);
+        block.push('\n');
+    }
+    panic!("no closing `---` fence found in generated output:\n{contents}")
 }

--- a/tests/generate_strip_ssot_fields.rs
+++ b/tests/generate_strip_ssot_fields.rs
@@ -1,0 +1,85 @@
+//! ATDD: SSOT-only frontmatter fields (`requires`, `ignore`) MUST NOT
+//! appear in generated per-client output.
+//!
+//! Skills emit their `extra` pass-through map verbatim into output, so a
+//! field that lands in `extra` leaks. Making `requires`/`ignore` typed
+//! fields routes them away from `extra`; this test proves the strip.
+
+mod common;
+
+use std::fs;
+
+#[test]
+fn generated_skill_output_omits_requires_and_ignore() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    // Mark `target` as a project directory so auto-fallback picks project
+    // scope (cwd) instead of global ($HOME).
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // Skill that declares both SSOT-only fields. References `other` so the
+    // on-disk form is realistic; resolution does not block install today.
+    let code_review_dir = source.join("code-review");
+    fs::create_dir_all(&code_review_dir).unwrap();
+    fs::write(
+        code_review_dir.join("SKILL.md"),
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: code-review\n",
+            "description: Use when reviewing changes for correctness\n",
+            "requires:\n",
+            "  skills:\n",
+            "    - other\n",
+            "ignore:\n",
+            "  - \"scripts/**\"\n",
+            "---\n",
+            "\n",
+            "Review the diff carefully.\n",
+        ),
+    )
+    .unwrap();
+
+    // The required `other` skill so the source is well-formed.
+    let other_dir = source.join("other");
+    fs::create_dir_all(&other_dir).unwrap();
+    fs::write(
+        other_dir.join("SKILL.md"),
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: other\n",
+            "description: Use when a dependency target is needed\n",
+            "---\n",
+            "\n",
+            "Helper skill body.\n",
+        ),
+    )
+    .unwrap();
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let generated = target.join(".claude/skills/code-review/SKILL.md");
+    assert!(
+        generated.exists(),
+        "expected generated skill at {}",
+        generated.display()
+    );
+    let contents = fs::read_to_string(&generated).unwrap();
+    assert!(
+        !contents.contains("requires"),
+        "SSOT-only `requires` leaked into generated output:\n{contents}"
+    );
+    assert!(
+        !contents.contains("ignore"),
+        "SSOT-only `ignore` leaked into generated output:\n{contents}"
+    );
+}

--- a/tests/pipeline_ignore.rs
+++ b/tests/pipeline_ignore.rs
@@ -1,0 +1,78 @@
+//! Integration coverage for the `ignore` field (format-spec §2.4):
+//! supporting resources matching an item's `ignore` globs are dropped
+//! before being copied into per-client output.
+
+mod common;
+
+use assert_cmd::Command;
+use common::upskill_cmd;
+use std::fs;
+use std::path::PathBuf;
+
+/// Isolated test environment: a fake `$HOME`, an SSOT `src/` to author into,
+/// and a `proj/` working dir marked with `.git` so `upskill` picks project
+/// scope (cwd) instead of global ($HOME). See issue #193.
+struct Env {
+    _tmp: tempfile::TempDir,
+    home: PathBuf,
+    src: PathBuf,
+    proj: PathBuf,
+}
+
+fn env() -> Env {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let src = tmp.path().join("src");
+    let proj = tmp.path().join("proj");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(proj.join(".git")).unwrap();
+    Env {
+        _tmp: tmp,
+        home,
+        src,
+        proj,
+    }
+}
+
+impl Env {
+    fn cmd(&self) -> Command {
+        let mut c = upskill_cmd(&self.home);
+        c.current_dir(&self.proj);
+        c
+    }
+}
+
+#[test]
+fn ignored_resource_subtree_is_not_copied() {
+    let e = env();
+    let dir = e.src.join("demo");
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::create_dir_all(dir.join("refs")).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        "---\nschema: 1\nname: demo\ndescription: demo skill\nignore:\n  - scripts/**\n---\n\n## Demo\n\nSee [the reference](./refs/p.md).\n",
+    )
+    .unwrap();
+    fs::write(dir.join("scripts/gate.sh"), "#!/bin/sh\necho gate\n").unwrap();
+    fs::write(dir.join("refs/p.md"), "# Reference\n\nstuff\n").unwrap();
+
+    e.cmd()
+        .args(["add", e.src.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let claude = e.proj.join(".claude/skills/demo");
+    assert!(
+        claude.join("refs/p.md").is_file(),
+        "non-ignored resource must be copied"
+    );
+    assert!(
+        !claude.join("scripts/gate.sh").exists(),
+        "resource under an ignored subtree must NOT be copied"
+    );
+    assert!(
+        !claude.join("scripts").exists(),
+        "ignored subtree directory must not be materialised"
+    );
+}

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -144,6 +144,7 @@ fn install_preserves_unrelated_existing_entries() {
         git_ref: Some("v1.0".into()),
         hash: Some("a".repeat(64)),
         source_name: None,
+        required_by: vec![],
     });
     seed.save(&target).unwrap();
 

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -145,6 +145,7 @@ fn install_preserves_unrelated_existing_entries() {
         hash: Some("a".repeat(64)),
         source_name: None,
         required_by: vec![],
+        group: None,
     });
     seed.save(&target).unwrap();
 


### PR DESCRIPTION
Implements **ADR-0009** (amends [ADR-0006](docs/adr/0006-flat-item-layout.md)): a three-tier coupling model. This is **Slice 1 (same-source)** of a two-slice plan; cross-source `requires` resolution is Slice 2 (separate PR).

Design + plan: `docs/superpowers/specs/2026-06-03-coupling-redesign-design.md`, `docs/superpowers/plans/2026-06-03-coupling-redesign-slice1.md`.

## What's in this PR

- **Three-tier coupling** — co-location (symmetric unit) / `requires` + `preload-skills` (directed) / bundles (curated). A mutual dependency is co-location, never mutual `requires` (cycle = error).
- **Optional + relaxed naming** — item `name` is optional with folder fallback. Skills bind to the folder (Agent Skills standard); rules/agents take their frontmatter name and may diverge from the folder. Identity is `(kind, name)`, layout-independent; rule/agent divergence is silent (no lint finding).
- **`requires` + `ignore` SSOT fields** — both stripped from generated client output. `requires` is per-entrypoint (string or `{name, source}`), hard, acyclic, resolved by `(kind, name)`. `ignore` is a subtractive `.gitignore`-style copy-scope filter (hand-rolled, no new deps).
- **Same-source `requires` closure** — installing an item auto-installs its same-source requirements, with `required_by` provenance in the lockfile. Cycles and (deferred) cross-source entries error clearly.
- **`preload-skills` → `requires.skills` (soft)** — preloaded skills present in the same source are auto-installed; absent ones are runtime hints (not installed, not an error). For Copilot/opencode (no native preload), the preloaded skills are rendered as a prose `## Skills` section in the agent body; Claude keeps its native `skills:` field.
- **Co-location grouping + unit removal** — `remove <name>` removes every item sharing the source folder, so a co-located rule+skill (even with divergent names) travel as one unit.
- **`doctor` orphaned-dependency flag** — advisory only (never auto-removes, #196; does not affect exit code): flags an item whose every requirer is gone.
- **Docs** — ADR-0009 + format-spec §§2.1, 2.4, 3.1, 3.4, 3.7, 3.8, 11 (multi-repo sources marked RESOLVED).

## Reviewer notes / known limitations

- **Slice 1 of 2 — same-source only.** A cross-source `{name, source}` `requires` entry errors ("cross-source dependency resolution is not yet available"); the on-disk contract + conflict/cycle rules are specified (ADR-0009, §3.7) and land in Slice 2.
- **Doctor orphaned-dependency is advisory** — informational, with a `remove` hint; never auto-deletes, never fails the exit code.
- **Soft preload semantics** — deliberate asymmetry vs explicit `requires` (which errors on a missing target).
- **Co-location `group` is the folder leaf name**, not a source-relative path (documented). Same-leaf folders under different category dirs in one source would share a group — accepted, documented, tested.

## Follow-up debt (not blocking)

- Alias + `requires` interaction is untested; aliasing a *dependency* would drop its `required_by`, and aliasing a *requirer* could yield a false orphan flag in `doctor`. Dependencies are never aliased in practice and resource-bearing aliasing already bails, so low-risk for Slice 1.
- `scaffold.rs` (`upskill new`) still rejects an explicit co-located name that diverges from the folder, stricter than the install/lint identity layer now permits. UX-only; consider relaxing.

Verified: `just fmt` + `just verify` green (tests, clippy `-D warnings`, fmt, dprint, markdownlint, shellcheck, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
