### PR TITLE
fix: keep required_by provenance consistent under --as aliases (#205)

### DIFF
--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -349,13 +349,39 @@ pub fn install_with_lockfile(
         .iter()
         .map(|it| ((it.kind, it.name.clone()), it.source_hash.clone()))
         .collect();
+    // Translate `requires` provenance through any applied `--as` aliases so
+    // the recorded `required_by` is consistent with the post-alias names that
+    // `doctor` matches against (#205). The closure keys dependencies and labels
+    // requirers by ORIGINAL effective name; the rename loop above already moved
+    // the installed items to their alias. `aliased_names` maps `alias ->
+    // original`; invert it to `original -> alias` and rewrite (a) each
+    // dependency key's name and (b) each `"{kind}:{name}"` requirer label.
+    let original_to_alias: std::collections::HashMap<&str, &str> = aliased_names
+        .iter()
+        .map(|(alias, original)| (original.as_str(), alias.as_str()))
+        .collect();
+    let alias_label = |label: &str| -> String {
+        match label.split_once(':') {
+            Some((kind, name)) => match original_to_alias.get(name) {
+                Some(alias) => format!("{kind}:{alias}"),
+                None => label.to_string(),
+            },
+            None => label.to_string(),
+        }
+    };
     let provenance: std::collections::BTreeMap<(ItemKind, String), Vec<String>> =
         if let Some(closure) = &closure {
             closure
                 .required_by
                 .iter()
-                .map(|(key, requirers)| {
-                    (key.clone(), requirers.iter().cloned().collect::<Vec<_>>())
+                .map(|((kind, name), requirers)| {
+                    let aliased_name = original_to_alias
+                        .get(name.as_str())
+                        .map(|a| a.to_string())
+                        .unwrap_or_else(|| name.clone());
+                    let aliased_requirers =
+                        requirers.iter().map(|r| alias_label(r)).collect::<Vec<_>>();
+                    ((*kind, aliased_name), aliased_requirers)
                 })
                 .collect()
         } else {

--- a/tests/cli_alias_requires.rs
+++ b/tests/cli_alias_requires.rs
@@ -1,0 +1,132 @@
+//! ATDD tests for `--as` alias interaction with `requires` provenance (#205).
+//!
+//! Slice 1 records same-source `requires` provenance as `required_by`
+//! `"kind:name"` strings and `doctor` flags an item as an orphaned dependency
+//! when none of its recorded requirers is still installed. `--as` renames an
+//! item AFTER the closure provenance is computed, so without translation the
+//! recorded requirer label (or dependency key) names the ORIGINAL identity and
+//! `doctor` mismatches:
+//!
+//! - aliasing the REQUIRER (`--as code-review=cr`) leaves the dependency's
+//!   `required_by` pointing at `"agent:code-review"` while the installed item
+//!   is `"agent:cr"` -> false orphaned-dependency flag.
+//! - aliasing the DEPENDENCY (`--as sarif=s`) drops the provenance entirely
+//!   because the provenance key still names `sarif`, not `s`.
+
+mod common;
+
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+
+/// Write an item entrypoint of `kind` (SKILL/AGENT) named `name` into its own
+/// `<root>/<name>/` directory (so items are NOT co-located).
+fn write_item(root: &Path, entrypoint: &str, name: &str, frontmatter_extra: &str) {
+    let dir = root.join(name);
+    fs::create_dir_all(&dir).unwrap();
+    let body = format!(
+        "---\nschema: 1\nname: {name}\ndescription: test {name}\n{frontmatter_extra}---\n# {name}\n"
+    );
+    fs::write(dir.join(entrypoint), body).unwrap();
+}
+
+/// Read the installed lockfile and return the `required_by` Vec for the item
+/// matching `(kind, name)`, or `None` if no such item is present.
+fn required_by_of(lock_path: &Path, kind: &str, name: &str) -> Option<Vec<String>> {
+    let raw = fs::read_to_string(lock_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    for item in json["items"].as_array().unwrap() {
+        if item["kind"] == kind && item["name"] == name {
+            return Some(
+                item["required_by"]
+                    .as_array()
+                    .map(|a| a.iter().map(|v| v.as_str().unwrap().to_string()).collect())
+                    .unwrap_or_default(),
+            );
+        }
+    }
+    None
+}
+
+#[test]
+fn doctor_does_not_flag_dependency_when_requirer_aliased() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    // Fake git repo so upskill uses project scope (lockfile in cwd).
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg = tmp.path().join("reg");
+    write_item(
+        &reg,
+        "AGENT.md",
+        "code-review",
+        "requires:\n  skills: [sarif]\n",
+    );
+    write_item(&reg, "SKILL.md", "sarif", "");
+
+    // Alias the REQUIRER: the agent installs as `cr`, pulling in `sarif`.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg", "code-review", "--as", "code-review=cr"])
+        .assert()
+        .success();
+
+    // sarif's required_by must name the FINAL (aliased) requirer "agent:cr".
+    let lock = tmp.path().join(".upskill-lock.json");
+    assert_eq!(
+        required_by_of(&lock, "skill", "sarif"),
+        Some(vec!["agent:cr".to_string()]),
+        "sarif required_by should reference the aliased requirer agent:cr"
+    );
+
+    // doctor: the requirer (cr) is still installed, so sarif is NOT flagged as
+    // an orphaned dependency. (Exit code is not asserted: aliasing a local item
+    // separately trips doctor's source lookup, which keys on the alias rather
+    // than `source_name` — a distinct pre-existing bug, not #205.)
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["doctor"])
+        .assert()
+        .stdout(predicates::str::contains("orphaned").not());
+}
+
+#[test]
+fn dependency_provenance_survives_dependency_alias() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg = tmp.path().join("reg");
+    write_item(
+        &reg,
+        "AGENT.md",
+        "code-review",
+        "requires:\n  skills: [sarif]\n",
+    );
+    write_item(&reg, "SKILL.md", "sarif", "");
+
+    // Alias the DEPENDENCY: the pulled skill installs as `s`.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg", "code-review", "--as", "sarif=s"])
+        .assert()
+        .success();
+
+    // The renamed dependency `s` must still carry its provenance.
+    let lock = tmp.path().join(".upskill-lock.json");
+    assert_eq!(
+        required_by_of(&lock, "skill", "s"),
+        Some(vec!["agent:code-review".to_string()]),
+        "renamed dependency s should keep required_by agent:code-review"
+    );
+
+    // doctor: requirer code-review is still installed -> s is NOT flagged as an
+    // orphaned dependency. (Exit code not asserted — see the sibling test.)
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["doctor"])
+        .assert()
+        .stdout(predicates::str::contains("orphaned").not());
+}


### PR DESCRIPTION
## The bug (#205)

Slice 1 records same-source `requires` provenance as `required_by` `"kind:name"`
strings in the lockfile, and `doctor` flags an item as an *orphaned dependency*
when none of its recorded requirers is still installed. `upskill add --as`
renames items. These interacted incorrectly because the alias rename loop in
`install_with_lockfile` runs **before** the provenance map is built, while the
closure's `required_by` is keyed by the **original** effective `(kind, name)`
and its requirer labels are the **original** `"kind:name"` strings.

- **Aliasing a requirer** (`--as code-review=cr`, where `code-review` requires
  `sarif`): the installed requirer becomes `cr`, but `sarif`'s `required_by`
  still said `"agent:code-review"`. `doctor` builds its installed-set from
  current lockfile names (`"agent:cr"`) and saw no matching requirer →
  **false orphaned-dependency flag** on `sarif`.
- **Aliasing a dependency** (`--as sarif=s`): the pulled dep was renamed to `s`,
  but the provenance key still named `sarif`, so the renamed item got an
  **empty `required_by`** (provenance dropped).

## The fix

In `install_with_lockfile`, after the rename loop has populated `aliased_names`
(`alias → original`), invert it to `original → alias` and translate the
provenance before it flows into `items_from_report`:

1. **Dependency key name** — rewrite each `(kind, original-name)` key to
   `(kind, alias)` so it matches the post-alias `report.items` name that
   `items_from_report` looks up.
2. **Requirer labels** — rewrite each `"{kind}:{name}"` requirer string,
   replacing `name` with its alias when one was applied.

After translation a recorded `required_by` entry names the requirer's final
(aliased) name and the provenance key matches the final dependency name, so
`doctor` matches with **no doctor-side logic change** and the lockfile stays
self-consistent.

## Tests

New `tests/cli_alias_requires.rs`:
- `doctor_does_not_flag_dependency_when_requirer_aliased` — `--as code-review=cr`;
  asserts `sarif.required_by == ["agent:cr"]` and that `doctor` does not emit
  "orphaned".
- `dependency_provenance_survives_dependency_alias` — `--as sarif=s`; asserts
  the renamed dep `s` keeps `required_by == ["agent:code-review"]`.

Both failed before the fix (showing `agent:code-review` and `[]` respectively)
and pass after. Full `cargo test -p upskill` green; `just verify` clean.

## Out of scope (follow-up)

While testing I found a **separate, pre-existing** bug: `doctor`'s local-source
lookup keys on the (aliased) `name` instead of `source_name`, so any aliased
local item is falsely reported as "item not in source" (and missing outputs),
making `doctor` exit 1. This reproduces on `main` independent of `requires` and
is unrelated to the provenance fix; the tests therefore assert the
no-"orphaned" finding rather than the exit code. Tracking separately.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)