### PR TITLE
fix: doctor resolves local-source dir by folder, not effective name (#208)

### DIFF
--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -186,7 +186,19 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
                 });
                 continue;
             }
-            let item_dir = ssot_root.join(&entry.name);
+            // On the SOURCE side an item lives in its FOLDER directory, which
+            // can differ from the consumer-side effective `name` (via `--as`
+            // aliasing, or relaxed rule/agent naming where the folder name and
+            // the `name:` field diverge). Resolve the source dir from the
+            // recorded folder key: `group` (the canonical source folder) ->
+            // `source_name` (the original effective name, set when aliased) ->
+            // `name`. See #208.
+            let folder = entry
+                .group
+                .as_deref()
+                .or(entry.source_name.as_deref())
+                .unwrap_or(&entry.name);
+            let item_dir = ssot_root.join(folder);
             if !item_dir.is_dir() {
                 report.orphan_entries.push(OrphanEntry {
                     kind,

--- a/tests/cli_doctor_source_lookup.rs
+++ b/tests/cli_doctor_source_lookup.rs
@@ -1,0 +1,98 @@
+//! ATDD tests for `doctor`'s local-source item-directory lookup (#208).
+//!
+//! On the SOURCE side an item lives in its FOLDER directory, not under its
+//! consumer-side effective name. The lockfile records that folder as
+//! `LockedItem.group` (and, when `--as`-aliased, the original effective name
+//! as `source_name`). `doctor` must resolve the source item directory from the
+//! folder key — group -> source_name -> name — not from the effective name.
+//!
+//! Two ways the consumer name can diverge from the source folder:
+//!   (a) divergent-named rule/agent: folder `stuff/` holds `RULE.md` whose
+//!       `name:` is `security-baseline` (relaxed naming, Slice 1);
+//!   (b) `--as` alias: source skill `foo` installed as `bar`.
+//! In both cases the pre-fix `ssot_root.join(&entry.name)` lookup misses,
+//! producing a false `ItemMissingInSource` orphan and a non-zero exit.
+
+mod common;
+
+use predicates::prelude::*;
+use std::fs;
+
+/// Scenario (a): a folder whose name differs from the item's `name:`.
+/// Pre-fix `doctor` looks for `<reg>/security-baseline/` (the effective name)
+/// instead of `<reg>/stuff/` (the folder) and falsely flags it missing.
+#[test]
+fn doctor_clean_for_divergent_named_rule() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    // Fake git repo so upskill uses project scope (lockfile in cwd).
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    // Registry: folder `stuff/` holding a RULE.md named `security-baseline`.
+    let reg = tmp.path().join("reg");
+    let dir = reg.join("stuff");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("RULE.md"),
+        "---\nschema: 1\nname: security-baseline\ndescription: baseline security rules\n---\n# Security baseline\n\nKeep secrets out of source control.\n",
+    )
+    .unwrap();
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg"])
+        .assert()
+        .success();
+
+    // doctor must be clean: no false "not in source" orphan.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains("clean")
+                .and(predicates::str::contains("not in source").not())
+                .and(predicates::str::contains("no recoverable source").not()),
+        );
+}
+
+/// Scenario (b): an `--as`-aliased item. Source skill `foo` installed as `bar`.
+/// Pre-fix `doctor` looks for `<reg>/bar/` (the alias) instead of `<reg>/foo/`
+/// and falsely flags it missing.
+#[test]
+fn doctor_clean_for_aliased_item() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    // Registry: a skill `foo`.
+    let reg = tmp.path().join("reg");
+    let dir = reg.join("foo");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        "---\nschema: 1\nname: foo\ndescription: the foo skill\n---\n# foo\n",
+    )
+    .unwrap();
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg", "--as", "foo=bar"])
+        .assert()
+        .success();
+
+    // doctor must be clean: no false "not in source" orphan for the alias.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains("clean")
+                .and(predicates::str::contains("not in source").not())
+                .and(predicates::str::contains("no recoverable source").not()),
+        );
+}


### PR DESCRIPTION
## The bug

\`doctor\`'s local-source branch in \`src/pipeline/lifecycle.rs\` computed the SSOT item directory as \`ssot_root.join(&entry.name)\`, using the **consumer-side effective name**. But on the SOURCE side an item lives in its **folder** directory, recorded in the lockfile as \`LockedItem.group\`. Whenever the consumer name diverges from the source folder, the lookup misfired — producing a false \`ItemMissingInSource\` orphan and a non-zero exit.

## Root cause is broader than the reported symptom

\#208 was reported against \`--as\`-aliased items, but the same lookup also breaks for **divergent-named rules/agents** (relaxed naming, Slice 1): e.g. a folder \`stuff/\` holding a \`RULE.md\` with \`name: security-baseline\`. \`entry.name\` is \`security-baseline\` but the source dir is \`stuff/\`. Same false flag — even with no aliasing at all.

## The fix

In the local-source branch of \`doctor\`, resolve the source item directory from the recorded folder key with precedence:

1. \`entry.group\` — the recorded source folder (Slice 1; canonical),
2. else \`entry.source_name\` — the original effective name (set when \`--as\`-aliased; helps pre-\`group\` aliased lockfiles),
3. else \`entry.name\`.

\`\`\`rust
let folder = entry.group.as_deref().or(entry.source_name.as_deref()).unwrap_or(&entry.name);
let item_dir = ssot_root.join(folder);
\`\`\`

Both the \`ItemMissingInSource\` existence check **and** the stale-hash \`hash_item_dir(&item_dir)\` now use the corrected source dir. The missing-outputs check is unchanged — it correctly uses \`entry.name\` (outputs ARE at the consumer/effective path).

## Tests (TDD)

New \`tests/cli_doctor_source_lookup.rs\`, both RED before the fix (exit 1, false \"item not in source\"), GREEN after:

- **(a) divergent-named rule** — registry folder \`stuff/\` with a \`RULE.md\` named \`security-baseline\`; \`upskill add ./reg\` then \`doctor\` is clean.
- **(b) aliased item** — registry skill \`foo\` added \`--as foo=bar\`; \`doctor\` is clean.

\`cargo test -p upskill\` and \`just verify\` both pass.

## Note: parallel gap in \`update\` (out of scope)

\`update --dry-run\`'s lookup (\`src/pipeline/lifecycle.rs:443\`) uses \`entry.source_name.as_deref().unwrap_or(&entry.name)\` — it does **not** consult \`group\`. For divergent-named rules/agents (folder ≠ name, no aliasing) \`source_name\` is \`None\`, so it falls back to the effective name. This may have a parallel divergent-rule gap, but it is out of scope for #208 and left untouched here.

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)