### PR TITLE
feat: coupling redesign slice 2 — cross-source requires resolution

### DIFF
--- a/docs/adr/0009-coupling-tiers-and-dependencies.md
+++ b/docs/adr/0009-coupling-tiers-and-dependencies.md
@@ -112,8 +112,9 @@ ignore: ["scripts/**", "fixtures/**"]
 - **Removal never cascades** (the #196 "never auto-delete" ethos). `doctor`
   flags an item that is now present only as a removed item's dependency as an
   "orphaned dependency."
-- **Staging.** Cross-source resolution ships in a follow-up release (Slice 2);
-  same-source resolution ships now (Slice 1).
+- **Status.** Both same-source (Slice 1) and cross-source (Slice 2) resolution
+  are implemented. A cross-source `source` is fetched once and cached for the
+  duration of one resolution; the transitive closure may span sources.
 
 ### Inherent limit
 
@@ -143,8 +144,9 @@ not a defect to engineer around.
 
 - The inherent-limit note stands: cross-kind coupling is an upskill-only
   guarantee and does not survive a round-trip through standard-only tooling.
-- Cross-source resolution is staged to a later release, so the full transitive
-  closure across sources is not available in Slice 1.
+- A cross-source closure fetches each distinct source once per resolution
+  (no shared on-disk cache across separate `upskill add` invocations); a large
+  multi-source dependency graph therefore re-fetches its sources on each install.
 
 ## Alternatives considered (Rejected — do not revisit)
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -691,9 +691,15 @@ Implementations:
 
 Each `requires.<kind>` entry is a bare name (same source) or a `{ name, source }` map
 (cross-source), where `source` reuses the `upskill add` source DSL. Same-source resolution
-(bare-name entries against the entry item's own already-fetched source) is implemented in the
-initial release; cross-source resolution (`{ name, source }` entries) is specified here but
-lands in a later release.
+(bare-name entries against the entry item's own already-fetched source) and cross-source
+resolution (`{ name, source }` entries) are both implemented: a cross-source entry is fetched
+via the same machinery as `upskill add` (a distinct source is fetched once and cached for the
+duration of the resolution), the transitive closure MAY span sources, and each
+dependency-pulled item is recorded in the lockfile with its **own** `source` (and `ref`) plus
+a `required_by` provenance list. Cycle detection is keyed by `(canonical-source-label, kind,
+name)`; the same `(kind, name)` resolving to two different sources within one closure — or
+conflicting with an existing different-source install — is an error. There is no version-range
+solving.
 
 ### 3.8 Frontmatter canonicalisation
 
@@ -1044,8 +1050,8 @@ The following topics are explicitly deferred and tracked for future specificatio
 7. **Multi-repo item sources** (RESOLVED): the item `requires` field with a `{ name, source }`
    locator (§3.7) defines the cross-source resolution contract — `source` reuses the `upskill
    add` source DSL, conflicts reuse the same-name-different-source rule, and cycles are keyed by
-   `(canonical-source-label, kind, name)`. Same-source resolution is implemented; cross-source
-   resolution is staged to a later release. See
+   `(canonical-source-label, kind, name)`. Both same-source and cross-source resolution are
+   implemented. See
    [ADR-0009](./adr/0009-coupling-tiers-and-dependencies.md).
 8. **Content hashing**: whether items should carry a content hash for integrity verification
    during distribution, independent of `metadata.version`.

--- a/docs/superpowers/plans/2026-06-03-coupling-redesign-slice2.md
+++ b/docs/superpowers/plans/2026-06-03-coupling-redesign-slice2.md
@@ -1,0 +1,1266 @@
+# Coupling Redesign Slice 2 — Cross-Source `requires` Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make cross-source `requires` entries (`{ name, source }`) actually fetch, resolve, install, and record in the lockfile — additively on top of the merged Slice 1 same-source machinery.
+
+**Architecture:** Widen the dependency-closure resolver so it tracks a _per-item canonical source label_, fetches each distinct cross-source locator once (via `fetch_ssot`, cached by canonical label, with `TempDir` guards owned by the returned closure), detects cross-source cycles keyed by `(label, kind, name)` and same-`(kind,name)`-different-source conflicts, then installs each item from _its own_ fetched root and records each lockfile entry with _its own_ source/ref. The design (ADR-0009, design spec §2.5) is fixed — this plan only builds it.
+
+**Tech Stack:** Rust (edition 2024, MSRV 1.85), `anyhow`, `serde`/`serde_json`, `tempfile`. No new dependencies. Tests use `assert_cmd` + `tempfile` + `tests/common::upskill_cmd`.
+
+---
+
+## Background: what Slice 1 built (already on `main`)
+
+- `src/model/requires.rs` — `RequireRef` (untagged `Name(String)` | `Detailed { name, source }`) with `.name()` / `.source() -> Option<&str>`; `ItemRequires { rules, skills, agents: Vec<RequireRef> }`.
+- `src/pipeline/install.rs` — `resolve_requires_closure(source: &Path, initial: &[(ItemKind,String)]) -> Result<DependencyClosure>`. `DependencyClosure { items: bundle::ResolvedItems, required_by: BTreeMap<(ItemKind,String), BTreeSet<String>> }`. DFS over `(kind,name)` within ONE source; cross-source entries **bail at `src/pipeline/install.rs:311-316`**. Helpers `index_source`, `read_item_requires`, `visit_requires`.
+- `src/pipeline/mod.rs` `install_with_lockfile` — fetches one source, builds `requested`, builds `closure` (skipped for bundle-file / name-resolution deferrals), runs conflict detection over the closure items, installs via one `install_from_local_path(&local_source, target, Some(&closure.items))`, records the lockfile via `items_from_report(report, &label, git_ref, &provenance, hash_for)`.
+- `src/lockfile.rs` — `LockedItem { kind, name, source, git_ref, hash, source_name, required_by, group }`; `items_from_report(report, source_label, git_ref, required_by, hash_for)`.
+- `src/pipeline/git.rs` — `fetch_ssot(&InstallSource) -> Result<(PathBuf, Option<TempDir>)>` (the auth/clone path; `LocalPath` returns the path with `None` guard).
+- `src/source.rs` — `parse_install_source(&str) -> Result<InstallSource, _>` parses the `add` DSL (`owner/repo@ref`, `https://…`, `gitlab:…`, `./path`, `/abs`). `InstallSource::Display` produces the canonical label (`github:owner/repo[@ref][:sub]`, `local:<path>`, …).
+- `src/conflict.rs` — `detect_conflicts(incoming: &[(ItemKind,String)], &Lockfile, incoming_source: &str) -> Vec<ItemConflict>`; same `(kind,name)` from a different source = conflict.
+- `src/pipeline/lifecycle.rs` `doctor` — advisory orphaned-dependency flag (item whose every `required_by` requirer is gone). Unchanged by Slice 2.
+
+## File Structure (what this slice creates / modifies)
+
+- **Modify** `src/pipeline/install.rs` — the core change: replace the single-source `DependencyClosure` + `resolve_requires_closure` + `visit_requires` with a source-aware `Resolver` that fetches cross-source locators and tracks per-item source labels. (~150 lines changed, the bulk of the slice.)
+- **Modify** `src/pipeline/mod.rs` `install_with_lockfile` — consume the new closure: group conflict detection by source, install per-source, record per-item source/ref. Move the `git_ref` computation above the closure block.
+- **Modify** `src/lockfile.rs` — change `items_from_report` to take a per-item `source_for(kind, name) -> (String, Option<String>)` resolver instead of one `source_label` + `git_ref`. Update its one unit test.
+- **Create** `tests/cross_source_requires.rs` — ATDD integration coverage (happy path, transitive, conflict, cycle, doctor-orphan) using local-path "other sources".
+- **Modify** `docs/format-spec.md` §3.7 + §11 item 7 — flip cross-source from "lands in a later release" to implemented.
+- **Modify** `docs/adr/0009-coupling-tiers-and-dependencies.md` — flip the "Staging" bullet and the negative-consequence bullet to implemented.
+
+> **Why local-path "other sources" for tests (not bare git repos):** the `requires` `source:` field uses the `add` DSL verbatim, which has **no `file://` form** — so a `requires` entry cannot point at a bare repo by URL. A local path (`/abs/...`) _is_ a valid DSL form, flows through `parse_install_source` → `InstallSource::LocalPath` → `fetch_ssot` (returns the path, `None` guard) → `index_source` → per-source install/record, exercising the entire cross-source path deterministically and offline. The git-clone arm of `fetch_ssot` is already covered by `tests/pipeline_source.rs`; cross-source calls the identical function.
+
+---
+
+## Task 1: Source-aware dependency closure (the core refactor)
+
+This task rewrites the closure to span sources and rewires its two consumers (`mod.rs`, `lockfile.rs`) so the crate stays green. Unit tests in `install.rs` drive it.
+
+**Files:**
+
+- Modify: `src/pipeline/install.rs` (closure types, `resolve_requires_closure`, `Resolver`, unit tests)
+- Modify: `src/pipeline/mod.rs` (`install_with_lockfile`)
+- Modify: `src/lockfile.rs` (`items_from_report` signature + its unit test)
+
+- [ ] **Step 1: Write the failing unit test for a cross-source pull**
+
+Add to the `#[cfg(test)] mod tests` block in `src/pipeline/install.rs` (the existing `write_item` helper already creates `<root>/<name>/<ENTRY>.md`). This test creates two source roots and asserts the closure resolves the dependency under the _other_ source's canonical label.
+
+```rust
+#[test]
+fn closure_pulls_cross_source_dependency() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_a = tmp.path().join("a");
+    let src_b = tmp.path().join("b");
+    std::fs::create_dir_all(&src_a).unwrap();
+    std::fs::create_dir_all(&src_b).unwrap();
+    write_item(&src_b, ItemKind::Skill, "sarif", "");
+    write_item(
+        &src_a,
+        ItemKind::Agent,
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+            src_b.display()
+        ),
+    );
+
+    let a_label = format!("local:{}", src_a.display());
+    let b_label = format!("local:{}", src_b.display());
+    let closure = resolve_requires_closure(
+        &a_label,
+        &src_a,
+        None,
+        &[(ItemKind::Agent, "code-review".to_string())],
+    )
+    .expect("closure");
+
+    // code-review resolves under source A; sarif under source B.
+    assert_eq!(
+        closure.item_source.get(&(ItemKind::Agent, "code-review".to_string())),
+        Some(&a_label)
+    );
+    assert_eq!(
+        closure.item_source.get(&(ItemKind::Skill, "sarif".to_string())),
+        Some(&b_label)
+    );
+    // sarif installs from B's root.
+    assert!(closure.by_source[&b_label].items.skills.contains(&"sarif".to_string()));
+    // provenance recorded.
+    let prov = closure
+        .required_by
+        .get(&(ItemKind::Skill, "sarif".to_string()))
+        .expect("sarif provenance");
+    assert!(prov.contains("agent:code-review"), "{prov:?}");
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails to compile**
+
+Run: `cargo test -p upskill --lib closure_pulls_cross_source_dependency`
+Expected: FAIL — `resolve_requires_closure` takes 2 args not 4; no `item_source` / `by_source` fields. (Compile error is the expected failure.)
+
+- [ ] **Step 3: Replace the closure types and resolver in `install.rs`**
+
+Replace the entire region from the `DependencyClosure` struct (line ~166) through the end of `visit_requires` (line ~335) with the source-aware implementation below. Also add the imports at the top of the file: in the existing `use crate::model::{...}` line keep it, and add `use crate::source::{InstallSource, parse_install_source};`.
+
+```rust
+/// The transitive closure of items reached by expanding a requested set
+/// along `requires` edges — possibly spanning multiple sources.
+#[derive(Debug, Default)]
+pub(super) struct DependencyClosure {
+    /// Per canonical source label: the fetched root, its pinned ref, and
+    /// the items to install from it (in dependency order).
+    pub by_source: BTreeMap<String, SourceInstall>,
+    /// Canonical source label each resolved `(kind, name)` came from.
+    /// `(kind, name)` is globally unique within a valid closure (a clash
+    /// across sources is a conflict error), so this maps cleanly.
+    pub item_source: BTreeMap<(ItemKind, String), String>,
+    /// `(kind, name) -> { "<requirer-kind>:<requirer-name>", .. }`. Empty
+    /// for directly-requested items. Drives the lockfile's `required_by`.
+    pub required_by: BTreeMap<(ItemKind, String), BTreeSet<String>>,
+    /// Tempdir guards for cross-source fetches. Held here so the clones
+    /// outlive the per-source install calls in `install_with_lockfile`.
+    pub guards: Vec<tempfile::TempDir>,
+}
+
+/// One source's contribution to a [`DependencyClosure`].
+#[derive(Debug)]
+pub(super) struct SourceInstall {
+    pub root: PathBuf,
+    pub git_ref: Option<String>,
+    pub items: crate::bundle::ResolvedItems,
+}
+
+/// A fetched-and-indexed source, cached by canonical label during DFS.
+struct FetchedSource {
+    root: PathBuf,
+    git_ref: Option<String>,
+    index: BTreeMap<(ItemKind, String), PathBuf>,
+}
+
+/// Index every item in `source` by its effective `(kind, name)` identity.
+fn index_source(source: &Path) -> Result<BTreeMap<(ItemKind, String), PathBuf>> {
+    let mut idx = BTreeMap::new();
+    for (folder, dir) in iter_item_dirs(source)? {
+        for kind in [ItemKind::Skill, ItemKind::Rule, ItemKind::Agent] {
+            let entry = dir.join(kind.entrypoint_filename());
+            if entry.is_file() {
+                let name = super::discovery::probe_effective_name(&entry, kind, &folder);
+                idx.insert((kind, name), dir.clone());
+            }
+        }
+    }
+    Ok(idx)
+}
+
+/// Parse an item's `requires` block. For agents, fold `preload_skills` into
+/// `requires.skills` softly (a preloaded skill present in the SAME source is
+/// implicitly required; an absent one is a runtime hint, skipped).
+fn read_item_requires(
+    dir: &Path,
+    kind: ItemKind,
+    index: &BTreeMap<(ItemKind, String), PathBuf>,
+) -> Result<crate::model::ItemRequires> {
+    let entry = dir.join(kind.entrypoint_filename());
+    let raw = fs::read_to_string(&entry).with_context(|| format!("read {}", entry.display()))?;
+    let req = match kind {
+        ItemKind::Skill => frontmatter::parse::<Skill>(&raw)?.0.requires,
+        ItemKind::Rule => frontmatter::parse::<Rule>(&raw)?.0.requires,
+        ItemKind::Agent => {
+            let agent = frontmatter::parse::<Agent>(&raw)?.0;
+            let mut req = agent.requires;
+            for s in &agent.preload_skills {
+                let present = index.contains_key(&(ItemKind::Skill, s.clone()));
+                if present && !req.skills.iter().any(|r| r.name() == s) {
+                    req.skills.push(RequireRef::Name(s.clone()));
+                }
+            }
+            req
+        }
+    };
+    Ok(req)
+}
+
+/// DFS state for [`resolve_requires_closure`]. Carries the fetch cache so a
+/// source pulled by two edges is fetched once, and the visited/on-path sets
+/// keyed for cross-source cycle and conflict detection.
+struct Resolver {
+    /// Canonical label -> fetched-and-indexed source.
+    sources: BTreeMap<String, FetchedSource>,
+    /// Tempdir guards for cross-source clones (drained into the closure).
+    guards: Vec<tempfile::TempDir>,
+    /// Fully-resolved identities (dedup).
+    resolved: BTreeSet<(ItemKind, String)>,
+    /// The label each identity resolved under — second visit under a
+    /// different label is a cross-source conflict.
+    item_label: BTreeMap<(ItemKind, String), String>,
+    /// Dependency-order accumulation.
+    order: Vec<(ItemKind, String)>,
+    /// On-path set keyed by `(label, kind, name)` for cycle detection (§2.5).
+    on_path: BTreeSet<(String, ItemKind, String)>,
+    /// Dependency provenance keyed by identity.
+    required_by: BTreeMap<(ItemKind, String), BTreeSet<String>>,
+}
+
+impl Resolver {
+    /// Ensure `src_dsl` (an `add`-DSL locator) is fetched and indexed;
+    /// return its canonical label.
+    fn ensure_source(&mut self, src_dsl: &str) -> Result<String> {
+        let install_source = parse_install_source(src_dsl)
+            .map_err(|e| anyhow::anyhow!("parse requires source `{src_dsl}`: {e}"))?;
+        let label = install_source.to_string();
+        if !self.sources.contains_key(&label) {
+            let (root, guard) = super::git::fetch_ssot(&install_source)
+                .with_context(|| format!("fetch requires source `{label}`"))?;
+            let index = index_source(&root)?;
+            if let Some(g) = guard {
+                self.guards.push(g);
+            }
+            self.sources.insert(
+                label.clone(),
+                FetchedSource {
+                    root,
+                    git_ref: source_git_ref(&install_source),
+                    index,
+                },
+            );
+        }
+        Ok(label)
+    }
+
+    fn visit(
+        &mut self,
+        label: &str,
+        node: (ItemKind, String),
+        requirer: Option<&(ItemKind, String)>,
+    ) -> Result<()> {
+        let (kind, name) = node.clone();
+
+        // Cross-source identity conflict: the same (kind, name) reached from
+        // two different sources (format-spec §3.7).
+        if let Some(prev) = self.item_label.get(&node)
+            && prev != label
+        {
+            anyhow::bail!(
+                "{kind} `{name}` is required from two different sources: `{prev}` and `{label}`"
+            );
+        }
+
+        let dir = self
+            .sources
+            .get(label)
+            .expect("source fetched before visit")
+            .index
+            .get(&node)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow::anyhow!("{kind} `{name}` is required but not found in source `{label}`")
+            })?;
+
+        if let Some((rk, rn)) = requirer {
+            self.required_by
+                .entry(node.clone())
+                .or_default()
+                .insert(format!("{rk}:{rn}"));
+        }
+
+        if self.resolved.contains(&node) {
+            return Ok(());
+        }
+        let path_key = (label.to_string(), kind, name.clone());
+        if self.on_path.contains(&path_key) {
+            anyhow::bail!("circular dependency detected including {kind} `{name}`");
+        }
+        self.on_path.insert(path_key.clone());
+        self.item_label.insert(node.clone(), label.to_string());
+
+        let requires = {
+            let index = &self.sources.get(label).expect("source present").index;
+            read_item_requires(&dir, kind, index)?
+        };
+        for (dep_kind, refs) in [
+            (ItemKind::Rule, &requires.rules),
+            (ItemKind::Skill, &requires.skills),
+            (ItemKind::Agent, &requires.agents),
+        ] {
+            for r in refs {
+                let dep = (dep_kind, r.name().to_string());
+                match r.source() {
+                    None => self.visit(label, dep, Some(&node))?,
+                    Some(src_dsl) => {
+                        let dep_label = self.ensure_source(src_dsl)?;
+                        self.visit(&dep_label, dep, Some(&node))?;
+                    }
+                }
+            }
+        }
+
+        self.on_path.remove(&path_key);
+        self.resolved.insert(node.clone());
+        self.order.push(node);
+        Ok(())
+    }
+}
+
+fn source_git_ref(s: &InstallSource) -> Option<String> {
+    match s {
+        InstallSource::Github(r) => r.git_ref.clone(),
+        InstallSource::Gitlab(r) => r.git_ref.clone(),
+        InstallSource::LocalPath(_) => None,
+    }
+}
+
+/// Expand `initial` (identities in the already-fetched entry source) along
+/// `requires` edges into the full cross-source closure.
+///
+/// `entry_label` is the entry source's canonical label, `entry_root` its
+/// already-fetched root (seeded into the fetch cache so it is not re-fetched),
+/// `entry_git_ref` its pinned ref. Cross-source `{ name, source }` entries
+/// are fetched via [`fetch_ssot`], cached by canonical label. Cycles
+/// (keyed `(label, kind, name)`) and same-`(kind,name)`-different-source
+/// clashes are errors; a required item missing from its source is an error.
+pub(super) fn resolve_requires_closure(
+    entry_label: &str,
+    entry_root: &Path,
+    entry_git_ref: Option<&str>,
+    initial: &[(ItemKind, String)],
+) -> Result<DependencyClosure> {
+    let mut resolver = Resolver {
+        sources: BTreeMap::new(),
+        guards: Vec::new(),
+        resolved: BTreeSet::new(),
+        item_label: BTreeMap::new(),
+        order: Vec::new(),
+        on_path: BTreeSet::new(),
+        required_by: BTreeMap::new(),
+    };
+    resolver.sources.insert(
+        entry_label.to_string(),
+        FetchedSource {
+            root: entry_root.to_path_buf(),
+            git_ref: entry_git_ref.map(str::to_string),
+            index: index_source(entry_root)?,
+        },
+    );
+
+    for node in initial {
+        resolver.visit(entry_label, node.clone(), None)?;
+    }
+
+    let mut by_source: BTreeMap<String, SourceInstall> = BTreeMap::new();
+    let mut item_source: BTreeMap<(ItemKind, String), String> = BTreeMap::new();
+    for node in &resolver.order {
+        let label = resolver
+            .item_label
+            .get(node)
+            .cloned()
+            .expect("resolved item has a source");
+        let group = by_source.entry(label.clone()).or_insert_with(|| {
+            let fs = resolver.sources.get(&label).expect("source present");
+            SourceInstall {
+                root: fs.root.clone(),
+                git_ref: fs.git_ref.clone(),
+                items: crate::bundle::ResolvedItems::default(),
+            }
+        });
+        match node.0 {
+            ItemKind::Rule => group.items.rules.push(node.1.clone()),
+            ItemKind::Skill => group.items.skills.push(node.1.clone()),
+            ItemKind::Agent => group.items.agents.push(node.1.clone()),
+        }
+        item_source.insert(node.clone(), label);
+    }
+
+    Ok(DependencyClosure {
+        by_source,
+        item_source,
+        required_by: resolver.required_by,
+        guards: resolver.guards,
+    })
+}
+```
+
+- [ ] **Step 4: Update the existing `install.rs` closure unit tests to the new API**
+
+The three existing tests (`closure_pulls_same_source_dependency`, `closure_rejects_cycle`, `closure_folds_preload_skills`, `closure_skips_absent_preload_skill`) call the old 2-arg `resolve_requires_closure(src, &[...])` and assert on `closure.items`. Update each call to `resolve_requires_closure("local:test", src, None, &[...])` and replace `closure.items.contains(kind, name)` assertions with `closure.item_source.contains_key(&(kind, name.to_string()))`. Example for `closure_pulls_same_source_dependency`:
+
+```rust
+#[test]
+fn closure_pulls_same_source_dependency() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path();
+    write_item(src, ItemKind::Agent, "code-review", "requires:\n  skills: [sarif]\n");
+    write_item(src, ItemKind::Skill, "sarif", "");
+
+    let closure = resolve_requires_closure(
+        "local:test",
+        src,
+        None,
+        &[(ItemKind::Agent, "code-review".to_string())],
+    )
+    .expect("closure");
+
+    assert!(closure.item_source.contains_key(&(ItemKind::Agent, "code-review".to_string())));
+    assert!(closure.item_source.contains_key(&(ItemKind::Skill, "sarif".to_string())));
+    let prov = closure
+        .required_by
+        .get(&(ItemKind::Skill, "sarif".to_string()))
+        .expect("sarif provenance");
+    assert!(prov.contains("agent:code-review"), "{prov:?}");
+}
+```
+
+Apply the same call-signature change to `closure_rejects_cycle`, `closure_folds_preload_skills`, and `closure_skips_absent_preload_skill` (the latter two replace `closure.items.contains(...)` / `!closure.items.contains(...)` with `closure.item_source.contains_key(...)` / `!closure.item_source.contains_key(...)`).
+
+- [ ] **Step 5: Replace `closure_errors_on_cross_source_entry` with a not-found test**
+
+Cross-source no longer bails as "not yet available". Replace that test with one asserting a cross-source dependency that is absent from its (existing-but-empty) source errors with "not found in source":
+
+```rust
+#[test]
+fn closure_errors_on_missing_cross_source_item() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_a = tmp.path().join("a");
+    let src_b = tmp.path().join("b");
+    std::fs::create_dir_all(&src_a).unwrap();
+    std::fs::create_dir_all(&src_b).unwrap(); // exists but holds no `x`
+    write_item(
+        &src_a,
+        ItemKind::Rule,
+        "a",
+        &format!("requires:\n  skills: [{{ name: x, source: {} }}]\n", src_b.display()),
+    );
+
+    let err = resolve_requires_closure(
+        &format!("local:{}", src_a.display()),
+        &src_a,
+        None,
+        &[(ItemKind::Rule, "a".to_string())],
+    )
+    .expect_err("missing cross-source item");
+    assert!(err.to_string().contains("not found in source"), "{err}");
+}
+```
+
+- [ ] **Step 6: Add a cross-source cycle unit test**
+
+```rust
+#[test]
+fn closure_rejects_cross_source_cycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_a = tmp.path().join("a");
+    let src_b = tmp.path().join("b");
+    std::fs::create_dir_all(&src_a).unwrap();
+    std::fs::create_dir_all(&src_b).unwrap();
+    write_item(
+        &src_a,
+        ItemKind::Rule,
+        "alpha",
+        &format!("requires:\n  rules: [{{ name: beta, source: {} }}]\n", src_b.display()),
+    );
+    write_item(
+        &src_b,
+        ItemKind::Rule,
+        "beta",
+        &format!("requires:\n  rules: [{{ name: alpha, source: {} }}]\n", src_a.display()),
+    );
+
+    let err = resolve_requires_closure(
+        &format!("local:{}", src_a.display()),
+        &src_a,
+        None,
+        &[(ItemKind::Rule, "alpha".to_string())],
+    )
+    .expect_err("cross-source cycle");
+    assert!(err.to_string().contains("circular"), "{err}");
+}
+```
+
+- [ ] **Step 7: Change `items_from_report` in `lockfile.rs` to a per-item source resolver**
+
+Replace the signature and body so each item's source/ref is looked up per `(kind, name)`:
+
+```rust
+pub fn items_from_report(
+    report: &InstallReport,
+    source_for: impl Fn(ItemKind, &str) -> (String, Option<String>),
+    required_by: &std::collections::BTreeMap<(ItemKind, String), Vec<String>>,
+    mut hash_for: impl FnMut(ItemKind, &str) -> Option<String>,
+) -> Vec<LockedItem> {
+    use std::collections::BTreeSet;
+    let mut seen: BTreeSet<(ItemKind, String)> = BTreeSet::new();
+    let mut out = Vec::new();
+    for entry in &report.items {
+        if !seen.insert((entry.kind, entry.name.clone())) {
+            continue;
+        }
+        let (source, git_ref) = source_for(entry.kind, &entry.name);
+        out.push(LockedItem {
+            kind: entry.kind,
+            name: entry.name.clone(),
+            source,
+            git_ref,
+            hash: hash_for(entry.kind, &entry.name),
+            source_name: None,
+            required_by: required_by
+                .get(&(entry.kind, entry.name.clone()))
+                .cloned()
+                .unwrap_or_default(),
+            group: entry.group.clone(),
+        });
+    }
+    out
+}
+```
+
+Update the doc comment above it to describe `source_for` (per-item `(label, ref)` lookup — supports cross-source dependency-pulled items recording their own source).
+
+- [ ] **Step 8: Update the `items_from_report` unit test in `lockfile.rs`**
+
+In `items_from_report_dedupes_per_kind_name`, change the call to pass a closure for `source_for`:
+
+```rust
+let items = items_from_report(
+    &report,
+    |_, _| ("local:./src".to_string(), None),
+    &std::collections::BTreeMap::new(),
+    |_, _| Some("sha256:abc".into()),
+);
+```
+
+(The rest of the assertions are unchanged: `items[0].source == "local:./src"`, etc.)
+
+- [ ] **Step 9: Rewire `install_with_lockfile` in `mod.rs` — move `git_ref` up and rebuild the closure**
+
+In `src/pipeline/mod.rs`, **delete** the later `let git_ref = match source { ... };` block (currently ~line 342) and **insert** it just before the closure block (replacing the `// -- Same-source`requires`closure --` region's closure construction). The closure now needs `entry_label` (`&label`), `entry_root` (`&local_source`), and `entry_git_ref` (`git_ref`).
+
+Replace the closure construction (currently lines ~222-226) with:
+
+```rust
+let git_ref = match source {
+    InstallSource::Github(r) => r.git_ref.as_deref(),
+    InstallSource::Gitlab(r) => r.git_ref.as_deref(),
+    InstallSource::LocalPath(_) => None,
+};
+let closure = if discovery::is_bundle_file(&local_source) || defer_to_name_resolution {
+    None
+} else {
+    Some(resolve_requires_closure(
+        &label,
+        &local_source,
+        git_ref,
+        &requested,
+    )?)
+};
+```
+
+- [ ] **Step 10: Rewire conflict detection in `mod.rs` to group by source**
+
+Replace the conflict-detection block (currently lines ~228-280, from `let mut lock = ...` through the `anyhow::bail!` on conflicts) with per-source grouping. Cross-source dependency items are never aliased; only entry-source items honor `--as`:
+
+```rust
+// -- Conflict detection (before any files are written) --
+let mut lock = crate::lockfile::Lockfile::load(target)?;
+let mut conflicts = Vec::new();
+if let Some(closure) = &closure {
+    // Group incoming items by their canonical source label; conflicts
+    // are per (kind, name, source). Aliases apply only to entry-source
+    // items — dependency-pulled items are never aliased.
+    let mut grouped: std::collections::BTreeMap<String, Vec<(ItemKind, String)>> =
+        std::collections::BTreeMap::new();
+    for ((kind, name), src_label) in &closure.item_source {
+        let effective = if *src_label == label {
+            options
+                .aliases
+                .iter()
+                .find(|(from, _)| from.is_empty() || *from == *name)
+                .map(|(_, to)| to.clone())
+                .unwrap_or_else(|| name.clone())
+        } else {
+            name.clone()
+        };
+        grouped
+            .entry(src_label.clone())
+            .or_default()
+            .push((*kind, effective));
+    }
+    for (src_label, items) in &grouped {
+        conflicts.extend(crate::conflict::detect_conflicts(items, &lock, src_label));
+    }
+} else {
+    let mut seen = std::collections::BTreeSet::new();
+    let incoming: Vec<(ItemKind, String)> = scanned_items
+        .iter()
+        .filter(|(_, n)| !options.excludes.contains(n))
+        .filter(|(_, n)| items.is_empty() || items.contains(n))
+        .filter_map(|(kind, name)| {
+            let effective_name = options
+                .aliases
+                .iter()
+                .find(|(from, _)| from.is_empty() || *from == *name)
+                .map(|(_, to)| to.clone())
+                .unwrap_or_else(|| name.clone());
+            if seen.insert((*kind, effective_name.clone())) {
+                Some((*kind, effective_name))
+            } else {
+                None
+            }
+        })
+        .collect();
+    conflicts.extend(crate::conflict::detect_conflicts(&incoming, &lock, &label));
+}
+if !conflicts.is_empty() && !options.force {
+    anyhow::bail!("{}", crate::conflict::format_conflict_error(&conflicts));
+}
+```
+
+- [ ] **Step 11: Rewire the install branch in `mod.rs` to install per source**
+
+Replace the install block (currently lines ~282-292, `let mut report = if let Some(closure) ...`) with a per-source loop. Cross-source `TempDir` guards live in `closure.guards`, which stays in scope until the end of the function:
+
+```rust
+// -- Now proceed with generation (files are written here) --
+// With a closure, install each source's resolved items from that
+// source's own fetched root. Without one (bundle file / name
+// resolution), keep the existing dispatch.
+let mut report = if let Some(closure) = &closure {
+    let mut r = InstallReport::default();
+    for si in closure.by_source.values() {
+        let part = install_from_local_path(&si.root, target, Some(&si.items))?;
+        r.items.extend(part.items);
+        r.bundles.extend(part.bundles);
+    }
+    r
+} else if items.is_empty() {
+    install_from_local_path(&local_source, target, None)?
+} else {
+    install_with_name_resolution_from_local(&local_source, target, items)?
+};
+```
+
+- [ ] **Step 12: Rewire the lockfile recording in `mod.rs` to per-item source**
+
+The `provenance` map construction (from `closure.required_by`) is unchanged. Replace the `items_from_report` call (currently ~lines 364-367) and keep `hashes` as-is. Note the `git_ref` binding is now defined earlier (Step 9), so the bundle-recording code below it still works:
+
+```rust
+let item_source_lookup = |kind: ItemKind, name: &str| -> (String, Option<String>) {
+    if let Some(closure) = &closure
+        && let Some(src_label) = closure.item_source.get(&(kind, name.to_string()))
+    {
+        let gr = closure
+            .by_source
+            .get(src_label)
+            .and_then(|si| si.git_ref.clone());
+        return (src_label.clone(), gr);
+    }
+    (label.clone(), git_ref.map(str::to_string))
+};
+let new_items = crate::lockfile::items_from_report(
+    &report,
+    item_source_lookup,
+    &provenance,
+    |k, n| hashes.get(&(k, n.to_string())).cloned().flatten(),
+);
+```
+
+(Leave the `for mut item in new_items { ... lock.upsert(item); }` loop, the alias `source_name` fix-up, the bundle-recording loop using `label`/`git_ref`, and the plugin/ancillary tails unchanged.)
+
+- [ ] **Step 13: Build and run all library unit tests**
+
+Run: `just assemble` then `cargo test -p upskill --lib`
+Expected: PASS — all `install.rs` closure tests (including the new `closure_pulls_cross_source_dependency`, `closure_rejects_cross_source_cycle`, `closure_errors_on_missing_cross_source_item`), the `lockfile.rs` `items_from_report_dedupes_per_kind_name`, and every pre-existing test compile and pass. Fix any borrow/type errors surfaced by the compiler before moving on.
+
+- [ ] **Step 14: Run the full existing test suite to confirm no regressions**
+
+Run: `just test`
+Expected: PASS — the Slice 1 integration tests (`cli_add`, `pipeline_*`, `generate_*`) still pass; same-source closure behavior is preserved.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/pipeline/install.rs src/pipeline/mod.rs src/lockfile.rs
+git commit -m "feat(pipeline): resolve cross-source requires into a per-source install closure"
+```
+
+---
+
+## Task 2: ATDD — cross-source happy path
+
+**Files:**
+
+- Create: `tests/cross_source_requires.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/cross_source_requires.rs` with the shared helper plus the happy-path test. Local-path "other source" `source-b`; entry source `source-a` whose agent requires B's skill. Isolated fake `$HOME` + `.git` marker per issue #193.
+
+```rust
+//! ATDD: cross-source `requires` resolution (ADR-0009 / format-spec §3.7).
+//!
+//! The "other source" is a local-path SSOT root — a valid `add`-DSL locator
+//! that flows through `parse_install_source` -> `fetch_ssot` (LocalPath arm)
+//! -> per-source install, exercising the whole cross-source path offline.
+
+mod common;
+
+use common::upskill_cmd;
+use std::fs;
+use std::path::Path;
+
+fn write_item(root: &Path, kind: &str, name: &str, extra: &str) {
+    let dir = root.join(name);
+    fs::create_dir_all(&dir).unwrap();
+    let entry = match kind {
+        "skill" => "SKILL.md",
+        "rule" => "RULE.md",
+        "agent" => "AGENT.md",
+        _ => unreachable!(),
+    };
+    let body =
+        format!("---\nschema: 1\nname: {name}\ndescription: test {name}\n{extra}---\n# {name}\n");
+    fs::write(dir.join(entry), body).unwrap();
+}
+
+fn read_lock(project: &Path) -> serde_json::Value {
+    let raw = fs::read_to_string(project.join(".upskill-lock.json")).unwrap();
+    serde_json::from_str(&raw).unwrap()
+}
+
+#[test]
+fn cross_source_requires_pulls_and_records_dependency() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let source_b = tmp.path().join("source-b");
+    write_item(&source_b, "skill", "sarif-formatting", "");
+
+    let source_a = tmp.path().join("source-a");
+    write_item(
+        &source_a,
+        "agent",
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif-formatting, source: {} }}]\n",
+            source_b.display()
+        ),
+    );
+
+    let project = tmp.path().join("project");
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", source_a.to_str().unwrap(), "code-review"])
+        .assert()
+        .success();
+
+    // The dependency skill is generated alongside the requested agent.
+    assert!(
+        project
+            .join(".claude/skills/sarif-formatting/SKILL.md")
+            .exists(),
+        "cross-source dependency skill must be generated"
+    );
+
+    // Lockfile records the dependency with ITS OWN source + provenance.
+    let lock = read_lock(&project);
+    let items = lock["items"].as_array().unwrap();
+    let sarif = items
+        .iter()
+        .find(|i| i["name"] == "sarif-formatting" && i["kind"] == "skill")
+        .expect("sarif-formatting in lockfile");
+    assert_eq!(
+        sarif["source"].as_str().unwrap(),
+        format!("local:{}", source_b.display())
+    );
+    assert_eq!(sarif["required_by"][0], "agent:code-review");
+
+    // The requested agent records the ENTRY source.
+    let agent = items
+        .iter()
+        .find(|i| i["name"] == "code-review" && i["kind"] == "agent")
+        .expect("code-review in lockfile");
+    assert_eq!(
+        agent["source"].as_str().unwrap(),
+        format!("local:{}", source_a.display())
+    );
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test --test cross_source_requires cross_source_requires_pulls_and_records_dependency`
+Expected: PASS (Task 1 already implemented the behavior). If the `.claude/skills/...` path assertion fails, confirm the skill output path via `src/pipeline/output.rs::output_path` and adjust the asserted path — do not change production code.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/cross_source_requires.rs
+git commit -m "test(pipeline): ATDD cross-source requires happy path"
+```
+
+---
+
+## Task 3: ATDD — transitive cross-source closure
+
+**Files:**
+
+- Modify: `tests/cross_source_requires.rs`
+
+- [ ] **Step 1: Add the transitive test**
+
+A→B→C chain across three sources: agent in A requires skill in B; that skill requires a rule in C. All three install; each records its own source.
+
+```rust
+#[test]
+fn cross_source_requires_resolves_transitively() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let source_c = tmp.path().join("source-c");
+    write_item(&source_c, "rule", "security-baseline", "");
+
+    let source_b = tmp.path().join("source-b");
+    write_item(
+        &source_b,
+        "skill",
+        "sarif-formatting",
+        &format!(
+            "requires:\n  rules: [{{ name: security-baseline, source: {} }}]\n",
+            source_c.display()
+        ),
+    );
+
+    let source_a = tmp.path().join("source-a");
+    write_item(
+        &source_a,
+        "agent",
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif-formatting, source: {} }}]\n",
+            source_b.display()
+        ),
+    );
+
+    let project = tmp.path().join("project");
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", source_a.to_str().unwrap(), "code-review"])
+        .assert()
+        .success();
+
+    let lock = read_lock(&project);
+    let items = lock["items"].as_array().unwrap();
+    let baseline = items
+        .iter()
+        .find(|i| i["name"] == "security-baseline" && i["kind"] == "rule")
+        .expect("transitive rule in lockfile");
+    assert_eq!(
+        baseline["source"].as_str().unwrap(),
+        format!("local:{}", source_c.display())
+    );
+    assert_eq!(baseline["required_by"][0], "skill:sarif-formatting");
+    assert!(
+        project
+            .join(".github/instructions/security-baseline.instructions.md")
+            .exists()
+            || project.join(".claude/rules").exists()
+            || items.len() == 3,
+        "the transitive rule must be installed; saw {} items",
+        items.len()
+    );
+}
+```
+
+> Note: the rule output path varies per client; the lockfile assertion (`baseline.source` + `required_by`) is the authoritative check. Trim the final `||` assertion to the confirmed rule output path during execution if desired.
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test --test cross_source_requires cross_source_requires_resolves_transitively`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/cross_source_requires.rs
+git commit -m "test(pipeline): ATDD transitive cross-source closure"
+```
+
+---
+
+## Task 4: ATDD — cross-source conflict is an error
+
+**Files:**
+
+- Modify: `tests/cross_source_requires.rs`
+
+- [ ] **Step 1: Add the conflict test**
+
+Pre-install `sarif-formatting` from source C, then add source A (which pulls `sarif-formatting` from a _different_ source B). The closure-vs-lockfile conflict must abort with the existing "already installed" message and a non-zero exit.
+
+```rust
+#[test]
+fn cross_source_conflict_with_existing_install_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    // Source C provides sarif-formatting directly.
+    let source_c = tmp.path().join("source-c");
+    write_item(&source_c, "skill", "sarif-formatting", "");
+
+    // Source B also provides sarif-formatting (different source).
+    let source_b = tmp.path().join("source-b");
+    write_item(&source_b, "skill", "sarif-formatting", "");
+
+    // Source A's agent requires sarif-formatting FROM B.
+    let source_a = tmp.path().join("source-a");
+    write_item(
+        &source_a,
+        "agent",
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif-formatting, source: {} }}]\n",
+            source_b.display()
+        ),
+    );
+
+    let project = tmp.path().join("project");
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    // First, install sarif-formatting from C.
+    upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", source_c.to_str().unwrap(), "sarif-formatting"])
+        .assert()
+        .success();
+
+    // Now adding A pulls sarif-formatting from B — conflict with C.
+    upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", source_a.to_str().unwrap(), "code-review"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("already installed"));
+}
+```
+
+This test uses `predicates` (an `assert_cmd` companion already in the dev-dependency tree via `assert_cmd`). If `predicates` is not a direct dev-dependency, replace the `.stderr(...)` line with a manual check: capture `.get_output().stderr` and `assert!(String::from_utf8_lossy(...).contains("already installed"))` — but first try `predicates`, which `assert_cmd` re-exports patterns for.
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test --test cross_source_requires cross_source_conflict_with_existing_install_errors`
+Expected: PASS. If `predicates` is unavailable, switch to the manual stderr check described above and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/cross_source_requires.rs
+git commit -m "test(pipeline): ATDD cross-source conflict aborts"
+```
+
+---
+
+## Task 5: ATDD — cross-source cycle is an error
+
+**Files:**
+
+- Modify: `tests/cross_source_requires.rs`
+
+- [ ] **Step 1: Add the cycle test**
+
+A's rule `alpha` requires B's rule `beta` (cross), B's `beta` requires A's `alpha` (cross). `upskill add <A> alpha` must fail with "circular".
+
+```rust
+#[test]
+fn cross_source_cycle_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let source_a = tmp.path().join("source-a");
+    let source_b = tmp.path().join("source-b");
+    fs::create_dir_all(&source_a).unwrap();
+    fs::create_dir_all(&source_b).unwrap();
+
+    write_item(
+        &source_a,
+        "rule",
+        "alpha",
+        &format!(
+            "requires:\n  rules: [{{ name: beta, source: {} }}]\n",
+            source_b.display()
+        ),
+    );
+    write_item(
+        &source_b,
+        "rule",
+        "beta",
+        &format!(
+            "requires:\n  rules: [{{ name: alpha, source: {} }}]\n",
+            source_a.display()
+        ),
+    );
+
+    let project = tmp.path().join("project");
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", source_a.to_str().unwrap(), "alpha"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("circular"));
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test --test cross_source_requires cross_source_cycle_errors`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/cross_source_requires.rs
+git commit -m "test(pipeline): ATDD cross-source cycle aborts"
+```
+
+---
+
+## Task 6: ATDD — doctor flags an orphaned cross-source dependency after removal
+
+**Files:**
+
+- Modify: `tests/cross_source_requires.rs`
+
+- [ ] **Step 1: Add the doctor-orphan test**
+
+Install A's `code-review` (pulls B's `sarif-formatting`). Remove `code-review` (no cascade). `doctor` must report `sarif-formatting` as an orphaned dependency (advisory; exit 0).
+
+```rust
+#[test]
+fn removing_requirer_leaves_cross_source_dependency_as_doctor_orphan() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let source_b = tmp.path().join("source-b");
+    write_item(&source_b, "skill", "sarif-formatting", "");
+
+    let source_a = tmp.path().join("source-a");
+    write_item(
+        &source_a,
+        "agent",
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif-formatting, source: {} }}]\n",
+            source_b.display()
+        ),
+    );
+
+    let project = tmp.path().join("project");
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", source_a.to_str().unwrap(), "code-review"])
+        .assert()
+        .success();
+
+    // Remove the requirer; the dependency is NOT cascaded.
+    upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["remove", "code-review"])
+        .assert()
+        .success();
+
+    // The dependency is still recorded.
+    let lock = read_lock(&project);
+    assert!(
+        lock["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["name"] == "sarif-formatting"),
+        "removal must not cascade to the dependency"
+    );
+
+    // doctor surfaces it as an orphaned dependency (advisory → exit 0).
+    upskill_cmd(&home)
+        .current_dir(&project)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("sarif-formatting"));
+}
+```
+
+> During execution, confirm `main.rs`'s doctor presentation includes orphaned-dependency item names in stdout. If the wording differs (e.g. the name is only shown under an "orphaned dependencies" heading), keep the `contains("sarif-formatting")` check — it is robust to heading wording. Adjust only if doctor omits the name entirely.
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test --test cross_source_requires removing_requirer_leaves_cross_source_dependency_as_doctor_orphan`
+Expected: PASS
+
+- [ ] **Step 3: Run the whole new test file**
+
+Run: `cargo test --test cross_source_requires`
+Expected: PASS — all six tests green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/cross_source_requires.rs
+git commit -m "test(pipeline): ATDD doctor flags orphaned cross-source dependency"
+```
+
+---
+
+## Task 7: Documentation — flip cross-source to implemented
+
+**Files:**
+
+- Modify: `docs/format-spec.md` (§3.7 item-requires resolution, §11 item 7)
+- Modify: `docs/adr/0009-coupling-tiers-and-dependencies.md` (Cross-source contract staging bullet + Consequences)
+
+- [ ] **Step 1: Update format-spec §3.7**
+
+In `docs/format-spec.md`, replace the trailing paragraph of "Item `requires` resolution" (currently lines ~692-696):
+
+Old:
+
+```markdown
+Each `requires.<kind>` entry is a bare name (same source) or a `{ name, source }` map
+(cross-source), where `source` reuses the `upskill add` source DSL. Same-source resolution
+(bare-name entries against the entry item's own already-fetched source) is implemented in the
+initial release; cross-source resolution (`{ name, source }` entries) is specified here but
+lands in a later release.
+```
+
+New:
+
+```markdown
+Each `requires.<kind>` entry is a bare name (same source) or a `{ name, source }` map
+(cross-source), where `source` reuses the `upskill add` source DSL. Same-source resolution
+(bare-name entries against the entry item's own already-fetched source) and cross-source
+resolution (`{ name, source }` entries) are both implemented: a cross-source entry is fetched
+via the same machinery as `upskill add` (a distinct source is fetched once and cached for the
+duration of the resolution), the transitive closure MAY span sources, and each
+dependency-pulled item is recorded in the lockfile with its **own** `source` (and `ref`) plus
+a `required_by` provenance list. Cycle detection is keyed by `(canonical-source-label, kind,
+name)`; the same `(kind, name)` resolving to two different sources within one closure — or
+conflicting with an existing different-source install — is an error. There is no version-range
+solving.
+```
+
+- [ ] **Step 2: Update format-spec §11 item 7**
+
+Replace the "Same-source resolution is implemented; cross-source resolution is staged to a later release." sentence (currently lines ~1047-1049) with:
+
+```markdown
+`(canonical-source-label, kind, name)`. Both same-source and cross-source resolution are
+implemented. See
+[ADR-0009](./adr/0009-coupling-tiers-and-dependencies.md).
+```
+
+- [ ] **Step 3: Update ADR-0009 cross-source staging bullet**
+
+In `docs/adr/0009-coupling-tiers-and-dependencies.md`, replace the "Staging" bullet (currently lines ~115-116):
+
+Old:
+
+```markdown
+- **Staging.** Cross-source resolution ships in a follow-up release (Slice 2);
+  same-source resolution ships now (Slice 1).
+```
+
+New:
+
+```markdown
+- **Status.** Both same-source (Slice 1) and cross-source (Slice 2) resolution
+  are implemented. A cross-source `source` is fetched once and cached for the
+  duration of one resolution; the transitive closure may span sources.
+```
+
+- [ ] **Step 4: Update ADR-0009 negative-consequences bullet**
+
+Replace the "Cross-source resolution is staged to a later release..." bullet (currently lines ~146-147) with:
+
+```markdown
+- A cross-source closure fetches each distinct source once per resolution
+  (no shared on-disk cache across separate `upskill add` invocations); a large
+  multi-source dependency graph therefore re-fetches its sources on each install.
+```
+
+- [ ] **Step 5: Format and lint the docs**
+
+Run: `just fmt`
+Expected: Markdown reflowed; no errors. Then `markdownlint` runs under `just lint` later.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/format-spec.md docs/adr/0009-coupling-tiers-and-dependencies.md
+git commit -m "docs: cross-source requires resolution is implemented (Slice 2)"
+```
+
+---
+
+## Task 8: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format everything**
+
+Run: `just fmt`
+Expected: no changes needed (or only whitespace already committed).
+
+- [ ] **Step 2: Full gate**
+
+Run: `just verify`
+Expected: PASS — `cargo clippy -- -D warnings` (zero warnings), `cargo fmt --check`, dprint, markdownlint, shellcheck, and the full test suite all green. Fix any clippy findings (watch for `too_many_arguments` on `Resolver::visit` — it takes `&mut self` + 2 args, so it is fine; and `clippy::type_complexity` on the closure maps — extract type aliases only if clippy flags them).
+
+- [ ] **Step 3: Confirm the cross-source seam no longer bails**
+
+Run: `grep -rn "not yet available" src/`
+Expected: no matches — the Slice 1 bail message is gone.
+
+- [ ] **Step 4: Commit any verification fixups, then hand off**
+
+If `just verify` required fixes, commit them:
+
+```bash
+git add -A
+git commit -m "chore: satisfy verify gate for cross-source slice"
+```
+
+Then proceed to `superpowers:finishing-a-development-branch` to open the PR (`just fmt` + `just verify` already green; one PR for the slice; squash-merge).
+
+---
+
+## Self-Review
+
+**Spec coverage (design spec §2.5 / ADR-0009 cross-source contract):**
+
+- `source` reuses the `add` DSL, parsed by `parse_install_source`, fetched by `fetch_ssot` → Task 1 Step 3 (`Resolver::ensure_source`).
+- Transitive closure spans sources → Task 1 (`visit` recurses across labels); Task 3 ATDD.
+- Cycle detection keyed `(canonical-source-label, kind, name)` → Task 1 (`on_path` keyed `(label, kind, name)`); Task 5 ATDD.
+- Conflict: same `(kind, name)` different source/ref is an error, reusing `conflict.rs` → Task 1 (`item_label` for in-closure clash) + Task 1 Step 10 (per-source `detect_conflicts` vs lockfile); Task 4 ATDD.
+- Dependency-pulled items recorded with own source + `required_by` → Task 1 Steps 7/12; Task 2 ATDD.
+- Removal never cascades; doctor flags orphan → no production change needed (Slice 1 doctor); Task 6 ATDD.
+- No version solving / SAT → nothing added; documented in Task 7.
+- Docs flipped to implemented → Task 7.
+
+**Placeholder scan:** every code step shows complete code; commands list exact invocations + expected outcomes. No TBD/TODO.
+
+**Type consistency:** `DependencyClosure { by_source: BTreeMap<String, SourceInstall>, item_source: BTreeMap<(ItemKind,String), String>, required_by, guards }`, `SourceInstall { root, git_ref, items }`, `resolve_requires_closure(entry_label, entry_root, entry_git_ref, initial)`, and `items_from_report(report, source_for, required_by, hash_for)` are used identically across Tasks 1, 2-6 (assertions), and the rewired `mod.rs`. `Resolver::visit(label, node, requirer)` and `ensure_source(src_dsl)` signatures are self-consistent.
+
+**Out-of-scope guardrails honored:** no version ranges/SAT, no auto-cascading removal, no path-based cross-source refs (always source-locator + name). Pre-1.0: the old single-source `DependencyClosure`/`resolve_requires_closure` shape is deleted outright (no back-compat); `items_from_report` signature changed in place.

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -243,15 +243,15 @@ fn lockfile_path(project_root: &Path) -> PathBuf {
 /// name)` (the report has one entry per kind × name × client; the lockfile
 /// records each item once).
 ///
-/// `source_label` is taken verbatim from the caller — typically the
-/// `Display` form of the [`InstallSource`] or the original CLI string.
-/// `git_ref` and `hash` are looked up by the caller (the pipeline) per
-/// item; threading them through here keeps the lockfile module free of
-/// filesystem and source concerns.
+/// `source_for` is a per-item `(label, ref)` lookup: it maps each `(kind,
+/// name)` to the `Display` form of the [`InstallSource`] it came from and
+/// that source's pinned ref. This lets cross-source dependency-pulled items
+/// record their own source rather than the entry source's. `hash` is looked
+/// up by the caller (the pipeline) per item; threading these through here
+/// keeps the lockfile module free of filesystem and source concerns.
 pub fn items_from_report(
     report: &InstallReport,
-    source_label: &str,
-    git_ref: Option<&str>,
+    source_for: impl Fn(ItemKind, &str) -> (String, Option<String>),
     required_by: &std::collections::BTreeMap<(ItemKind, String), Vec<String>>,
     mut hash_for: impl FnMut(ItemKind, &str) -> Option<String>,
 ) -> Vec<LockedItem> {
@@ -262,11 +262,12 @@ pub fn items_from_report(
         if !seen.insert((entry.kind, entry.name.clone())) {
             continue;
         }
+        let (source, git_ref) = source_for(entry.kind, &entry.name);
         out.push(LockedItem {
             kind: entry.kind,
             name: entry.name.clone(),
-            source: source_label.to_string(),
-            git_ref: git_ref.map(str::to_string),
+            source,
+            git_ref,
             hash: hash_for(entry.kind, &entry.name),
             source_name: None,
             required_by: required_by
@@ -437,8 +438,7 @@ mod tests {
 
         let items = items_from_report(
             &report,
-            "local:./src",
-            None,
+            |_, _| ("local:./src".to_string(), None),
             &std::collections::BTreeMap::new(),
             |_, _| Some("sha256:abc".into()),
         );

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -26,6 +26,7 @@ use super::{ALL_CLIENTS, InstallReport, InstalledItem, ItemKind, PluginResult};
 use crate::generate::{self, Client};
 use crate::model::{Agent, Audience, RequireRef, Rule, Skill};
 use crate::parse::frontmatter;
+use crate::source::{InstallSource, parse_install_source};
 
 /// Install every item under `source` into `target`, generating per-client
 /// output for each client unless filtered by the item's `audience` field.
@@ -160,22 +161,42 @@ pub(super) fn install_with_name_resolution_from_local(
 // Same-source `requires` transitive closure
 // ---------------------------------------------------------------------------
 
-/// The set of items reached by expanding a requested item set along
-/// same-source `requires` edges, plus per-item provenance recording which
-/// installed item(s) pulled each dependency in.
-#[derive(Debug)]
+/// The transitive closure of items reached by expanding a requested set
+/// along `requires` edges — possibly spanning multiple sources.
+#[derive(Debug, Default)]
 pub(super) struct DependencyClosure {
-    /// Every item to install: the requested set plus its transitive
-    /// same-source dependencies, deduplicated by `(kind, name)`.
-    pub items: crate::bundle::ResolvedItems,
+    /// Per canonical source label: the fetched root, its pinned ref, and
+    /// the items to install from it (in dependency order).
+    pub by_source: BTreeMap<String, SourceInstall>,
+    /// Canonical source label each resolved `(kind, name)` came from.
+    /// `(kind, name)` is globally unique within a valid closure (a clash
+    /// across sources is a conflict error), so this maps cleanly.
+    pub item_source: BTreeMap<(ItemKind, String), String>,
     /// `(kind, name) -> { "<requirer-kind>:<requirer-name>", .. }`. Empty
-    /// for directly-requested items; populated for items pulled in as a
-    /// dependency. Drives the lockfile's `required_by` provenance.
+    /// for directly-requested items. Drives the lockfile's `required_by`.
     pub required_by: BTreeMap<(ItemKind, String), BTreeSet<String>>,
+    /// Tempdir guards for cross-source fetches. Held here so the clones
+    /// outlive the per-source install calls in `install_with_lockfile`.
+    #[allow(dead_code)]
+    pub guards: Vec<tempfile::TempDir>,
 }
 
-/// Index every item in `source` by its effective `(kind, name)` identity,
-/// mapping to the item directory that holds its entrypoint.
+/// One source's contribution to a [`DependencyClosure`].
+#[derive(Debug)]
+pub(super) struct SourceInstall {
+    pub root: PathBuf,
+    pub git_ref: Option<String>,
+    pub items: crate::bundle::ResolvedItems,
+}
+
+/// A fetched-and-indexed source, cached by canonical label during DFS.
+struct FetchedSource {
+    root: PathBuf,
+    git_ref: Option<String>,
+    index: BTreeMap<(ItemKind, String), PathBuf>,
+}
+
+/// Index every item in `source` by its effective `(kind, name)` identity.
 fn index_source(source: &Path) -> Result<BTreeMap<(ItemKind, String), PathBuf>> {
     let mut idx = BTreeMap::new();
     for (folder, dir) in iter_item_dirs(source)? {
@@ -191,13 +212,8 @@ fn index_source(source: &Path) -> Result<BTreeMap<(ItemKind, String), PathBuf>> 
 }
 
 /// Parse an item's `requires` block. For agents, fold `preload_skills` into
-/// `requires.skills` (a preloaded skill is implicitly required).
-///
-/// A preloaded skill that is absent from the source index is treated as a
-/// runtime hint, not a hard SSOT dependency, and is NOT folded in: agents
-/// may preload built-in or separately-installed skills that this registry
-/// does not vend. Explicit `requires` entries remain strict and are never
-/// dropped — a missing one bails later in `visit_requires`.
+/// `requires.skills` softly (a preloaded skill present in the SAME source is
+/// implicitly required; an absent one is a runtime hint, skipped).
 fn read_item_requires(
     dir: &Path,
     kind: ItemKind,
@@ -223,115 +239,202 @@ fn read_item_requires(
     Ok(req)
 }
 
-/// Expand `initial` along same-source `requires` edges into the full set of
-/// items to install, recording dependency provenance.
-///
-/// Resolution identity is the effective `(kind, name)`. Cross-source
-/// `{ name, source }` requires entries are NOT resolved in this release —
-/// they bail with a clear error. Dependency cycles bail with a "circular"
-/// error. A required item missing from the source bails with a "not found"
-/// error.
-pub(super) fn resolve_requires_closure(
-    source: &Path,
-    initial: &[(ItemKind, String)],
-) -> Result<DependencyClosure> {
-    let index = index_source(source)?;
-
-    let mut required_by: BTreeMap<(ItemKind, String), BTreeSet<String>> = BTreeMap::new();
-    let mut resolved: BTreeSet<(ItemKind, String)> = BTreeSet::new();
-    let mut order: Vec<(ItemKind, String)> = Vec::new();
-    let mut on_path: BTreeSet<(ItemKind, String)> = BTreeSet::new();
-
-    for node in initial {
-        visit_requires(
-            &index,
-            node,
-            None,
-            &mut required_by,
-            &mut resolved,
-            &mut order,
-            &mut on_path,
-        )?;
-    }
-
-    let mut items = crate::bundle::ResolvedItems::default();
-    for (kind, name) in order {
-        match kind {
-            ItemKind::Rule => items.rules.push(name),
-            ItemKind::Skill => items.skills.push(name),
-            ItemKind::Agent => items.agents.push(name),
-        }
-    }
-
-    Ok(DependencyClosure { items, required_by })
+/// DFS state for [`resolve_requires_closure`]. Carries the fetch cache so a
+/// source pulled by two edges is fetched once, and the visited/on-path sets
+/// keyed for cross-source cycle and conflict detection.
+struct Resolver {
+    /// Canonical label -> fetched-and-indexed source.
+    sources: BTreeMap<String, FetchedSource>,
+    /// Tempdir guards for cross-source clones (drained into the closure).
+    guards: Vec<tempfile::TempDir>,
+    /// Fully-resolved identities (dedup).
+    resolved: BTreeSet<(ItemKind, String)>,
+    /// The label each identity resolved under — second visit under a
+    /// different label is a cross-source conflict.
+    item_label: BTreeMap<(ItemKind, String), String>,
+    /// Dependency-order accumulation.
+    order: Vec<(ItemKind, String)>,
+    /// On-path set keyed by `(label, kind, name)` for cycle detection (§2.5).
+    on_path: BTreeSet<(String, ItemKind, String)>,
+    /// Dependency provenance keyed by identity.
+    required_by: BTreeMap<(ItemKind, String), BTreeSet<String>>,
 }
 
-#[allow(clippy::too_many_arguments)]
-fn visit_requires(
-    index: &BTreeMap<(ItemKind, String), PathBuf>,
-    node: &(ItemKind, String),
-    requirer: Option<&(ItemKind, String)>,
-    required_by: &mut BTreeMap<(ItemKind, String), BTreeSet<String>>,
-    resolved: &mut BTreeSet<(ItemKind, String)>,
-    order: &mut Vec<(ItemKind, String)>,
-    on_path: &mut BTreeSet<(ItemKind, String)>,
-) -> Result<()> {
-    let (kind, name) = node;
-
-    let dir = index.get(node).ok_or_else(|| {
-        anyhow::anyhow!("{kind} `{name}` is required but not found in the source")
-    })?;
-
-    // Record provenance when reached via a requirer (even if already
-    // resolved — multiple installed items may require the same dependency).
-    // Directly-requested items (no requirer) get no entry here; they appear
-    // in the map only if also pulled in elsewhere.
-    if let Some((rk, rn)) = requirer {
-        required_by
-            .entry(node.clone())
-            .or_default()
-            .insert(format!("{rk}:{rn}"));
-    }
-
-    if resolved.contains(node) {
-        return Ok(());
-    }
-    if on_path.contains(node) {
-        anyhow::bail!("circular dependency detected including {kind} `{name}`");
-    }
-    on_path.insert(node.clone());
-
-    let requires = read_item_requires(dir, *kind, index)?;
-    for (dep_kind, refs) in [
-        (ItemKind::Rule, &requires.rules),
-        (ItemKind::Skill, &requires.skills),
-        (ItemKind::Agent, &requires.agents),
-    ] {
-        for r in refs {
-            if let Some(src) = r.source() {
-                let rname = r.name();
-                anyhow::bail!(
-                    "{kind} `{name}` requires {dep_kind} `{rname}` from cross-source `{src}`: \
-                     cross-source dependency resolution is not yet available in this release"
-                );
+impl Resolver {
+    /// Ensure `src_dsl` (an `add`-DSL locator) is fetched and indexed;
+    /// return its canonical label.
+    fn ensure_source(&mut self, src_dsl: &str) -> Result<String> {
+        let install_source = parse_install_source(src_dsl)
+            .map_err(|e| anyhow::anyhow!("parse requires source `{src_dsl}`: {e}"))?;
+        let label = install_source.to_string();
+        if !self.sources.contains_key(&label) {
+            let (root, guard) = super::git::fetch_ssot(&install_source)
+                .with_context(|| format!("fetch requires source `{label}`"))?;
+            let index = index_source(&root)?;
+            if let Some(g) = guard {
+                self.guards.push(g);
             }
-            let dep = (dep_kind, r.name().to_string());
-            visit_requires(
-                index,
-                &dep,
-                Some(node),
-                required_by,
-                resolved,
-                order,
-                on_path,
-            )?;
+            self.sources.insert(
+                label.clone(),
+                FetchedSource {
+                    root,
+                    git_ref: source_git_ref(&install_source),
+                    index,
+                },
+            );
         }
+        Ok(label)
     }
 
-    on_path.remove(node);
-    resolved.insert(node.clone());
-    order.push(node.clone());
-    Ok(())
+    fn visit(
+        &mut self,
+        label: &str,
+        node: (ItemKind, String),
+        requirer: Option<&(ItemKind, String)>,
+    ) -> Result<()> {
+        let (kind, name) = node.clone();
+
+        // Cross-source identity conflict: the same (kind, name) reached from
+        // two different sources (format-spec §3.7).
+        if let Some(prev) = self.item_label.get(&node)
+            && prev != label
+        {
+            anyhow::bail!(
+                "{kind} `{name}` is required from two different sources: `{prev}` and `{label}`"
+            );
+        }
+
+        let dir = self
+            .sources
+            .get(label)
+            .expect("source fetched before visit")
+            .index
+            .get(&node)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow::anyhow!("{kind} `{name}` is required but not found in source `{label}`")
+            })?;
+
+        if let Some((rk, rn)) = requirer {
+            self.required_by
+                .entry(node.clone())
+                .or_default()
+                .insert(format!("{rk}:{rn}"));
+        }
+
+        if self.resolved.contains(&node) {
+            return Ok(());
+        }
+        let path_key = (label.to_string(), kind, name.clone());
+        if self.on_path.contains(&path_key) {
+            anyhow::bail!("circular dependency detected including {kind} `{name}`");
+        }
+        self.on_path.insert(path_key.clone());
+        self.item_label.insert(node.clone(), label.to_string());
+
+        let requires = {
+            let index = &self.sources.get(label).expect("source present").index;
+            read_item_requires(&dir, kind, index)?
+        };
+        for (dep_kind, refs) in [
+            (ItemKind::Rule, &requires.rules),
+            (ItemKind::Skill, &requires.skills),
+            (ItemKind::Agent, &requires.agents),
+        ] {
+            for r in refs {
+                let dep = (dep_kind, r.name().to_string());
+                match r.source() {
+                    None => self.visit(label, dep, Some(&node))?,
+                    Some(src_dsl) => {
+                        let dep_label = self.ensure_source(src_dsl)?;
+                        self.visit(&dep_label, dep, Some(&node))?;
+                    }
+                }
+            }
+        }
+
+        self.on_path.remove(&path_key);
+        self.resolved.insert(node.clone());
+        self.order.push(node);
+        Ok(())
+    }
+}
+
+fn source_git_ref(s: &InstallSource) -> Option<String> {
+    match s {
+        InstallSource::Github(r) => r.git_ref.clone(),
+        InstallSource::Gitlab(r) => r.git_ref.clone(),
+        InstallSource::LocalPath(_) => None,
+    }
+}
+
+/// Expand `initial` (identities in the already-fetched entry source) along
+/// `requires` edges into the full cross-source closure.
+///
+/// `entry_label` is the entry source's canonical label, `entry_root` its
+/// already-fetched root (seeded into the fetch cache so it is not re-fetched),
+/// `entry_git_ref` its pinned ref. Cross-source `{ name, source }` entries
+/// are fetched via [`fetch_ssot`], cached by canonical label. Cycles
+/// (keyed `(label, kind, name)`) and same-`(kind,name)`-different-source
+/// clashes are errors; a required item missing from its source is an error.
+pub(super) fn resolve_requires_closure(
+    entry_label: &str,
+    entry_root: &Path,
+    entry_git_ref: Option<&str>,
+    initial: &[(ItemKind, String)],
+) -> Result<DependencyClosure> {
+    let mut resolver = Resolver {
+        sources: BTreeMap::new(),
+        guards: Vec::new(),
+        resolved: BTreeSet::new(),
+        item_label: BTreeMap::new(),
+        order: Vec::new(),
+        on_path: BTreeSet::new(),
+        required_by: BTreeMap::new(),
+    };
+    resolver.sources.insert(
+        entry_label.to_string(),
+        FetchedSource {
+            root: entry_root.to_path_buf(),
+            git_ref: entry_git_ref.map(str::to_string),
+            index: index_source(entry_root)?,
+        },
+    );
+
+    for node in initial {
+        resolver.visit(entry_label, node.clone(), None)?;
+    }
+
+    let mut by_source: BTreeMap<String, SourceInstall> = BTreeMap::new();
+    let mut item_source: BTreeMap<(ItemKind, String), String> = BTreeMap::new();
+    for node in &resolver.order {
+        let label = resolver
+            .item_label
+            .get(node)
+            .cloned()
+            .expect("resolved item has a source");
+        let group = by_source.entry(label.clone()).or_insert_with(|| {
+            let fs = resolver.sources.get(&label).expect("source present");
+            SourceInstall {
+                root: fs.root.clone(),
+                git_ref: fs.git_ref.clone(),
+                items: crate::bundle::ResolvedItems::default(),
+            }
+        });
+        match node.0 {
+            ItemKind::Rule => group.items.rules.push(node.1.clone()),
+            ItemKind::Skill => group.items.skills.push(node.1.clone()),
+            ItemKind::Agent => group.items.agents.push(node.1.clone()),
+        }
+        item_source.insert(node.clone(), label);
+    }
+
+    Ok(DependencyClosure {
+        by_source,
+        item_source,
+        required_by: resolver.required_by,
+        guards: resolver.guards,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -759,12 +862,77 @@ mod tests {
         );
         write_item(src, ItemKind::Skill, "sarif", "");
 
-        let closure =
-            resolve_requires_closure(src, &[(ItemKind::Agent, "code-review".to_string())])
-                .expect("closure");
+        let closure = resolve_requires_closure(
+            "local:test",
+            src,
+            None,
+            &[(ItemKind::Agent, "code-review".to_string())],
+        )
+        .expect("closure");
 
-        assert!(closure.items.contains(ItemKind::Agent, "code-review"));
-        assert!(closure.items.contains(ItemKind::Skill, "sarif"));
+        assert!(
+            closure
+                .item_source
+                .contains_key(&(ItemKind::Agent, "code-review".to_string()))
+        );
+        assert!(
+            closure
+                .item_source
+                .contains_key(&(ItemKind::Skill, "sarif".to_string()))
+        );
+        let prov = closure
+            .required_by
+            .get(&(ItemKind::Skill, "sarif".to_string()))
+            .expect("sarif provenance");
+        assert!(prov.contains("agent:code-review"), "{prov:?}");
+    }
+
+    #[test]
+    fn closure_pulls_cross_source_dependency() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src_a = tmp.path().join("a");
+        let src_b = tmp.path().join("b");
+        std::fs::create_dir_all(&src_a).unwrap();
+        std::fs::create_dir_all(&src_b).unwrap();
+        write_item(&src_b, ItemKind::Skill, "sarif", "");
+        write_item(
+            &src_a,
+            ItemKind::Agent,
+            "code-review",
+            &format!(
+                "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+                src_b.display()
+            ),
+        );
+
+        let a_label = format!("local:{}", src_a.display());
+        let b_label = format!("local:{}", src_b.display());
+        let closure = resolve_requires_closure(
+            &a_label,
+            &src_a,
+            None,
+            &[(ItemKind::Agent, "code-review".to_string())],
+        )
+        .expect("closure");
+
+        assert_eq!(
+            closure
+                .item_source
+                .get(&(ItemKind::Agent, "code-review".to_string())),
+            Some(&a_label)
+        );
+        assert_eq!(
+            closure
+                .item_source
+                .get(&(ItemKind::Skill, "sarif".to_string())),
+            Some(&b_label)
+        );
+        assert!(
+            closure.by_source[&b_label]
+                .items
+                .skills
+                .contains(&"sarif".to_string())
+        );
         let prov = closure
             .required_by
             .get(&(ItemKind::Skill, "sarif".to_string()))
@@ -779,25 +947,120 @@ mod tests {
         write_item(src, ItemKind::Rule, "a", "requires:\n  rules: [b]\n");
         write_item(src, ItemKind::Rule, "b", "requires:\n  rules: [a]\n");
 
-        let err =
-            resolve_requires_closure(src, &[(ItemKind::Rule, "a".to_string())]).expect_err("cycle");
+        let err = resolve_requires_closure(
+            "local:test",
+            src,
+            None,
+            &[(ItemKind::Rule, "a".to_string())],
+        )
+        .expect_err("cycle");
         assert!(err.to_string().contains("circular"), "{err}");
     }
 
     #[test]
-    fn closure_errors_on_cross_source_entry() {
+    fn closure_errors_on_missing_cross_source_item() {
         let tmp = tempfile::tempdir().unwrap();
-        let src = tmp.path();
+        let src_a = tmp.path().join("a");
+        let src_b = tmp.path().join("b");
+        std::fs::create_dir_all(&src_a).unwrap();
+        std::fs::create_dir_all(&src_b).unwrap(); // exists but holds no `x`
         write_item(
-            src,
+            &src_a,
             ItemKind::Rule,
             "a",
-            "requires:\n  skills: [{ name: x, source: org/repo }]\n",
+            &format!(
+                "requires:\n  skills: [{{ name: x, source: {} }}]\n",
+                src_b.display()
+            ),
         );
 
-        let err = resolve_requires_closure(src, &[(ItemKind::Rule, "a".to_string())])
-            .expect_err("cross-source");
-        assert!(err.to_string().contains("cross-source"), "{err}");
+        let err = resolve_requires_closure(
+            &format!("local:{}", src_a.display()),
+            &src_a,
+            None,
+            &[(ItemKind::Rule, "a".to_string())],
+        )
+        .expect_err("missing cross-source item");
+        assert!(err.to_string().contains("not found in source"), "{err}");
+    }
+
+    #[test]
+    fn closure_rejects_cross_source_cycle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src_a = tmp.path().join("a");
+        let src_b = tmp.path().join("b");
+        std::fs::create_dir_all(&src_a).unwrap();
+        std::fs::create_dir_all(&src_b).unwrap();
+        write_item(
+            &src_a,
+            ItemKind::Rule,
+            "alpha",
+            &format!(
+                "requires:\n  rules: [{{ name: beta, source: {} }}]\n",
+                src_b.display()
+            ),
+        );
+        write_item(
+            &src_b,
+            ItemKind::Rule,
+            "beta",
+            &format!(
+                "requires:\n  rules: [{{ name: alpha, source: {} }}]\n",
+                src_a.display()
+            ),
+        );
+
+        let err = resolve_requires_closure(
+            &format!("local:{}", src_a.display()),
+            &src_a,
+            None,
+            &[(ItemKind::Rule, "alpha".to_string())],
+        )
+        .expect_err("cross-source cycle");
+        assert!(err.to_string().contains("circular"), "{err}");
+    }
+
+    #[test]
+    fn closure_rejects_same_item_from_two_sources() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = tmp.path().join("entry");
+        let src_b = tmp.path().join("b");
+        let src_c = tmp.path().join("c");
+        std::fs::create_dir_all(&entry).unwrap();
+        std::fs::create_dir_all(&src_b).unwrap();
+        std::fs::create_dir_all(&src_c).unwrap();
+        write_item(&src_b, ItemKind::Skill, "sarif", "");
+        write_item(&src_c, ItemKind::Skill, "sarif", "");
+        write_item(
+            &entry,
+            ItemKind::Rule,
+            "wants-b",
+            &format!(
+                "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+                src_b.display()
+            ),
+        );
+        write_item(
+            &entry,
+            ItemKind::Rule,
+            "wants-c",
+            &format!(
+                "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+                src_c.display()
+            ),
+        );
+
+        let err = resolve_requires_closure(
+            &format!("local:{}", entry.display()),
+            &entry,
+            None,
+            &[
+                (ItemKind::Rule, "wants-b".to_string()),
+                (ItemKind::Rule, "wants-c".to_string()),
+            ],
+        )
+        .expect_err("conflict");
+        assert!(err.to_string().contains("two different sources"), "{err}");
     }
 
     #[test]
@@ -812,11 +1075,19 @@ mod tests {
         );
         write_item(src, ItemKind::Skill, "sarif", "");
 
-        let closure =
-            resolve_requires_closure(src, &[(ItemKind::Agent, "code-review".to_string())])
-                .expect("closure");
+        let closure = resolve_requires_closure(
+            "local:test",
+            src,
+            None,
+            &[(ItemKind::Agent, "code-review".to_string())],
+        )
+        .expect("closure");
 
-        assert!(closure.items.contains(ItemKind::Skill, "sarif"));
+        assert!(
+            closure
+                .item_source
+                .contains_key(&(ItemKind::Skill, "sarif".to_string()))
+        );
         let prov = closure
             .required_by
             .get(&(ItemKind::Skill, "sarif".to_string()))
@@ -835,11 +1106,24 @@ mod tests {
             "preload-skills: [missing-skill]\n",
         );
 
-        let closure = resolve_requires_closure(src, &[(ItemKind::Agent, "reviewer".to_string())])
-            .expect("closure");
+        let closure = resolve_requires_closure(
+            "local:test",
+            src,
+            None,
+            &[(ItemKind::Agent, "reviewer".to_string())],
+        )
+        .expect("closure");
 
-        assert!(closure.items.contains(ItemKind::Agent, "reviewer"));
-        assert!(!closure.items.contains(ItemKind::Skill, "missing-skill"));
+        assert!(
+            closure
+                .item_source
+                .contains_key(&(ItemKind::Agent, "reviewer".to_string()))
+        );
+        assert!(
+            !closure
+                .item_source
+                .contains_key(&(ItemKind::Skill, "missing-skill".to_string()))
+        );
         assert!(
             !closure
                 .required_by

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -191,7 +191,7 @@ pub fn install_with_lockfile(
         }
     }
 
-    // -- Same-source `requires` closure --
+    // -- `requires` dependency closure (same- and cross-source) --
     // The directly-requested item set, keyed on effective names from
     // `scan_source_items` and respecting the `items` filter and excludes.
     // Bundle-file sources resolve their own items, so the item-level
@@ -219,43 +219,53 @@ pub fn install_with_lockfile(
             || items
                 .iter()
                 .any(|n| discovery::find_bundle_by_name(&local_source, n).is_some()));
+    let git_ref = match source {
+        InstallSource::Github(r) => r.git_ref.as_deref(),
+        InstallSource::Gitlab(r) => r.git_ref.as_deref(),
+        InstallSource::LocalPath(_) => None,
+    };
     let closure = if discovery::is_bundle_file(&local_source) || defer_to_name_resolution {
         None
     } else {
-        Some(resolve_requires_closure(&local_source, &requested)?)
+        Some(resolve_requires_closure(
+            &label,
+            &local_source,
+            git_ref,
+            &requested,
+        )?)
     };
 
     // -- Conflict detection (before any files are written) --
-    // When a closure is present, conflict detection runs over the closure's
-    // full item set so a pulled dependency that collides with an existing
-    // different-source install is caught. Directly-named items still honor
-    // `--as` aliasing; pulled dependencies are never aliased.
     let mut lock = crate::lockfile::Lockfile::load(target)?;
-    let incoming: Vec<(ItemKind, String)> = if let Some(closure) = &closure {
-        let mut seen = std::collections::BTreeSet::new();
-        let mut out = Vec::new();
-        for kind in [ItemKind::Rule, ItemKind::Skill, ItemKind::Agent] {
-            let names = match kind {
-                ItemKind::Rule => &closure.items.rules,
-                ItemKind::Skill => &closure.items.skills,
-                ItemKind::Agent => &closure.items.agents,
-            };
-            for name in names {
-                let effective_name = options
+    let mut conflicts = Vec::new();
+    if let Some(closure) = &closure {
+        // Group incoming items by their canonical source label; conflicts
+        // are per (kind, name, source). Aliases apply only to entry-source
+        // items — dependency-pulled items are never aliased.
+        let mut grouped: std::collections::BTreeMap<String, Vec<(ItemKind, String)>> =
+            std::collections::BTreeMap::new();
+        for ((kind, name), src_label) in &closure.item_source {
+            let effective = if *src_label == label {
+                options
                     .aliases
                     .iter()
                     .find(|(from, _)| from.is_empty() || *from == *name)
                     .map(|(_, to)| to.clone())
-                    .unwrap_or_else(|| name.clone());
-                if seen.insert((kind, effective_name.clone())) {
-                    out.push((kind, effective_name));
-                }
-            }
+                    .unwrap_or_else(|| name.clone())
+            } else {
+                name.clone()
+            };
+            grouped
+                .entry(src_label.clone())
+                .or_default()
+                .push((*kind, effective));
         }
-        out
+        for (src_label, items) in &grouped {
+            conflicts.extend(crate::conflict::detect_conflicts(items, &lock, src_label));
+        }
     } else {
         let mut seen = std::collections::BTreeSet::new();
-        scanned_items
+        let incoming: Vec<(ItemKind, String)> = scanned_items
             .iter()
             .filter(|(_, n)| !options.excludes.contains(n))
             .filter(|(_, n)| items.is_empty() || items.contains(n))
@@ -272,19 +282,28 @@ pub fn install_with_lockfile(
                     None
                 }
             })
-            .collect()
-    };
-    let conflicts = crate::conflict::detect_conflicts(&incoming, &lock, &label);
+            .collect();
+        conflicts.extend(crate::conflict::detect_conflicts(&incoming, &lock, &label));
+    }
     if !conflicts.is_empty() && !options.force {
         anyhow::bail!("{}", crate::conflict::format_conflict_error(&conflicts));
     }
 
     // -- Now proceed with generation (files are written here) --
-    // With a closure, install exactly its resolved item set (requested
-    // items plus same-source dependencies). Without one (bundle file),
-    // keep the existing dispatch so the bundle branch runs.
+    // With a closure, install each source's resolved items from that
+    // source's own fetched root. Without one (bundle file / name
+    // resolution), keep the existing dispatch.
     let mut report = if let Some(closure) = &closure {
-        install_from_local_path(&local_source, target, Some(&closure.items))?
+        // The cross-source clone guards in `closure.guards` are held alive by
+        // the owned `closure` until after every source's items are installed;
+        // dropping them early would delete the fetched roots.
+        let mut r = InstallReport::default();
+        for si in closure.by_source.values() {
+            let part = install_from_local_path(&si.root, target, Some(&si.items))?;
+            r.items.extend(part.items);
+            r.bundles.extend(part.bundles);
+        }
+        r
     } else if items.is_empty() {
         install_from_local_path(&local_source, target, None)?
     } else {
@@ -308,10 +327,22 @@ pub fn install_with_lockfile(
     if !options.aliases.is_empty() {
         // Rename output files on disk and update report items.
         for item in &mut report.items {
-            let alias = options
-                .aliases
-                .iter()
-                .find(|(from, _)| from.is_empty() || *from == item.name);
+            // Only entry-source items are aliasable; dependency-pulled
+            // (cross-source) items are never renamed. When there is no
+            // closure (bundle / name-resolution paths), every item is
+            // treated as entry-source, preserving prior behavior.
+            let is_entry_source = closure
+                .as_ref()
+                .and_then(|c| c.item_source.get(&(item.kind, item.name.clone())))
+                .is_none_or(|l| *l == label);
+            let alias = if is_entry_source {
+                options
+                    .aliases
+                    .iter()
+                    .find(|(from, _)| from.is_empty() || *from == item.name)
+            } else {
+                None
+            };
             if let Some((_, alias_name)) = alias {
                 let old_path = target.join(&item.output_path);
                 let new_output = rename_output_path(&item.output_path, &item.name, alias_name);
@@ -339,11 +370,6 @@ pub fn install_with_lockfile(
         }
     }
 
-    let git_ref = match source {
-        InstallSource::Github(r) => r.git_ref.as_deref(),
-        InstallSource::Gitlab(r) => r.git_ref.as_deref(),
-        InstallSource::LocalPath(_) => None,
-    };
     let hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> = report
         .items
         .iter()
@@ -361,8 +387,20 @@ pub fn install_with_lockfile(
         } else {
             std::collections::BTreeMap::new()
         };
+    let item_source_lookup = |kind: ItemKind, name: &str| -> (String, Option<String>) {
+        if let Some(closure) = &closure
+            && let Some(src_label) = closure.item_source.get(&(kind, name.to_string()))
+        {
+            let gr = closure
+                .by_source
+                .get(src_label)
+                .and_then(|si| si.git_ref.clone());
+            return (src_label.clone(), gr);
+        }
+        (label.clone(), git_ref.map(str::to_string))
+    };
     let new_items =
-        crate::lockfile::items_from_report(&report, &label, git_ref, &provenance, |k, n| {
+        crate::lockfile::items_from_report(&report, item_source_lookup, &provenance, |k, n| {
             hashes.get(&(k, n.to_string())).cloned().flatten()
         });
 

--- a/tests/cli_requires.rs
+++ b/tests/cli_requires.rs
@@ -148,3 +148,226 @@ fn add_pulls_cross_source_requires_from_local_sibling() {
         "cross-source sarif required_by must contain agent:code-review: {lock}"
     );
 }
+
+#[test]
+fn add_resolves_transitive_cross_source_closure() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg_c = tmp.path().join("reg-c");
+    write_item(&reg_c, "RULE.md", "security-baseline", "");
+
+    let reg_b = tmp.path().join("reg-b");
+    write_item(
+        &reg_b,
+        "SKILL.md",
+        "sarif",
+        &format!(
+            "requires:\n  rules: [{{ name: security-baseline, source: {} }}]\n",
+            reg_c.display()
+        ),
+    );
+
+    let reg_a = tmp.path().join("reg-a");
+    write_item(
+        &reg_a,
+        "AGENT.md",
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+            reg_b.display()
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg-a", "code-review"])
+        .assert()
+        .success();
+
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap())
+            .unwrap();
+    let items = lock["items"].as_array().unwrap();
+    let has = |kind: &str, name: &str| items.iter().any(|i| i["kind"] == kind && i["name"] == name);
+    assert!(has("agent", "code-review"), "lockfile: {lock}");
+    assert!(has("skill", "sarif"), "lockfile: {lock}");
+    assert!(has("rule", "security-baseline"), "lockfile: {lock}");
+
+    let baseline = items
+        .iter()
+        .find(|i| i["kind"] == "rule" && i["name"] == "security-baseline")
+        .unwrap();
+    assert_eq!(
+        baseline["source"],
+        format!("local:{}", reg_c.display()),
+        "transitive rule must record its own source: {baseline}"
+    );
+    let required_by = baseline["required_by"].as_array().unwrap();
+    assert!(
+        required_by.iter().any(|r| r == "skill:sarif"),
+        "security-baseline required_by must contain skill:sarif: {baseline}"
+    );
+}
+
+#[test]
+fn add_cross_source_conflict_with_existing_install_aborts() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    // Source C provides sarif directly.
+    let reg_c = tmp.path().join("reg-c");
+    write_item(&reg_c, "SKILL.md", "sarif", "");
+    // Source B also provides sarif (a different source).
+    let reg_b = tmp.path().join("reg-b");
+    write_item(&reg_b, "SKILL.md", "sarif", "");
+    // Source A's agent requires sarif FROM B.
+    let reg_a = tmp.path().join("reg-a");
+    write_item(
+        &reg_a,
+        "AGENT.md",
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+            reg_b.display()
+        ),
+    );
+
+    // Install sarif from C first.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg-c", "sarif"])
+        .assert()
+        .success();
+
+    // Adding A pulls sarif from B — conflict with the C install.
+    let out = common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg-a", "code-review"])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    assert!(
+        String::from_utf8_lossy(&out).contains("already installed"),
+        "expected conflict error; stderr was: {}",
+        String::from_utf8_lossy(&out)
+    );
+}
+
+#[test]
+fn add_cross_source_cycle_aborts() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg_a = tmp.path().join("reg-a");
+    let reg_b = tmp.path().join("reg-b");
+    fs::create_dir_all(&reg_a).unwrap();
+    fs::create_dir_all(&reg_b).unwrap();
+    write_item(
+        &reg_a,
+        "RULE.md",
+        "alpha",
+        &format!(
+            "requires:\n  rules: [{{ name: beta, source: {} }}]\n",
+            reg_b.display()
+        ),
+    );
+    write_item(
+        &reg_b,
+        "RULE.md",
+        "beta",
+        &format!(
+            "requires:\n  rules: [{{ name: alpha, source: {} }}]\n",
+            reg_a.display()
+        ),
+    );
+
+    // Add `alpha` by the SAME absolute locator that `beta`'s back-reference
+    // uses, so the entry source label matches the cross-source label. A
+    // relative `./reg-a` here would resolve to a different label than the
+    // absolute back-reference and trip the "two different sources" identity
+    // check before the cycle is ever traversed.
+    let reg_a_arg = reg_a.display().to_string();
+    let out = common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", &reg_a_arg, "alpha"])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    assert!(
+        String::from_utf8_lossy(&out).contains("circular"),
+        "expected circular error; stderr was: {}",
+        String::from_utf8_lossy(&out)
+    );
+}
+
+#[test]
+fn removing_requirer_leaves_cross_source_dep_as_doctor_orphan() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    let reg_b = tmp.path().join("reg-b");
+    write_item(&reg_b, "SKILL.md", "sarif", "");
+    let reg_a = tmp.path().join("reg-a");
+    write_item(
+        &reg_a,
+        "AGENT.md",
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+            reg_b.display()
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg-a", "code-review"])
+        .assert()
+        .success();
+
+    // Remove the requirer; dependency must NOT cascade.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["remove", "code-review"])
+        .assert()
+        .success();
+
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap())
+            .unwrap();
+    assert!(
+        lock["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["name"] == "sarif"),
+        "removal must not cascade to the cross-source dependency: {lock}"
+    );
+
+    // doctor surfaces the orphaned dependency (advisory -> exit 0).
+    let out = common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(
+        String::from_utf8_lossy(&out).contains("sarif"),
+        "doctor should surface orphaned dependency sarif; stdout was: {}",
+        String::from_utf8_lossy(&out)
+    );
+}

--- a/tests/cli_requires.rs
+++ b/tests/cli_requires.rs
@@ -1,9 +1,9 @@
-//! ATDD tests for the same-source `requires` transitive closure.
+//! ATDD tests for the `requires` transitive closure.
 //!
-//! Installing an item pulls in the items it requires from the SAME source.
-//! The lockfile records `required_by` provenance for each pulled-in
-//! dependency. Cross-source `{ name, source }` requires entries are not yet
-//! resolved and must error clearly.
+//! Installing an item pulls in the items it requires from the same source
+//! and from cross-source `{ name, source }` entries. The lockfile records
+//! `required_by` provenance for each pulled-in dependency and the dependency
+//! records its own source.
 
 mod common;
 
@@ -97,24 +97,54 @@ fn add_pulls_preload_skills_as_requires() {
 }
 
 #[test]
-fn add_errors_on_cross_source_requires() {
+fn add_pulls_cross_source_requires_from_local_sibling() {
     let tmp = tempfile::TempDir::new().unwrap();
     let home = tmp.path().join("home");
     fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
-    let reg = tmp.path().join("reg");
+    // Second source holding the required skill.
+    let reg_b = tmp.path().join("reg-b");
+    write_item(&reg_b, "SKILL.md", "sarif", "");
+
+    // Entry source requires `sarif` from `reg-b` by absolute path.
+    let reg_a = tmp.path().join("reg-a");
     write_item(
-        &reg,
+        &reg_a,
         "AGENT.md",
         "code-review",
-        "requires:\n  skills: [{ name: sarif, source: org/repo }]\n",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+            reg_b.display()
+        ),
     );
 
     common::upskill_cmd(&home)
         .current_dir(tmp.path())
-        .args(["add", "./reg", "code-review"])
+        .args(["add", "./reg-a", "code-review"])
         .assert()
-        .failure()
-        .stderr(predicates::str::contains("cross-source"));
+        .success();
+
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap())
+            .unwrap();
+    let items = lock["items"].as_array().unwrap();
+
+    let sarif = items
+        .iter()
+        .find(|i| i["kind"] == "skill" && i["name"] == "sarif")
+        .unwrap_or_else(|| panic!("cross-source sarif must be installed: {lock}"));
+
+    // The dependency records its OWN source (reg-b), not the entry source.
+    let expected_source = format!("local:{}", reg_b.display());
+    assert_eq!(
+        sarif["source"], expected_source,
+        "sarif must record its own cross-source: {sarif}"
+    );
+
+    let required_by = sarif["required_by"].as_array().unwrap();
+    assert!(
+        required_by.iter().any(|r| r == "agent:code-review"),
+        "cross-source sarif required_by must contain agent:code-review: {lock}"
+    );
 }


### PR DESCRIPTION
Implements **Slice 2 (cross-source)** of the coupling redesign (ADR-0009), additively on top of Slice 1 (#204). A `requires` entry `{ name, source }` now fetches, resolves, installs, and records dependencies that live in another source.

Design + plan: `docs/superpowers/specs/2026-06-03-coupling-redesign-design.md` §2.5, `docs/superpowers/plans/2026-06-03-coupling-redesign-slice2.md`.

## What's in this PR

- **Source-aware dependency closure** — `resolve_requires_closure` (`src/pipeline/install.rs`) was widened from single-source to a `Resolver` that tracks a per-item canonical source label, fetches each distinct cross-source locator **once** via `fetch_ssot` (cached by label; `TempDir` guards owned by the returned `DependencyClosure`), and continues the DFS into each fetched source. The transitive closure may span sources.
- **Per-source install + per-item lockfile recording** — `install_with_lockfile` (`src/pipeline/mod.rs`) installs each item from **its own** fetched root and records each lockfile entry with its **own** `source`/`ref` plus `required_by` provenance. `items_from_report` (`src/lockfile.rs`) now takes a per-item `source_for(kind, name) -> (label, ref)` resolver.
- **Cross-source cycle + conflict** — cycles keyed by `(canonical-source-label, kind, name)`; the same `(kind, name)` resolving to two different sources (within one closure **or** vs the lockfile) is an error, reusing `conflict.rs`. No version-range solving, no SAT.
- **Aliases stay entry-source-only** — `--as` is applied only to directly-requested entry-source items on both the conflict-detection and alias-application sides; dependency-pulled items are never renamed.
- **Docs** — format-spec §3.7 + §11 (item 7) and ADR-0009 flipped from "lands in a later release" to implemented.

## Tests

- Unit (`install.rs`): cross-source pull, transitive, cross-source cycle, same-`(kind,name)`-two-sources conflict, missing-cross-source-item.
- ATDD (`tests/cli_requires.rs`): cross-source happy path (records own source + provenance), transitive A→B→C, conflict-with-existing-install aborts, cross-source cycle aborts, and `doctor` flags an orphaned cross-source dependency after the requirer is removed (no cascade).
- All offline: the "other source" is a local-path SSOT root (a valid `add`-DSL locator that flows through the same `fetch_ssot` path). The git-clone arm of `fetch_ssot` is already covered by `tests/pipeline_source.rs`.

## Reviewer notes / known limitations (filed as follow-up debt)

- **`update` of a dependency-only source over-installs siblings.** A cross-source dep's own source is now in the lockfile; `update` re-installs a source as a unit, so it would pull that source's other items too. Newly reachable in Slice 2; fails safe (over-install / conflict, never corruption). Tracked as debt.
- **`local:` source labels are not path-canonicalized.** `./reg` and `/abs/reg` are distinct labels, so a local self-cycle via mixed spellings surfaces as a "two different sources" conflict rather than a cycle. Real cross-source deps are git locators (which canonicalize); the failure mode is a safe error. Tracked as debt.

## Follow-up debt carried from Slice 1 (still open)

- #205 (alias `--as` × `requires`/`required_by` provenance) and #206 (`scaffold.rs` divergent co-located names) remain open; not addressed here.

Verified: `just fmt` + `just verify` green (tests, clippy `-D warnings`, fmt, dprint, markdownlint, shellcheck, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
