### PR TITLE
fix: update --dry-run falsely reports WouldRemove for divergent-named rules/agents (#214)

### DIFF
--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -463,7 +463,17 @@ pub fn update(
                 guard_against_empty_source(&new_hashes, &source_entries, &source_label)?;
                 for entry in &source_entries {
                     let kind = entry.kind;
-                    let lookup_name = entry.source_name.as_deref().unwrap_or(&entry.name);
+                    // The source-side hash map is keyed by the item's FOLDER
+                    // (see `hash_items` / `iter_item_dirs`), which is the
+                    // co-location group. A rule/agent whose frontmatter name
+                    // diverges from its folder must be looked up by that folder,
+                    // not its effective name, or it is falsely reported as
+                    // `WouldRemove` (issue #214; mirrors the #208 doctor fix).
+                    let lookup_name = entry
+                        .group
+                        .as_deref()
+                        .or(entry.source_name.as_deref())
+                        .unwrap_or(&entry.name);
                     if !new_hashes.contains_key(&(kind, lookup_name.to_string())) {
                         report.items.push(UpdatedItem {
                             kind,

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -369,3 +369,39 @@ fn update_without_yes_proceeds_in_non_tty() {
         "update should have applied without --yes in non-TTY"
     );
 }
+
+#[test]
+fn update_dry_run_reports_up_to_date_for_divergent_named_rule() {
+    // Regression for #214: a rule whose frontmatter name diverges from its
+    // folder must not be falsely reported as `would remove` by dry-run (the
+    // source-side hash map is keyed by folder, the lookup must match).
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let source = tmp.path().join("source");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // Folder `stuff/` holds a rule named `security-baseline` (name diverges).
+    let rule_dir = source.join("stuff");
+    fs::create_dir_all(&rule_dir).unwrap();
+    fs::write(
+        rule_dir.join("RULE.md"),
+        "---\nschema: 1\nname: security-baseline\ndescription: divergent rule\n---\n# body\n",
+    )
+    .unwrap();
+
+    install(&target, &source, &home);
+
+    let assert = common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["update", "--dry-run"])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        !out.contains("would remove"),
+        "divergent-named rule must not be reported as would-remove:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #214.

`update --dry-run` shares the root-cause class that #208/#213 fixed in `doctor`: it resolved the source-side item by the consumer-side **effective name** instead of the source **folder**.

`planned_source_hashes` → `hash_items` keys its map by the item folder (`iter_item_dirs` returns the folder leaf). But the dry-run loop looked up `entry.source_name.unwrap_or(entry.name)` — the effective name. For a **divergent-named rule/agent** (folder `stuff/`, `RULE.md` `name: security-baseline`, no alias → `source_name` is `None`), the lookup keyed `(Rule, "security-baseline")` while the map holds `(Rule, "stuff")` → miss → falsely reported **`WouldRemove`**.

## Fix

Mirror the #208 fix: resolve the lookup by `entry.group` (the co-location folder, set on every Slice-1+ install), falling back to `source_name` then `name`:

```rust
let lookup_name = entry.group.as_deref().or(entry.source_name.as_deref()).unwrap_or(&entry.name);
```

Apply-mode was audited and is already correct — its `new_hashes` come from the install report (effective-name-keyed), matched against `entry.name` (also effective), so no change is needed there.

## Test

`tests/cli_update.rs::update_dry_run_reports_up_to_date_for_divergent_named_rule` — installs a rule whose frontmatter name diverges from its folder, then asserts `update --dry-run` does not report `would remove`. Fails before the fix, passes after.

## Verification

`cargo build`, full `cargo test` (40 suites, 0 failures), and `just lint` (clippy `-D warnings`, fmt, dprint, markdownlint, shellcheck) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
