### PR TITLE
docs: cover plugins, MCP & co-location; drop ADRs from book nav

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,15 +15,3 @@
 
 - [Specification](specification.md)
 - [Portable format](format-spec.md)
-
-# Architecture Decisions
-
-- [ADR-0000: Implementation baseline](adr/0000-implementation-baseline.md)
-- [ADR-0001: Multi-kind compiler architecture](adr/0001-multi-kind-compiler-architecture.md)
-- [ADR-0002: Portable content format](adr/0002-portable-content-format.md)
-- [ADR-0003: SSOT-to-client generation pipeline](adr/0003-generation-pipeline.md)
-- [ADR-0004: CLI surface](adr/0004-cli-surface.md)
-- [ADR-0005: skills.sh ecosystem interop](adr/0005-skills-sh-ecosystem-interop.md)
-- [ADR-0006: Flat item layout](adr/0006-flat-item-layout.md)
-- [ADR-0007: Bundle file format](adr/0007-bundle-yaml-format.md)
-- [ADR-0008: Plugin installation](adr/0008-plugin-install-shellout.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,21 +1,22 @@
 # Commands
 
-`upskill` ships nine commands. They split cleanly into **consumer**
+`upskill` ships ten commands. They split cleanly into **consumer**
 (run inside a project that consumes AI-assistance content) and
 **author** (run inside a source-registry repo).
 
-| Command  | Role     | Purpose                                             |
-| -------- | -------- | --------------------------------------------------- |
-| `add`    | Consumer | Install content from any source.                    |
-| `remove` | Consumer | Remove installed content.                           |
-| `update` | Consumer | Pull latest, regenerate changed items.              |
-| `list`   | Consumer | Show installed content from the lock file.          |
-| `doctor` | Consumer | Verify installation consistency.                    |
-| `search` | Consumer | Look up skills via the public registry.             |
-| `index`  | Consumer | Build or manage the local registry index cache.     |
-| `new`    | Author   | Scaffold a new rule, skill, or agent.               |
-| `lint`   | Author   | Validate SSOT files against the format spec.        |
-| `fmt`    | Author   | Canonicalise YAML frontmatter (key order, quoting). |
+| Command      | Role     | Purpose                                             |
+| ------------ | -------- | --------------------------------------------------- |
+| `add`        | Consumer | Install content from any source.                    |
+| `remove`     | Consumer | Remove installed content.                           |
+| `remove-mcp` | Consumer | Unregister an MCP server configured by a bundle.    |
+| `update`     | Consumer | Pull latest, regenerate changed items.              |
+| `list`       | Consumer | Show installed content from the lock file.          |
+| `doctor`     | Consumer | Verify installation consistency.                    |
+| `search`     | Consumer | Look up skills via the public registry.             |
+| `index`      | Consumer | Build or manage the local registry index cache.     |
+| `new`        | Author   | Scaffold a new rule, skill, or agent.               |
+| `lint`       | Author   | Validate SSOT files against the format spec.        |
+| `fmt`        | Author   | Canonicalise YAML frontmatter (key order, quoting). |
 
 ## Global flags
 
@@ -75,6 +76,17 @@ plugin is skipped (not an error) and recorded as `skipped` in the
 lockfile; `upskill doctor` reports skipped and missing plugins. Removing
 the bundle cleans up its plugins.
 
+**Bundle MCP servers.** When a bundle declares an `mcps:` map
+([format-spec §3.7](./format-spec.md#37-bundle-schema)), `add` configures
+those Model Context Protocol servers into each targeted client's MCP
+configuration — CLI-first (`claude mcp add ...`), falling back to writing
+the client config file (e.g. `.mcp.json`) when the CLI is absent. MCP
+configuration is idempotent, and a single MCP failure or skip never fails
+the rest of the bundle install. Configured and warn-skipped servers are
+recorded in the lockfile; remove one with
+[`upskill remove-mcp`](#upskill-remove-mcp-name). If an MCP server needs
+an environment variable that is unset, `add` warns so you can export it.
+
 ### `upskill update [name...]`
 
 Pull latest sources and regenerate changed items.
@@ -109,6 +121,23 @@ touched.
 every item from that label at once). Pass `-y` / `--yes` to skip.
 Non-interactive contexts (CI, pipes) skip the prompt automatically.
 
+### `upskill remove-mcp <name>`
+
+Unregister an MCP server that a bundle install configured (see the
+`mcps:` note under [`upskill add`](#upskill-add-source-items)).
+
+```bash
+upskill remove-mcp drawio            # remove from the current project
+upskill remove-mcp drawio --global   # remove from the $HOME scope
+```
+
+`<name>` is the upskill-level MCP name recorded in the lockfile.
+`remove-mcp` unregisters the server from the client (`claude mcp remove
+<name>`, falling back to deleting the entry from the client config file
+when the CLI is absent) and drops the `LockedMcp` entry from the
+lockfile. Scope follows the same `--project` / `--global` rules as
+`add`, auto-detecting global when `cwd` is not inside a git repo.
+
 ### `upskill list`
 
 Show installed content from `.upskill-lock.json`, grouped by kind.
@@ -136,7 +165,7 @@ matches the lockfile label (`local:/path` or `github:owner/repo` etc.).
 ### `upskill doctor`
 
 Verify on-disk state matches `.upskill-lock.json`. Reports drift in
-five independent buckets:
+six independent buckets:
 
 - **Missing per-client output files** — reinstall fixes (`upskill add
   <source>`).
@@ -150,12 +179,17 @@ five independent buckets:
 - **Skipped plugins** (informational) — recorded as `skipped` because
   the client CLI was not on PATH at install time. Install the CLI then
   run `upskill update` to install them. Does **not** cause exit 1.
+- **MCP servers** — each Claude-client MCP entry in the lockfile is
+  checked against `claude mcp list`. A server in the lockfile but **not
+  registered** in the client causes exit 1 (`upskill update`
+  reconfigures it). A missing `claude` CLI or a failed query is advisory
+  and does **not** cause exit 1.
 
 Exits 0 when clean, 1 when any drift bucket is non-empty (missing
-outputs, stale hashes, orphan entries, or missing plugins). Skipped
-plugins are informational warnings and do not affect the exit code.
-`doctor` never fetches; remote-source drift detection is `update
---dry-run`.
+outputs, stale hashes, orphan entries, missing plugins, or unregistered
+MCP servers). Skipped plugins and unverifiable MCP entries are
+informational warnings and do not affect the exit code. `doctor` never
+fetches; remote-source drift detection is `update --dry-run`.
 
 Pass `--json` for a stable machine-readable document. Exit code is
 unchanged.
@@ -181,13 +215,20 @@ unchanged.
     { "name": "superpowers", "client": "claude",
       "identifier": "superpowers@anthropics/claude-plugins",
       "bundle": "baseline" }
+  ],
+  "mcp_entries": [
+    { "name": "drawio", "client": "claude", "bundle": "baseline",
+      "status": "not-registered" }
   ]
 }
 ```
 
 `reason` is `"local-path-gone"` or `"item-missing-in-source"`. Hashes
-may be `null` when the SSOT can't be hashed (e.g. unreadable). All five
-arrays are always present, possibly empty.
+may be `null` when the SSOT can't be hashed (e.g. unreadable). MCP
+`status` is one of `"ok"`, `"not-registered"`, `"cli-not-found"`, or
+`{ "query-failed": { "stderr": "..." } }`. The plugin and item arrays
+are always present (possibly empty); `mcp_entries` is omitted when no
+MCP servers are recorded.
 
 ### `upskill search <query>`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -65,6 +65,16 @@ agents that render to a flat file (Claude Code, GitHub Copilot), resources go
 into a sibling `<name>/` directory and the body's relative links are rewritten
 to match. See [format-spec §2.4](./format-spec.md).
 
+**Bundle plugins.** When a bundle declares a `plugins:` map
+([format-spec §3.7](./format-spec.md#37-bundle-schema)), `add` installs
+those client-native plugins by shelling out to each client's own CLI
+(`claude plugin install`, `copilot plugin install`, `code
+--install-extension`, `opencode plugin`) — they are **not** rendered
+through the generation pipeline. If a client's CLI is not on `PATH`, the
+plugin is skipped (not an error) and recorded as `skipped` in the
+lockfile; `upskill doctor` reports skipped and missing plugins. Removing
+the bundle cleans up its plugins.
+
 ### `upskill update [name...]`
 
 Pull latest sources and regenerate changed items.
@@ -220,7 +230,9 @@ scaffold into the wrong tree.
 
 ### `upskill new <kind> <name>`
 
-Scaffold a new SSOT item directory.
+Scaffold a new SSOT item directory. `<kind>` is one of `rule`, `skill`,
+or `agent`; `<name>` is both the item name and the directory name
+(lowercase letters, digits, hyphens; max 64 chars).
 
 ```bash
 upskill new rule  no-direct-database-access
@@ -228,10 +240,32 @@ upskill new skill code-review
 upskill new agent security-reviewer
 ```
 
-Creates `<kind>s/<name>/<KIND>.md` with the minimum frontmatter the
-format spec requires. Agents get `mode: subagent` and `model: sonnet`
-so the file is generation-ready out of the box. The scaffold round-trips
-through `upskill fmt` as a no-op and passes `upskill lint --strict`.
+Creates `<name>/<KIND>.md` **relative to the current directory** with the
+minimum frontmatter the format spec requires — there is no `<kind>`
+parent folder and no separate "destination" argument. The folder is the
+`<name>` you pass, so to place an item under `skills/` you run the
+command from inside `skills/` (see
+[Conventions](./conventions.md#scaffolding-under-the-convention)). Agents
+get `mode: subagent` and `model: sonnet` so the file is generation-ready
+out of the box. The scaffold round-trips through `upskill fmt` as a no-op
+and passes `upskill lint --strict`.
+
+**Co-location.** Run `new` again with a different kind and the same
+`<name>` to add that kind as a sibling entrypoint inside the existing
+item directory ([format-spec §2.1](./format-spec.md#21-item-directory-structure)):
+
+```bash
+upskill new skill api-handler   # → api-handler/SKILL.md
+upskill new rule  api-handler   # → api-handler/RULE.md (added alongside)
+```
+
+This expresses one capability across multiple kinds (for example a skill
+paired with its enforcing rule). Co-location is refused only when an
+existing **skill** entrypoint's `name:` diverges from `<name>`; rule and
+agent siblings MAY carry a divergent name.
+
+`upskill new` is an author command — it refuses to run inside a consumer
+project (one with a `.upskill-lock.json`).
 
 ### `upskill lint [paths...]`
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -680,7 +680,7 @@ Implementations:
 The optional `mcps` map declares MCP (Model Context Protocol) servers that accompany this
 bundle. Configuring an MCP server requires no content generation — instead, upskill writes the
 server into each targeted client's MCP configuration at install time. See
-[ADR-0010](adr/0010-mcp-config-write.md) for design rationale.
+[ADR-0010](https://github.com/driftsys/upskill/blob/main/docs/adr/0010-mcp-config-write.md) for design rationale.
 
 Each entry in the `mcps` map is keyed by an upskill-level MCP name (used in the lockfile, CLI
 output, and `upskill remove-mcp`). The value carries a transport descriptor and an optional list

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -106,7 +106,7 @@ Constraints:
   or an agent paired with a skill it preloads). Co-location is optional; solo-kind item
   directories are the common case. Co-location expresses a _symmetric, inseparable_ unit; a
   _directed_ "A needs B" relationship is expressed with `requires` (§3.7) instead. See
-  [ADR-0009](./adr/0009-coupling-tiers-and-dependencies.md).
+  [ADR-0009](https://github.com/driftsys/upskill/blob/main/docs/adr/0009-coupling-tiers-and-dependencies.md).
 - **Effective name and relaxed naming.** Each entrypoint resolves to an **effective name**:
   - A **skill** `name:` is optional. When present it MUST equal the directory name (the Agent
     Skills standard mandate). When absent, the skill's effective name is the directory name.
@@ -163,7 +163,7 @@ Bundles are flat YAML manifest files, not directories:
 - A bundle MAY have an optional sibling Markdown file `<name>.bundle.md` carrying
   human-readable documentation (install examples, adoption path, caveats). Implementations
   ignore `<name>.bundle.md`; it exists for humans browsing the registry. See
-  [ADR-0007](./adr/0007-bundle-yaml-format.md).
+  [ADR-0007](https://github.com/driftsys/upskill/blob/main/docs/adr/0007-bundle-yaml-format.md).
 
 ### 2.3 Per-client override files
 
@@ -524,7 +524,7 @@ Implementations:
 The optional `plugins` map declares client-native plugins that accompany this bundle. Unlike
 rules, skills, and agents (which are SSOT content rendered per-client by the generation
 pipeline), plugins are installed via each client's native CLI. See
-[ADR-0008](adr/0008-plugin-install-shellout.md) for design rationale.
+[ADR-0008](https://github.com/driftsys/upskill/blob/main/docs/adr/0008-plugin-install-shellout.md) for design rationale.
 
 Each entry in the `plugins` map is keyed by an upskill-level plugin name (used in the lockfile,
 CLI output, and `upskill remove`). The value is a map of per-client install descriptors:
@@ -797,7 +797,7 @@ Implementations:
 
 Items (rules, skills, agents) MAY declare directed dependencies in their `requires` field
 (§3.1). This is distinct from bundle `requires`, which links bundles: item `requires` links
-individual items. See [ADR-0009](./adr/0009-coupling-tiers-and-dependencies.md).
+individual items. See [ADR-0009](https://github.com/driftsys/upskill/blob/main/docs/adr/0009-coupling-tiers-and-dependencies.md).
 
 Implementations:
 
@@ -1171,7 +1171,7 @@ The following topics are explicitly deferred and tracked for future specificatio
    add` source DSL, conflicts reuse the same-name-different-source rule, and cycles are keyed by
    `(canonical-source-label, kind, name)`. Both same-source and cross-source resolution are
    implemented. See
-   [ADR-0009](./adr/0009-coupling-tiers-and-dependencies.md).
+   [ADR-0009](https://github.com/driftsys/upskill/blob/main/docs/adr/0009-coupling-tiers-and-dependencies.md).
 8. **Content hashing**: whether items should carry a content hash for integrity verification
    during distribution, independent of `metadata.version`.
 


### PR DESCRIPTION
## What

Updates the user-facing docs for recently shipped features and removes the ADRs from the published book. Rebased on `main` so it includes #218 (MCP support).

### Plugins
- Documents bundle `plugins:` install behavior on `upskill add`: shells out to each client's native CLI (`claude` / `copilot` / `code` / `opencode`), warn-skips when the CLI is absent, and surfaces skipped/missing plugins via `doctor`.

### MCP servers (#218)
- Documents the new `upskill remove-mcp <name>` command and adds it to the command table (now ten commands).
- Documents bundle `mcps:` configuration on `add`: CLI-first config-write with client-config fallback, idempotent, never fails the rest of the bundle.
- Extends the `doctor` section with the MCP reconciliation bucket (`not-registered` → exit 1; CLI-absent/query-failed advisory) and adds `mcp_entries` to the `--json` example.

### Co-location
- Fixes the `upskill new` doc, which incorrectly claimed output went to `<kind>s/<name>/<KIND>.md`. Actual behavior is `<name>/<KIND>.md` relative to cwd (no `<kind>` parent, no destination arg).
- Documents co-locating multiple kinds in one item directory (run `new` again with a different kind + same name → sibling entrypoint).

### Drop ADRs from the book
- Removes the **Architecture Decisions** section from `docs/SUMMARY.md` so ADRs no longer render in the published mdBook. The ADR `.md` files stay in the repo as design records.
- Repoints the ADR links in `format-spec.md` (0007/0008/0009/0010) to GitHub source URLs so they resolve once the ADR pages leave the nav.

## Verification
- `just book` builds with no broken-link / fragment warnings.
- `just fmt` applied; `just verify` passed on push.

## Notes / follow-up
- AGENTS.md still describes `docs/adr/` as "0000…0002–0005" (stale) — left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
