### PR TITLE
fix: coupling redesign debt — scope update reinstall (#211) + canonicalize local source labels (#212)

### DIFF
--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -378,8 +378,31 @@ pub fn update(
                     aliases,
                     excludes: vec![],
                 };
+                // Scope the reinstall to exactly the items this source already
+                // contributes to the lockfile (by their in-source name), rather
+                // than reinstalling every item the source vends. Without this, a
+                // source that only contributed a single cross-source dependency
+                // would pull in all of its unrelated siblings on `update`
+                // (issue #211). An item's cross-source `requires` are still
+                // resolved and refreshed because `install_with_lockfile`
+                // re-expands the closure for each requested item.
+                //
+                // Bundle sources are exempt: a bundle is its own unit and must
+                // be reinstalled as a whole (an empty filter routes it through
+                // the bundle-resolution path), so scoping to item names there
+                // would mis-route a `.bundle.yaml` source into name resolution.
+                let is_bundle_source = source_label.ends_with(crate::parse::bundle::BUNDLE_SUFFIX)
+                    || lock.bundles.iter().any(|b| b.source == source_label);
+                let item_filter: Vec<String> = if is_bundle_source {
+                    Vec::new()
+                } else {
+                    source_entries
+                        .iter()
+                        .map(|e| e.source_name.clone().unwrap_or_else(|| e.name.clone()))
+                        .collect()
+                };
                 let install_report =
-                    install_with_lockfile(&source, target, &[], plugin_scope, &options)?;
+                    install_with_lockfile(&source, target, &item_filter, plugin_scope, &options)?;
                 let mut new_hashes: std::collections::BTreeMap<(ItemKind, String), Option<String>> =
                     std::collections::BTreeMap::new();
                 for it in &install_report.items {

--- a/src/source.rs
+++ b/src/source.rs
@@ -89,11 +89,14 @@ pub fn home_dir() -> Option<PathBuf> {
 }
 
 pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseError> {
-    if source.starts_with("./")
-        || source.starts_with("../")
-        || source.starts_with('/')
-        || is_windows_absolute(source)
-    {
+    // Relative local path: make it absolute (lexically) so two spellings of the
+    // same directory (`./reg` and `/abs/reg`) collapse to one canonical
+    // `local:` label and resolve identically as a dependency source (issue
+    // #212).
+    if source.starts_with("./") || source.starts_with("../") {
+        return Ok(InstallSource::LocalPath(absolutize_local(source)));
+    }
+    if source.starts_with('/') || is_windows_absolute(source) {
         return Ok(InstallSource::LocalPath(PathBuf::from(source)));
     }
 
@@ -124,6 +127,15 @@ pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseEr
     }
 
     parse_github_source(source).map(InstallSource::Github)
+}
+
+/// Make a relative local path absolute lexically — joining the current
+/// directory without touching the filesystem or resolving symlinks — so that
+/// the same directory always yields one canonical `local:` label regardless of
+/// how it was spelled (issue #212). Falls back to the path verbatim if the
+/// current directory cannot be determined.
+fn absolutize_local(path: &str) -> PathBuf {
+    std::path::absolute(path).unwrap_or_else(|_| PathBuf::from(path))
 }
 
 /// Returns `true` if `s` looks like a Windows absolute path (e.g. `C:\foo`
@@ -320,19 +332,27 @@ mod tests {
     #[test]
     fn parse_local_path_dot_slash() {
         let source = parse_install_source("./my-skills").expect("must parse");
-        assert_eq!(
-            source,
-            InstallSource::LocalPath(PathBuf::from("./my-skills"))
-        );
+        let expected = std::path::absolute("./my-skills").unwrap();
+        assert_eq!(source, InstallSource::LocalPath(expected));
     }
 
     #[test]
     fn parse_local_path_dot_dot_slash() {
         let source = parse_install_source("../shared/skills").expect("must parse");
-        assert_eq!(
-            source,
-            InstallSource::LocalPath(PathBuf::from("../shared/skills"))
-        );
+        let expected = std::path::absolute("../shared/skills").unwrap();
+        assert_eq!(source, InstallSource::LocalPath(expected));
+    }
+
+    #[test]
+    fn relative_local_path_canonicalizes_to_absolute_label() {
+        // Two spellings of the same directory must collapse to one canonical
+        // `local:` label so cross-source resolution and conflict detection
+        // treat them as the same source (issue #212).
+        let cwd = std::env::current_dir().unwrap();
+        let rel = parse_install_source("./some-reg").expect("relative");
+        let abs = parse_install_source(cwd.join("some-reg").to_str().unwrap()).expect("absolute");
+        assert_eq!(rel.to_string(), abs.to_string(), "spellings must unify");
+        assert_eq!(rel, InstallSource::LocalPath(cwd.join("some-reg")));
     }
 
     #[test]

--- a/tests/cli_conflict.rs
+++ b/tests/cli_conflict.rs
@@ -69,24 +69,6 @@ fn add_from_different_source_succeeds_with_force() {
 fn add_from_same_source_succeeds_without_force() {
     let tmp = TempDir::new().unwrap();
 
-    // Lockfile with source matching what we'll install from (local:source)
-    let lockfile = serde_json::json!({
-        "schema": 1,
-        "items": [{
-            "kind": "skill",
-            "name": "test-skill",
-            "source": "local:./source",
-            "hash": "sha256:aaa"
-        }],
-        "bundles": [],
-        "plugins": []
-    });
-    fs::write(
-        tmp.path().join(".upskill-lock.json"),
-        serde_json::to_string_pretty(&lockfile).unwrap(),
-    )
-    .unwrap();
-
     let skill_dir = tmp.path().join("source/test-skill");
     fs::create_dir_all(&skill_dir).unwrap();
     fs::write(
@@ -97,6 +79,17 @@ fn add_from_same_source_succeeds_without_force() {
 
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
+    // First install records the canonical (absolutized) `local:` source label.
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["add", "./source"])
+        .assert()
+        .success();
+
+    // Re-adding from the SAME source must succeed without --force: the
+    // recomputed source label matches the recorded one (issue #212 ensures
+    // both spellings canonicalize identically).
     Command::cargo_bin("upskill")
         .unwrap()
         .current_dir(tmp.path())

--- a/tests/cli_requires.rs
+++ b/tests/cli_requires.rs
@@ -371,3 +371,75 @@ fn removing_requirer_leaves_cross_source_dep_as_doctor_orphan() {
         String::from_utf8_lossy(&out)
     );
 }
+
+#[test]
+fn update_does_not_pull_unrelated_siblings_of_a_cross_source_dependency() {
+    // Regression for #211: a source that only contributes a cross-source
+    // dependency must not have its unrelated siblings installed by `update`.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+
+    // reg-b vends the required `sarif` skill AND an unrelated sibling.
+    let reg_b = tmp.path().join("reg-b");
+    write_item(&reg_b, "SKILL.md", "sarif", "");
+    write_item(&reg_b, "SKILL.md", "unrelated-sibling", "");
+
+    // reg-a's agent requires only `sarif` from reg-b.
+    let reg_a = tmp.path().join("reg-a");
+    write_item(
+        &reg_a,
+        "AGENT.md",
+        "code-review",
+        &format!(
+            "requires:\n  skills: [{{ name: sarif, source: {} }}]\n",
+            reg_b.display()
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["add", "./reg-a", "code-review"])
+        .assert()
+        .success();
+
+    let sibling_out = tmp.path().join(".claude/skills/unrelated-sibling/SKILL.md");
+    assert!(
+        !sibling_out.exists(),
+        "add must not install the unrelated sibling"
+    );
+
+    // The regression is in `update`: it groups by source and previously
+    // reinstalled the WHOLE dependency source, pulling the sibling in.
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["update", "--yes"])
+        .assert()
+        .success();
+
+    assert!(
+        !sibling_out.exists(),
+        "update must not pull the unrelated sibling of a cross-source dependency"
+    );
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tmp.path().join(".upskill-lock.json")).unwrap())
+            .unwrap();
+    assert!(
+        !lock["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["name"] == "unrelated-sibling"),
+        "unrelated sibling must not be recorded after update: {lock}"
+    );
+    // The genuine dependency is still present.
+    assert!(
+        lock["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["name"] == "sarif"),
+        "the cross-source dependency must survive update: {lock}"
+    );
+}


### PR DESCRIPTION
Closes #211 and #212 — the two follow-up debts from the Slice 2 cross-source PR (#210). They were authored on the #210 branch but the merge snapshot predated them, so they land here as a fresh PR off current `main` (cherry-picked, with the `lifecycle.rs` overlap against #213 resolved).

## #211 — `update` no longer pulls a dependency source's unrelated siblings

`fix(pipeline)`: in `update --apply`, scope the per-source reinstall to exactly the items that source already contributes to the lockfile (by their in-source name), instead of reinstalling every item the source vends. Without this, a source that only contributed a single cross-source dependency would pull in all of its unrelated siblings on `update`. An item's cross-source `requires` are still resolved and refreshed (the closure re-expands per requested item). **Bundle sources are exempt** — a bundle is its own unit and is reinstalled wholesale (an empty filter routes it through bundle resolution), so scoping is skipped when the source is a `.bundle.yaml` or has a lockfile bundle entry.

Test: `tests/cli_requires.rs::update_does_not_pull_unrelated_siblings_of_a_cross_source_dependency`.

## #212 — relative `local:` source labels canonicalize to absolute paths

`fix(source)`: `parse_install_source` now absolutizes relative local paths (`./reg`, `../reg`) lexically (via `std::path::absolute`, no filesystem access / no symlink resolution). Two spellings of one directory (`./reg` vs `/abs/reg`) collapse to a single canonical `local:` label, so cross-source resolution and conflict detection treat them as the same source. Absolute and Windows-drive paths are unchanged; the lockfile-label parser is left untouched so cross-platform label round-trips still hold.

Tests: `src/source.rs::relative_local_path_canonicalizes_to_absolute_label` (+ updated relative-path parse tests); `tests/cli_conflict.rs::add_from_same_source_succeeds_without_force` rewritten to install-then-readd (robust to cwd resolution).

## Verification

`cargo build`, full `cargo test` (40 suites, 0 failures — incl. `cli_requires`, `cli_update`, `cli_update_bundle`, `cli_conflict`, `cli_doctor`, and #213's `cli_doctor_source_lookup`), and `just lint` (clippy `-D warnings`, fmt, dprint, markdownlint, shellcheck) all green. (`just verify` as one command hit a local resource limit; the stages were run individually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
