### PR TITLE
feat: MCP server support (v1) — bundle mcps:, CLI-first config-write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /.claude
 /book
+# MCP config written by `claude mcp add` / config-write fallback during tests
+.mcp.json

--- a/docs/adr/0010-mcp-config-write.md
+++ b/docs/adr/0010-mcp-config-write.md
@@ -1,0 +1,313 @@
+# MCP server configuration — bundle `mcps:`, CLI-first config-write
+
+**Status**: Accepted (2026-06-03)
+
+## Context
+
+[ADR-0001](./0001-multi-kind-compiler-architecture.md) and
+[ADR-0003](./0003-generation-pipeline.md) established the SSOT-to-files
+contract: upskill reads SSOT items, generates per-client output files, and
+never invokes the host client at runtime.
+
+[ADR-0008](./0008-plugin-install-shellout.md) extended that contract with
+a `plugins:` map on Bundle that shells out to each client's plugin CLI at
+install time. MCP servers need the same extension: a skill that relies on
+an MCP server (e.g. a "draw.io diagrams" skill referencing
+`DrawIO:create_diagram`) is inoperable if that server was never configured
+in the client. Today the two halves of a coherent capability — the skill
+content and its server — are delivered separately and manually wired together
+by the consumer.
+
+### What an MCP server actually needs from an install tool
+
+MCP servers reach a client in one of two transport shapes:
+
+- **Remote** — a hosted server the client connects to over `http` or `sse`
+  at a URL. Already running; auth is OAuth (client-driven) or a static token
+  in a header.
+- **Local (stdio)** — the client spawns a local command (with args/env) and
+  speaks MCP over stdio. When the command is a self-fetching launcher
+  (`npx -y <pkg>`, `uvx <pkg>`, `docker run …`) the launcher downloads and
+  caches the server on first run — upskill installs nothing.
+
+The only case that genuinely needs a real install step is a bare binary with
+no launcher (a compiled tool, a Homebrew formula) that must be
+detected → version-checked → installed → set up. That heterogeneous case is
+out of scope for v1 and is noted in the Deferred section below.
+
+### Trust posture (non-negotiable invariant)
+
+`upskill add` is safe-by-construction: it only writes files into known
+paths and shells out to known client CLIs with declared args. Adding an
+arbitrary fetched bundle cannot execute arbitrary code.
+
+This ADR preserves that invariant. upskill itself never downloads, builds,
+or runs server code. The v1 implementation writes config (via the client's
+MCP CLI verb, or a config file) — the same class of action as the plugin
+shellout in ADR-0008.
+
+## Decision
+
+### Bundle gains an optional `mcps:` map
+
+This ADR adds one new top-level key, `mcps:`, to the Bundle schema defined
+in [ADR-0007](./0007-bundle-yaml-format.md), as a direct parallel of the
+`plugins:` map introduced by ADR-0008. The `mcps:` key is a sibling of
+`plugins:` in the YAML schema.
+
+```yaml
+schema: 1
+name: drawio-diagrams
+description: Draw.io diagram skill and its MCP server
+items:
+  skills:
+    - drawio-diagrams
+mcps:
+  drawio:
+    remote:
+      type: http # http | sse
+      url: https://mcp.draw.io/mcp
+      headers:
+        Authorization: "Bearer ${DRAWIO_TOKEN}"
+    requires-env: [DRAWIO_TOKEN]
+```
+
+Or with a local (stdio) launcher:
+
+```yaml
+mcps:
+  drawio:
+    local:
+      command: npx
+      args: ["-y", "drawio-mcp-server"]
+      env:
+        DRAWIO_TOKEN: "${DRAWIO_TOKEN}"
+    requires-env: [DRAWIO_TOKEN]
+```
+
+- The map key (`drawio`) is the upskill-level identity — used in the
+  lockfile, CLI output, and `upskill remove-mcp <name>`.
+- Each entry carries **exactly one** of `remote:` or `local:`. The
+  `validate_mcps` function (`src/model/bundle.rs`) enforces this at parse
+  time; both or neither is an error.
+- `remote.type` MUST be one of `http` or `sse`; `remote.url` MUST not be
+  empty; `local.command` MUST not be empty.
+
+### Secrets — `${VAR}` indirection, declare-and-check
+
+upskill never owns a secret value. The rule:
+
+- Config values that reference secrets MUST use `${VAR}` indirection only.
+  upskill writes the reference verbatim; the **client** expands it at
+  connect/launch time; the value lives in the user's environment or the
+  client's OAuth store.
+- upskill MUST NOT persist a literal secret — not into a client config
+  file, not into the lockfile, not into SSOT.
+- `requires-env: [VAR, …]` is a **declaration** (not a value). It lets
+  `upskill doctor` warn that an MCP server needs a variable that is not set
+  in the current environment, without ever reading the value.
+
+This is the same posture upskill already takes for git auth (tokens come
+from env / `gh` / `glab`, never persisted).
+
+### Per-client install contract — CLI-first, config-write fallback
+
+v1 targets **Claude Code only**. opencode, VS Code, and GitHub Copilot are
+deferred to future releases (see Deferred section). An MCP entry in a
+bundle that arrives on a machine where only non-Claude clients are targeted
+produces a warn-skip — not an error.
+
+For Claude Code, the preference order is:
+
+1. **CLI-first**: shell out to `claude mcp add`. The specific form depends
+   on transport:
+   - Local (stdio):
+     `claude mcp add <name> --scope <scope> [-e KEY=${VAR} …] -- <command> [args…]`
+   - Remote (http/sse):
+     `claude mcp add --transport <http|sse> <name> <url> --scope <scope> [-H "Header: ${VAR}" …]`
+2. **Config-write fallback**: when `claude` is not on PATH
+   (`ErrorKind::NotFound`), fall back to writing `.mcp.json` in the project
+   root (for project scope) or the user config location (for global scope).
+   The `.mcp.json` shape is `{ "mcpServers": { "<name>": { … } } }`.
+
+Config-write fallback is never the primary path — the same stance
+ADR-0008 took against patching `settings.json` as the primary plugin
+install mechanism.
+
+Claude's `--scope` derives from upskill's project/global context exactly
+as plugins do:
+
+| upskill scope | `claude --scope` |
+| ------------- | ---------------- |
+| project       | `project`        |
+| global        | `user`           |
+
+### CLI-missing policy: warn-skip
+
+If `claude` is not on PATH and the config-write fallback also fails,
+upskill prints a warning and continues installing the rest of the bundle.
+The rules, skills, and agents portion of the bundle MUST install regardless
+of MCP configuration success.
+
+### Lockfile lifecycle
+
+`LockedMcp` is recorded per `(name, client)` pair (parallel to
+`LockedPlugin` from ADR-0008):
+
+```json
+{
+  "name": "drawio",
+  "client": "claude",
+  "scope": "project",
+  "bundle": "drawio-diagrams",
+  "status": "installed"
+}
+```
+
+Status values:
+
+| `status`      | Meaning                                                             |
+| ------------- | ------------------------------------------------------------------- |
+| `"installed"` | Configured successfully via CLI shellout or config-write.           |
+| `"skipped"`   | CLI was not on PATH and no config-write target applied (warn-skip). |
+
+`upsert_mcp` / `remove_mcps_by_name` mirror the plugin equivalents. The
+lockfile `schema` field stays at **1** — the `mcps` array is additive and
+backward-compatible; old upskill versions reading a lockfile with `mcps`
+entries silently ignore the unknown array (serde `default`).
+
+### Removal and reconciliation
+
+- **`upskill remove-mcp <name>`**: a dedicated top-level subcommand (not
+  `upskill remove`). It shells out to `claude mcp remove <name> --scope
+  <scope>` (CLI-first), falling back to removing the entry from `.mcp.json`
+  when the CLI is absent. Drops the `LockedMcp` entry from the lockfile.
+- **`upskill doctor`**: checks each `claude`-client MCP entry in the
+  lockfile via `claude mcp list` (substring match on the server name). A
+  server present in the lockfile but absent from the client makes doctor
+  report `NotRegistered` and exit non-clean (exit 1). Doctor also warns on
+  unset `requires-env` variables. Reconciliation never auto-removes entries
+  — consistent with the project's "never auto-delete" ethos.
+
+### Implementation shape
+
+- `src/model/bundle.rs` — `McpEntry { transport: McpTransport, requires_env }`;
+  `McpTransport::Remote(McpRemote)` / `McpTransport::Local(McpLocal)`;
+  `Bundle::validate_mcps`.
+- `src/mcp.rs` — typed CLI-shellout functions (`install_claude_local`,
+  `install_claude_remote`, `uninstall_claude`, `check_claude_installed`),
+  reusing the spawn/CLI-not-found helpers from `src/plugin.rs`. Never
+  writes to stdout/stderr.
+- `src/ancillary.rs` — `write_claude_mcp_local` / `write_claude_mcp_remote`
+  (config-write fallback into `.mcp.json`); `remove_claude_mcp` (removal
+  fallback). Merge-preserving: existing servers in `mcpServers` are not
+  clobbered.
+- `src/pipeline/install.rs` — `install_mcps_from_bundles`: iterates
+  resolved bundles, attempts CLI shellout, falls back to config-write on
+  `CliNotFound`, returns structured `McpResult` per server.
+- `src/lockfile.rs` — `LockedMcp`, `McpInstallStatus`, `upsert_mcp`,
+  `remove_mcps_by_name`.
+- `src/cli.rs` / `src/main.rs` — `Commands::RemoveMcp`; doctor
+  reconciliation loop over `mcps` lockfile entries.
+
+## Consequences
+
+**Positive.**
+
+- Native lifecycle (scope semantics, CLI-driven add/remove) is delegated to
+  the `claude` CLI, not reinvented in upskill — consistent with ADR-0008's
+  stance on plugins.
+- Consistent with the "shell out to git instead of `git2`" pattern from
+  [ADR-0001](./0001-multi-kind-compiler-architecture.md) §3.
+- Bundle authors get a single SSOT entry that declares both transport
+  descriptors and required env vars. Consumers get server configuration as
+  part of `upskill add` rather than a separate manual step.
+- Secrets stay with the user: upskill never reads, stores, or transmits
+  actual token values.
+- Config-write fallback ensures the server is configured even when the
+  `claude` CLI is not on PATH (CI or first-time machines).
+
+**Negative / limits.**
+
+- v1 is Claude-only. Teams using opencode or VS Code in parallel do not get
+  MCP configuration from the same bundle install — they must configure MCP
+  manually until those clients are supported.
+- Determinism loss: install outcome depends on whether `claude` is on PATH.
+  Integration tests that exercise the CLI path must shim `claude` on PATH;
+  tests that exercise config-write must clear PATH or point to an absent
+  binary.
+- The warn-skip policy can mask a real misconfiguration. Mitigated by
+  `doctor`, which surfaces every `NotRegistered` server and every unset
+  `requires-env` variable.
+- Config-write fallback (`.mcp.json`) is a project-scope file; it does not
+  cover the global scope as cleanly as the CLI. The global config location
+  is client-version-specific and not yet handled by the fallback path.
+
+## Alternatives considered
+
+**(a) upskill runs a bundled `install.sh`.** Rejected: gives any bundle
+author a shell on the consumer's machine (the npm `postinstall`
+supply-chain hole). Breaks the safe-by-construction invariant. The v2
+install agent achieves the same provisioning with the client's permission
+system as the gate, not upskill's trust boundary.
+
+**(b) upskill "triggers an AI prompt" itself.** Rejected: upskill has no
+LLM runtime. Injecting fetched-bundle instructions into the consumer's
+agent session is prompt injection with the same RCE risk wearing a
+different hat.
+
+**(c) upskill as secret manager — storing tokens in the lockfile or SSOT.**
+Rejected: custody risk and redundant. Clients already resolve `${VAR}` and
+run OAuth. upskill stays indirection-only; secrets remain with the user.
+
+**(d) Patch client config files as the primary path.** Rejected: brittle
+across client versions, depends on undocumented internal schema, and breaks
+when the schema evolves. ADR-0008 rejected the same approach for plugins.
+CLI-first; config-write is the fallback-only path.
+
+**(e) New top-level `Mcp` kind for v1.** Rejected for the same reason
+ADR-0008 rejected a `Plugin` kind: MCP servers compose with skills and
+travel in bundles. A consumer bundle like `drawio-diagrams` wants to ship
+both the skill content and its server in one unit. A standalone `Mcp` kind
+would require two separate installs for a coherent setup. (v2 may revisit
+kind-hood as part of the `requires` coupling model — see Deferred.)
+
+**(f) Modeling bare-binary install declaratively** (per-platform install
+command matrix in the descriptor). Rejected: too heterogeneous. Version
+pins, build steps, and OS branches can't be captured in a static schema. The
+v2 install agent reasons through this at runtime instead.
+
+## Deferred (noted, not decided)
+
+**v2: skill dependency edge.** Once
+[ADR-0009](./0009-coupling-tiers-and-dependencies.md) lands, the
+`requires` vocabulary will be extended with `mcps` so a skill can declare
+`requires: { mcps: [drawio] }`. Resolving the dependency would re-use the
+v1 config-write machinery. v2 also includes a generated skill-body preflight
+(verify the MCP responds before the skill body runs) and an **install agent**
+— an `agent` SSOT item that reasons through bare-binary provisioning at
+runtime under the client's permission prompts. upskill stays
+execution-free.
+
+**Non-Claude clients.** opencode, VS Code (`code --add-mcp`), and GitHub
+Copilot MCP configuration are deferred. When added, they will follow the
+same CLI-first / config-write-fallback pattern used here for Claude.
+
+## Migration
+
+None — additive. `mcps:` is optional on Bundle. Existing bundles without
+`mcps:` are unaffected. Old lockfiles without an `mcps` array load fine
+(serde `#[serde(default)]`). Lockfile `schema` stays at `1`.
+
+## References
+
+- Structural precedent: [ADR-0008](./0008-plugin-install-shellout.md) —
+  plugin install via client CLI shellout.
+- Dependency coupling model (v2 prerequisite):
+  [ADR-0009](./0009-coupling-tiers-and-dependencies.md).
+- Design spec (background, rationale, alternatives):
+  [`docs/superpowers/specs/2026-06-03-mcp-support-design.md`](../superpowers/specs/2026-06-03-mcp-support-design.md).
+- Authoritative format spec: [`docs/format-spec.md`](../format-spec.md)
+  §3.7 — `mcps:` sub-shape.
+- `src/model/bundle.rs`, `src/mcp.rs`, `src/ancillary.rs`,
+  `src/pipeline/install.rs`, `src/lockfile.rs` — as-built implementation.

--- a/docs/adr/0010-mcp-config-write.md
+++ b/docs/adr/0010-mcp-config-write.md
@@ -104,8 +104,8 @@ upskill never owns a secret value. The rule:
 - upskill MUST NOT persist a literal secret — not into a client config
   file, not into the lockfile, not into SSOT.
 - `requires-env: [VAR, …]` is a **declaration** (not a value). It lets
-  `upskill doctor` warn that an MCP server needs a variable that is not set
-  in the current environment, without ever reading the value.
+  `upskill add` warn at install time that an MCP server needs a variable that
+  is not set in the current environment, without ever reading the value.
 
 This is the same posture upskill already takes for git auth (tokens come
 from env / `gh` / `glab`, never persisted).
@@ -185,9 +185,14 @@ entries silently ignore the unknown array (serde `default`).
 - **`upskill doctor`**: checks each `claude`-client MCP entry in the
   lockfile via `claude mcp list` (substring match on the server name). A
   server present in the lockfile but absent from the client makes doctor
-  report `NotRegistered` and exit non-clean (exit 1). Doctor also warns on
-  unset `requires-env` variables. Reconciliation never auto-removes entries
-  — consistent with the project's "never auto-delete" ethos.
+  report `NotRegistered` and exit non-clean (exit 1). Doctor also reports
+  `CliNotFound` when the `claude` CLI is absent and `QueryFailed` when the
+  list query fails; it does **not** check `requires-env` variables.
+  Reconciliation never auto-removes entries — consistent with the project's
+  "never auto-delete" ethos.
+- **`upskill add` (install time)**: warns for each variable listed in
+  `requires-env` that is not set in the current environment, immediately
+  after configuring the server.
 
 ### Implementation shape
 
@@ -237,8 +242,8 @@ entries silently ignore the unknown array (serde `default`).
   tests that exercise config-write must clear PATH or point to an absent
   binary.
 - The warn-skip policy can mask a real misconfiguration. Mitigated by
-  `doctor`, which surfaces every `NotRegistered` server and every unset
-  `requires-env` variable.
+  `doctor`, which surfaces every `NotRegistered` server, and by `upskill add`
+  which warns at install time for every unset `requires-env` variable.
 - Config-write fallback (`.mcp.json`) is a project-scope file; it does not
   cover the global scope as cleanly as the CLI. The global config location
   is client-version-specific and not yet handled by the fallback path.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@ Numbered sequentially. Status one of: Proposed | Accepted | Superseded.
 - [0006 — Flat item layout — drop kind subdirectories](0006-flat-item-layout.md)
 - [0007 — Bundle file format — YAML, not Markdown-with-frontmatter](0007-bundle-yaml-format.md)
 - [0008 — Plugin installation — extend Bundle, shell out to client CLIs](0008-plugin-install-shellout.md)
+- [0010 — MCP server configuration — bundle `mcps:`, CLI-first config-write](0010-mcp-config-write.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,4 +11,5 @@ Numbered sequentially. Status one of: Proposed | Accepted | Superseded.
 - [0006 — Flat item layout — drop kind subdirectories](0006-flat-item-layout.md)
 - [0007 — Bundle file format — YAML, not Markdown-with-frontmatter](0007-bundle-yaml-format.md)
 - [0008 — Plugin installation — extend Bundle, shell out to client CLIs](0008-plugin-install-shellout.md)
+- 0009 — reserved (coupling tiers and dependency edges — in flight on a separate branch)
 - [0010 — MCP server configuration — bundle `mcps:`, CLI-first config-write](0010-mcp-config-write.md)

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -690,8 +690,9 @@ be empty.
 use `${VAR}` syntax only. Implementations MUST pass these values through verbatim to the client
 config — they MUST NOT expand `${VAR}` references, read the underlying values, or store literal
 secret values anywhere (not in config files, not in the lockfile, not in SSOT). The
-`requires-env` list declares which variable names are needed; `upskill doctor` uses this list
-to warn when a declared variable is unset in the current environment, without reading its value.
+`requires-env` list declares which variable names are needed; implementations SHOULD warn at
+install time (e.g., during `upskill add`) when a declared variable is unset in the current
+environment, without reading its value.
 
 **Per-client install behavior (v1):** v1 targets Claude Code only. Other clients produce a
 warn-skip.
@@ -743,8 +744,10 @@ when the CLI is absent) and drops the `LockedMcp` entry from the lockfile.
 
 **Reconciliation:** `upskill doctor` checks each Claude-client MCP entry in the lockfile
 against `claude mcp list`. A server present in the lockfile but absent from the client is
-reported as not registered and causes doctor to exit non-clean (exit 1). Doctor also warns when
-any variable listed in `requires-env` is unset in the current environment.
+reported as `NotRegistered` and causes doctor to exit non-clean (exit 1). Doctor also reports
+`CliNotFound` when the `claude` CLI is absent and `QueryFailed` when the list query fails;
+it does not check `requires-env` variables. The unset-env warning for `requires-env` variables
+is emitted by `upskill add` at install time.
 
 Implementations:
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -459,6 +459,7 @@ documentation; the parser ignores it (§2.2).
 | `items.agents` | string[] | no       | Agent names.                         |
 | `requires`     | array    | no       | Bundle dependencies. See below.      |
 | `plugins`      | map      | no       | Client-native plugins. See below.    |
+| `mcps`         | map      | no       | MCP server descriptors. See below.   |
 | `metadata`     | map      | no       | Same as §3.6.                        |
 
 `requires` entries are maps. Each entry references another bundle by `name`, optionally pinned
@@ -639,6 +640,121 @@ Implementations:
 - MUST use warn-skip when the target client CLI is not found (`ErrorKind::NotFound`).
 - MUST NOT fail the entire bundle install when a single plugin install fails or is skipped.
 
+#### `mcps` map
+
+The optional `mcps` map declares MCP (Model Context Protocol) servers that accompany this
+bundle. Configuring an MCP server requires no content generation — instead, upskill writes the
+server into each targeted client's MCP configuration at install time. See
+[ADR-0010](adr/0010-mcp-config-write.md) for design rationale.
+
+Each entry in the `mcps` map is keyed by an upskill-level MCP name (used in the lockfile, CLI
+output, and `upskill remove-mcp`). The value carries a transport descriptor and an optional list
+of declared environment variables:
+
+```yaml
+mcps:
+  drawio: # remote server over HTTP
+    remote:
+      type: http # http | sse
+      url: https://mcp.draw.io/mcp
+      headers: # optional; values MUST use ${VAR} references for secrets
+        Authorization: "Bearer ${DRAWIO_TOKEN}"
+    requires-env: [DRAWIO_TOKEN]
+
+  my-tool: # local server spawned over stdio
+    local:
+      command: npx
+      args: ["-y", "my-tool-mcp"]
+      env: # optional; values MUST use ${VAR} references for secrets
+        API_KEY: "${MY_TOOL_API_KEY}"
+    requires-env: [MY_TOOL_API_KEY]
+```
+
+Exactly one of `remote:` or `local:` MUST be present per entry; both or neither is a validation
+error. `remote.type` MUST be one of `http` or `sse`. `remote.url` and `local.command` MUST NOT
+be empty.
+
+**Transport descriptor fields:**
+
+| Transport | Field          | Type     | Required | Description                                                  |
+| --------- | -------------- | -------- | -------- | ------------------------------------------------------------ |
+| `remote`  | `type`         | string   | YES      | Protocol: `http` or `sse`.                                   |
+| `remote`  | `url`          | string   | YES      | Endpoint URL the client connects to.                         |
+| `remote`  | `headers`      | map      | no       | HTTP headers. Values pass through verbatim (use `${VAR}`).   |
+| `local`   | `command`      | string   | YES      | Launcher command (e.g. `npx`, `uvx`, `docker`, bare binary). |
+| `local`   | `args`         | string[] | no       | Arguments passed to the command.                             |
+| `local`   | `env`          | map      | no       | Environment variables. Values pass through verbatim.         |
+| (either)  | `requires-env` | string[] | no       | Env var names the server requires (declared, not valued).    |
+
+**Secrets and `${VAR}` indirection.** Values in `headers` and `env` that reference secrets MUST
+use `${VAR}` syntax only. Implementations MUST pass these values through verbatim to the client
+config — they MUST NOT expand `${VAR}` references, read the underlying values, or store literal
+secret values anywhere (not in config files, not in the lockfile, not in SSOT). The
+`requires-env` list declares which variable names are needed; `upskill doctor` uses this list
+to warn when a declared variable is unset in the current environment, without reading its value.
+
+**Per-client install behavior (v1):** v1 targets Claude Code only. Other clients produce a
+warn-skip.
+
+| Client      | Primary (CLI)                                                                         | Fallback (config-write, CLI absent)                          |
+| ----------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Claude Code | `claude mcp add <name> --scope <scope> [-e K=${V}] -- <cmd> [args]` (local)           | Write `{ "mcpServers": { "<name>": { … } } }` to `.mcp.json` |
+| Claude Code | `claude mcp add --transport <http\|sse> <name> <url> --scope <scope> [-H …]` (remote) | Same `.mcp.json` fallback                                    |
+| other       | not supported in v1 — warn-skip                                                       | —                                                            |
+
+Claude's `--scope` derives from upskill's project/global context:
+
+| upskill scope | `claude --scope` |
+| ------------- | ---------------- |
+| project       | `project`        |
+| global        | `user`           |
+
+**CLI-missing policy (warn-skip):** If the target client CLI is not on PATH, the implementation
+MUST fall back to writing the client config file. If the config-write also fails, it MUST print
+a warning and continue installing the rest of the bundle. The rules, skills, and agents portion
+of the bundle MUST install regardless of MCP configuration success.
+
+**Lockfile recording:** Each configured or warn-skipped MCP server MUST be recorded in the
+lockfile with its client, scope, bundle, and status:
+
+| `status`      | Meaning                                                                    |
+| ------------- | -------------------------------------------------------------------------- |
+| `"installed"` | Configured successfully via CLI shellout or config-write.                  |
+| `"skipped"`   | Client CLI was not on PATH and no config-write target applied (warn-skip). |
+
+Lockfile MCP entry shape:
+
+```json
+{
+  "name": "drawio",
+  "client": "claude",
+  "scope": "project",
+  "bundle": "drawio-diagrams",
+  "status": "installed"
+}
+```
+
+The `mcps` array is additive. Implementations that do not support this field MUST ignore it
+(serde `default`). The lockfile `schema` field stays at `1` — no version bump.
+
+**Removal:** `upskill remove-mcp <name>` unregisters the named server from the client (via
+`claude mcp remove <name> --scope <scope>`, falling back to removing the entry from `.mcp.json`
+when the CLI is absent) and drops the `LockedMcp` entry from the lockfile.
+
+**Reconciliation:** `upskill doctor` checks each Claude-client MCP entry in the lockfile
+against `claude mcp list`. A server present in the lockfile but absent from the client is
+reported as not registered and causes doctor to exit non-clean (exit 1). Doctor also warns when
+any variable listed in `requires-env` is unset in the current environment.
+
+Implementations:
+
+- MUST prefer the client's native MCP CLI verb over direct config-file writes.
+- MUST fall back to writing the client config file when the CLI is not found.
+- MUST treat MCP configuration as idempotent (re-configuring an existing server is a no-op or
+  safe overwrite).
+- MUST NOT fail the entire bundle install when a single MCP configuration fails or is skipped.
+- MUST NOT expand `${VAR}` references in header or env values.
+
 ### 3.8 Frontmatter canonicalisation
 
 An implementation MAY provide a formatting command (e.g., `upskill fmt`) that canonicalises SSOT
@@ -653,7 +769,7 @@ following order (unlisted keys appear at the end in their original relative orde
 | Rule   | `schema`, `name`, `description`, `audience`, `license`, `scope`, `metadata`, `claude`, `copilot`, `opencode`, `extras`                                    |
 | Skill  | `schema`, `name`, `description`, `audience`, `license`, `tools`, `preload-skills`, `metadata`, `claude`, `copilot`, `opencode`, `extras`                  |
 | Agent  | `schema`, `name`, `description`, `audience`, `license`, `mode`, `model`, `tools`, `preload-skills`, `metadata`, `claude`, `copilot`, `opencode`, `extras` |
-| Bundle | `schema`, `name`, `description`, `license`, `items`, `requires`, `plugins`, `metadata`, `extras`                                                          |
+| Bundle | `schema`, `name`, `description`, `license`, `items`, `requires`, `plugins`, `mcps`, `metadata`, `extras`                                                  |
 
 **Comment preservation.** Canonicalisation:
 

--- a/docs/superpowers/plans/2026-06-03-mcp-support-v1.md
+++ b/docs/superpowers/plans/2026-06-03-mcp-support-v1.md
@@ -1,0 +1,1481 @@
+# MCP Server Support (v1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an upskill bundle declare MCP servers (`mcps:`) that `upskill add` configures into each targeted client — CLI-first, config-write fallback — with a lockfile + `doctor` lifecycle and `${VAR}` secret indirection.
+
+**Architecture:** A near-exact parallel of the existing plugin mechanism (ADR-0008). A new `mcps:` map on `Bundle` carries per-server descriptors (remote `http`/`sse` URL, or local stdio `command`). A new `src/mcp.rs` module shells out to each client's native MCP verb (`claude mcp add`), falling back to writing the client config file when the CLI is absent. Outcomes are recorded as `LockedMcp` entries; `remove`/`doctor` reconcile via the inverse verb. upskill never expands `${VAR}` — values pass through verbatim, so it holds no secret.
+
+**Tech Stack:** Rust 2024 (MSRV 1.85), `serde`/`serde_yaml_ng`/`serde_json`, `std::process::Command` (no new deps), `assert_cmd` + `tempfile` for integration tests.
+
+**Spec:** [docs/superpowers/specs/2026-06-03-mcp-support-design.md](../specs/2026-06-03-mcp-support-design.md)
+
+**Out of scope (v2):** `requires.mcps` skill dependency edge, generated skill-body preflight, the install agent for bare binaries. This plan is v1 (bundle-level, eager config-write) only.
+
+---
+
+## File Structure
+
+| File                                | Responsibility                                                                                                                | New/Modify |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `src/model/bundle.rs`               | `mcps: BTreeMap<String, McpEntry>` on `Bundle`; `McpEntry`, `McpTransport`, `McpRemote`, `McpLocal` types + `validate_mcps()` | Modify     |
+| `src/parse/bundle.rs`               | Call `bundle.validate_mcps()` from `load`/`load_if_bundle`; parse tests                                                       | Modify     |
+| `src/mcp.rs`                        | Client shellout (`claude mcp add`/`remove`/`list`) + outcome types; reuses `plugin.rs` command helpers                        | New        |
+| `src/plugin.rs`                     | Make `run_command`, `run_command_output`, `CommandOutput`, `check_output_for_substring` `pub(crate)` for reuse                | Modify     |
+| `src/ancillary.rs`                  | `write_claude_mcp_json`, `write_opencode_mcp`, `write_vscode_mcp_json` config-write fallbacks                                 | Modify     |
+| `src/pipeline/report.rs`            | `McpResult` struct; `mcp_results` field on `InstallReport`                                                                    | Modify     |
+| `src/pipeline/install.rs`           | `install_mcps_from_bundles()`                                                                                                 | Modify     |
+| `src/pipeline/mod.rs`               | Call it; record `LockedMcp` entries                                                                                           | Modify     |
+| `src/lockfile.rs`                   | `LockedMcp`, `McpInstallStatus`, `upsert_mcp`, `remove_mcps_by_name`; `mcps` field                                            | Modify     |
+| `src/main.rs`                       | `print_mcp_results`; `remove mcp <name>`; doctor reconciliation + `requires-env` warn                                         | Modify     |
+| `src/lint.rs`                       | Lint `mcps:` shape (delegates to `validate_mcps`)                                                                             | Modify     |
+| `tests/cli_mcp.rs`                  | CLI integration: config-write + warn-skip + remove                                                                            | New        |
+| `tests/pipeline_mcp.rs`             | Pipeline + lockfile recording                                                                                                 | New        |
+| `docs/adr/0010-mcp-config-write.md` | ADR for this decision                                                                                                         | New        |
+| `docs/format-spec.md`               | `mcps:` sub-shape + lockfile schema note                                                                                      | Modify     |
+
+> **Worktree note:** all paths are relative to the worktree root
+> `.claude/worktrees/feat-mcp-support/`. Use the full worktree-prefixed
+> absolute path for every Write/Edit.
+
+---
+
+## Task 1: Model — `mcps:` descriptor types
+
+**Files:**
+
+- Modify: `src/model/bundle.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `#[cfg(test)] mod tests` in `src/parse/bundle.rs` (it already exercises `Bundle` parsing — the model has no own test module):
+
+```rust
+#[test]
+fn load_parses_mcp_remote_and_local() {
+    use crate::model::bundle::McpTransport;
+
+    let content = "schema: 1
+name: with-mcp
+description: Bundle with MCP servers
+items:
+  skills: []
+mcps:
+  drawio:
+    remote:
+      type: http
+      url: https://mcp.draw.io/mcp
+  local-server:
+    local:
+      command: npx
+      args: [\"-y\", \"drawio-mcp-server\"]
+      env:
+        DRAWIO_TOKEN: \"${DRAWIO_TOKEN}\"
+    requires-env: [DRAWIO_TOKEN]
+";
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_file(tmp.path(), "with-mcp.bundle.yaml", content);
+
+    let bundle = load(&path).expect("load");
+    assert_eq!(bundle.mcps.len(), 2);
+
+    match &bundle.mcps["drawio"].transport {
+        McpTransport::Remote(r) => {
+            assert_eq!(r.transport_type, "http");
+            assert_eq!(r.url, "https://mcp.draw.io/mcp");
+        }
+        McpTransport::Local(_) => panic!("expected remote"),
+    }
+
+    let local = &bundle.mcps["local-server"];
+    match &local.transport {
+        McpTransport::Local(l) => {
+            assert_eq!(l.command, "npx");
+            assert_eq!(l.args, vec!["-y", "drawio-mcp-server"]);
+            assert_eq!(l.env["DRAWIO_TOKEN"], "${DRAWIO_TOKEN}");
+        }
+        McpTransport::Remote(_) => panic!("expected local"),
+    }
+    assert_eq!(local.requires_env, vec!["DRAWIO_TOKEN"]);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib parse::bundle::tests::load_parses_mcp_remote_and_local`
+Expected: FAIL — `no field mcps on type Bundle` / `unresolved import McpTransport`.
+
+- [ ] **Step 3: Add the model types**
+
+In `src/model/bundle.rs`, add the field to `Bundle` (next to `plugins`):
+
+```rust
+/// MCP servers configured into each targeted client (ADR-0010, §3.8).
+/// Map key is the upskill-level MCP name; value carries the transport
+/// descriptor and declared required env vars.
+#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+pub mcps: BTreeMap<String, McpEntry>,
+```
+
+Append these types to the end of the file (before `#[cfg(test)]` if any, else end):
+
+```rust
+/// One entry in the bundle `mcps:` map. Exactly one transport (`remote`
+/// or `local`) is present; `validate_mcps` enforces this.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpEntry {
+    /// Transport descriptor — flattened so YAML carries either a
+    /// `remote:` or a `local:` key directly under the server name.
+    #[serde(flatten)]
+    pub transport: McpTransport,
+
+    /// Environment variables the server requires. Declared (not valued) so
+    /// `upskill doctor` can warn when one is unset. upskill never reads the
+    /// values — secret custody stays with the user's environment.
+    #[serde(default, rename = "requires-env", skip_serializing_if = "Vec::is_empty")]
+    pub requires_env: Vec<String>,
+}
+
+/// MCP transport: a hosted server reached by URL, or a local process the
+/// client spawns and speaks to over stdio.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum McpTransport {
+    #[serde(rename = "remote")]
+    Remote(McpRemote),
+    #[serde(rename = "local")]
+    Local(McpLocal),
+}
+
+/// Remote (hosted) MCP server descriptor.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpRemote {
+    /// `http` or `sse`.
+    #[serde(rename = "type")]
+    pub transport_type: String,
+    /// Endpoint URL the client connects to.
+    pub url: String,
+    /// Optional headers. Values pass through verbatim (use `${VAR}`
+    /// references for secrets — upskill never expands them).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
+/// Local (stdio) MCP server descriptor.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpLocal {
+    /// Launcher command (e.g. `npx`, `uvx`, `docker`, or a bare binary).
+    pub command: String,
+    /// Arguments passed to the command.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    /// Environment variables. Values pass through verbatim (use `${VAR}`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --lib parse::bundle::tests::load_parses_mcp_remote_and_local`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/model/bundle.rs src/parse/bundle.rs
+git commit -m "feat(model): add mcps: descriptor types to Bundle"
+```
+
+---
+
+## Task 2: Model — validation (`exactly-one-of`, remote/local required fields)
+
+`#[serde(flatten)]` on an untagged-style enum already rejects "neither"
+(deserialization fails when neither `remote` nor `local` is present) and
+"both" is rejected because `McpTransport` deserializes the first matching
+variant — so we add an explicit `validate_mcps` for the cases serde does not
+catch: an empty `type`/`url`/`command`, and an unknown remote `type`.
+
+**Files:**
+
+- Modify: `src/model/bundle.rs`
+- Modify: `src/parse/bundle.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/parse/bundle.rs` tests:
+
+```rust
+#[test]
+fn load_rejects_mcp_remote_with_bad_type() {
+    let content = "schema: 1
+name: bad-type
+description: bad transport type
+items:
+  skills: []
+mcps:
+  x:
+    remote:
+      type: websocket
+      url: https://example.com
+";
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_file(tmp.path(), "bad-type.bundle.yaml", content);
+    let err = load(&path).expect_err("must reject unknown transport type");
+    let msg = format!("{:#}", err);
+    assert!(msg.contains("transport type") && msg.contains("websocket"), "got: {msg}");
+}
+
+#[test]
+fn load_rejects_mcp_local_empty_command() {
+    let content = "schema: 1
+name: empty-cmd
+description: empty command
+items:
+  skills: []
+mcps:
+  x:
+    local:
+      command: \"\"
+";
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_file(tmp.path(), "empty-cmd.bundle.yaml", content);
+    let err = load(&path).expect_err("must reject empty command");
+    let msg = format!("{:#}", err);
+    assert!(msg.contains("command") && msg.contains("empty"), "got: {msg}");
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib parse::bundle::tests::load_rejects_mcp`
+Expected: FAIL — `load` currently accepts these (no validation).
+
+- [ ] **Step 3: Add `validate_mcps` and call it**
+
+In `src/model/bundle.rs`, add an `impl Bundle` block (or extend an existing one):
+
+```rust
+impl Bundle {
+    /// Validate the `mcps:` map beyond what serde enforces. Returns the
+    /// first offending `(server-name, reason)` as an error.
+    pub fn validate_mcps(&self) -> Result<(), String> {
+        for (name, entry) in &self.mcps {
+            match &entry.transport {
+                McpTransport::Remote(r) => {
+                    if r.transport_type != "http" && r.transport_type != "sse" {
+                        return Err(format!(
+                            "mcp `{name}`: transport type `{}` is not one of http, sse",
+                            r.transport_type
+                        ));
+                    }
+                    if r.url.trim().is_empty() {
+                        return Err(format!("mcp `{name}`: remote url must not be empty"));
+                    }
+                }
+                McpTransport::Local(l) => {
+                    if l.command.trim().is_empty() {
+                        return Err(format!("mcp `{name}`: local command must not be empty"));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+In `src/parse/bundle.rs`, in **both** `load` and `load_if_bundle`, after the
+filename-stem check and before `Ok(bundle)` / `Ok(Some(bundle))`, add:
+
+```rust
+bundle
+    .validate_mcps()
+    .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib parse::bundle::tests::load_rejects_mcp`
+Expected: PASS (both).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/model/bundle.rs src/parse/bundle.rs
+git commit -m "feat(model): validate mcps transport fields"
+```
+
+---
+
+## Task 3: Expose `plugin.rs` command helpers for reuse
+
+`src/mcp.rs` needs the same spawn/CLI-not-found/run helpers `plugin.rs`
+already has. Promote them to `pub(crate)` rather than duplicating.
+
+**Files:**
+
+- Modify: `src/plugin.rs`
+
+- [ ] **Step 1: Promote visibility**
+
+In `src/plugin.rs`, change these signatures (bodies unchanged):
+
+```rust
+pub(crate) enum CommandOutput {
+    Success { stdout: String },
+    CliNotFound,
+    Failed { exit_code: Option<i32>, stderr: String },
+}
+
+pub(crate) fn run_command_output(program: &str, args: &[&str]) -> CommandOutput { /* unchanged */ }
+
+pub(crate) fn run_command(program: &str, args: &[&str]) -> PluginOutcome { /* unchanged */ }
+
+pub(crate) fn check_output_for_substring(output: CommandOutput, needle: &str) -> PluginCheckResult { /* unchanged */ }
+```
+
+(`is_cli_available` and `PluginOutcome`/`PluginCheckResult` are already `pub`.)
+
+- [ ] **Step 2: Verify the crate still builds**
+
+Run: `cargo build`
+Expected: builds with zero warnings (the items are now used cross-module in later tasks; until then `pub(crate)` on an in-crate-unused item does not warn).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/plugin.rs
+git commit -m "refactor(plugin): expose command helpers as pub(crate)"
+```
+
+---
+
+## Task 4: `src/mcp.rs` — Claude CLI shellout (add)
+
+**Files:**
+
+- Create: `src/mcp.rs`
+- Modify: `src/lib.rs` (add `pub mod mcp;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/mcp.rs` with only this test module to start:
+
+```rust
+//! Client-native MCP server configuration (ADR-0010).
+//!
+//! CLI-first: shells out to each client's MCP verb (`claude mcp add`),
+//! falling back to writing the client config file when the CLI is absent.
+//! Reuses the command helpers in [`crate::plugin`]. Never expands `${VAR}`
+//! values — they pass through verbatim, so upskill holds no secret.
+
+use crate::model::bundle::{McpLocal, McpRemote};
+use crate::plugin::PluginScope;
+
+/// Build the argument vector for `claude mcp add` from a local (stdio)
+/// descriptor. Returned as owned strings so the caller can borrow them.
+pub fn claude_add_local_args(name: &str, local: &McpLocal, scope: PluginScope) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        name.to_string(),
+        "--scope".to_string(),
+        scope.as_claude_flag().to_string(),
+    ];
+    for (k, v) in &local.env {
+        args.push("-e".to_string());
+        args.push(format!("{k}={v}"));
+    }
+    args.push("--".to_string());
+    args.push(local.command.clone());
+    args.extend(local.args.iter().cloned());
+    args
+}
+
+/// Build the argument vector for `claude mcp add` from a remote descriptor.
+pub fn claude_add_remote_args(name: &str, remote: &McpRemote, scope: PluginScope) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "--transport".to_string(),
+        remote.transport_type.clone(),
+        name.to_string(),
+        remote.url.clone(),
+        "--scope".to_string(),
+        scope.as_claude_flag().to_string(),
+    ];
+    for (header, value) in &remote.headers {
+        args.push("-H".to_string());
+        args.push(format!("{header}: {value}"));
+    }
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn claude_local_args_include_scope_env_and_command() {
+        let mut env = BTreeMap::new();
+        env.insert("DRAWIO_TOKEN".to_string(), "${DRAWIO_TOKEN}".to_string());
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec!["-y".into(), "drawio-mcp-server".into()],
+            env,
+        };
+        let args = claude_add_local_args("drawio", &local, PluginScope::Project);
+        assert_eq!(
+            args,
+            vec![
+                "mcp", "add", "drawio", "--scope", "project",
+                "-e", "DRAWIO_TOKEN=${DRAWIO_TOKEN}",
+                "--", "npx", "-y", "drawio-mcp-server",
+            ]
+        );
+    }
+
+    #[test]
+    fn claude_remote_args_include_transport_and_url() {
+        let remote = McpRemote {
+            transport_type: "http".into(),
+            url: "https://mcp.draw.io/mcp".into(),
+            headers: BTreeMap::new(),
+        };
+        let args = claude_add_remote_args("drawio", &remote, PluginScope::User);
+        assert_eq!(
+            args,
+            vec![
+                "mcp", "add", "--transport", "http",
+                "drawio", "https://mcp.draw.io/mcp",
+                "--scope", "user",
+            ]
+        );
+    }
+}
+```
+
+Add to `src/lib.rs` alphabetically near `pub mod plugin;`:
+
+```rust
+pub mod mcp;
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `cargo test --lib mcp::tests`
+Expected: PASS (these are pure arg-builders — they pass as soon as the code compiles; the value is locking the exact CLI contract).
+
+- [ ] **Step 3: Add the install/remove/check shellout functions**
+
+Append to `src/mcp.rs` (before the test module):
+
+```rust
+use crate::plugin::{PluginCheckResult, PluginOutcome};
+
+/// Install a local (stdio) MCP server into Claude Code via `claude mcp add`.
+pub fn install_claude_local(name: &str, local: &McpLocal, scope: PluginScope) -> PluginOutcome {
+    let args = claude_add_local_args(name, local, scope);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::plugin::run_command("claude", &arg_refs)
+}
+
+/// Install a remote MCP server into Claude Code via `claude mcp add`.
+pub fn install_claude_remote(name: &str, remote: &McpRemote, scope: PluginScope) -> PluginOutcome {
+    let args = claude_add_remote_args(name, remote, scope);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::plugin::run_command("claude", &arg_refs)
+}
+
+/// Remove an MCP server from Claude Code via `claude mcp remove`.
+pub fn uninstall_claude(name: &str, scope: PluginScope) -> PluginOutcome {
+    crate::plugin::run_command(
+        "claude",
+        &["mcp", "remove", name, "--scope", scope.as_claude_flag()],
+    )
+}
+
+/// Check whether an MCP server is registered in Claude Code via
+/// `claude mcp list` (substring match on the server name).
+pub fn check_claude_installed(name: &str) -> PluginCheckResult {
+    let out = crate::plugin::run_command_output("claude", &["mcp", "list"]);
+    crate::plugin::check_output_for_substring(out, name)
+}
+```
+
+- [ ] **Step 4: Run the full module + build**
+
+Run: `cargo test --lib mcp:: && cargo build`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp.rs src/lib.rs
+git commit -m "feat(mcp): claude mcp add/remove/list shellout"
+```
+
+---
+
+## Task 5: `src/ancillary.rs` — config-write fallbacks
+
+Write the MCP entry into a client config file when its CLI is absent.
+`.mcp.json` (Claude project-scope fallback) and `opencode.json` (`mcp` key)
+are the v1 targets. Both merge without clobbering existing entries, mirroring
+`write_opencode_plugin_uri`.
+
+**Files:**
+
+- Modify: `src/ancillary.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` in `src/ancillary.rs`:
+
+```rust
+#[test]
+fn write_claude_mcp_json_adds_local_server() {
+    use crate::model::bundle::McpLocal;
+    use std::collections::BTreeMap;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let mut env = BTreeMap::new();
+    env.insert("TOK".to_string(), "${TOK}".to_string());
+    let local = McpLocal { command: "npx".into(), args: vec!["-y".into(), "srv".into()], env };
+
+    let outcome = write_claude_mcp_local(tmp.path(), "drawio", &local);
+    assert!(outcome.is_success());
+
+    let raw = std::fs::read_to_string(tmp.path().join(".mcp.json")).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(doc["mcpServers"]["drawio"]["command"], "npx");
+    assert_eq!(doc["mcpServers"]["drawio"]["args"][1], "srv");
+    assert_eq!(doc["mcpServers"]["drawio"]["env"]["TOK"], "${TOK}");
+}
+
+#[test]
+fn write_claude_mcp_json_preserves_existing_servers() {
+    use crate::model::bundle::McpLocal;
+    use std::collections::BTreeMap;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".mcp.json"),
+        r#"{"mcpServers":{"existing":{"command":"foo"}}}"#,
+    )
+    .unwrap();
+
+    let local = McpLocal { command: "npx".into(), args: vec![], env: BTreeMap::new() };
+    write_claude_mcp_local(tmp.path(), "drawio", &local);
+
+    let raw = std::fs::read_to_string(tmp.path().join(".mcp.json")).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(doc["mcpServers"]["existing"]["command"], "foo");
+    assert_eq!(doc["mcpServers"]["drawio"]["command"], "npx");
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib ancillary::tests::write_claude_mcp`
+Expected: FAIL — `write_claude_mcp_local` not found.
+
+- [ ] **Step 3: Implement the config-write helpers**
+
+Add to `src/ancillary.rs` (near `write_opencode_plugin_uri`). The
+`.mcp.json` shape Claude Code reads is `{ "mcpServers": { "<name>": {…} } }`:
+
+```rust
+use crate::model::bundle::{McpLocal, McpRemote};
+
+/// Filename Claude Code reads for project-scoped MCP servers.
+const CLAUDE_MCP_JSON: &str = ".mcp.json";
+
+/// Write a local (stdio) MCP server into `<target>/.mcp.json` under
+/// `mcpServers.<name>`. Merge-preserving; creates the file if absent.
+/// Used as the fallback when the `claude` CLI is not on PATH.
+pub fn write_claude_mcp_local(target: &Path, name: &str, local: &McpLocal) -> PluginOutcome {
+    let mut server = serde_json::Map::new();
+    server.insert("command".into(), json!(local.command));
+    if !local.args.is_empty() {
+        server.insert("args".into(), json!(local.args));
+    }
+    if !local.env.is_empty() {
+        let env: serde_json::Map<String, Value> =
+            local.env.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+        server.insert("env".into(), Value::Object(env));
+    }
+    upsert_mcp_server(target, name, Value::Object(server))
+}
+
+/// Write a remote MCP server into `<target>/.mcp.json` under
+/// `mcpServers.<name>`. Merge-preserving; creates the file if absent.
+pub fn write_claude_mcp_remote(target: &Path, name: &str, remote: &McpRemote) -> PluginOutcome {
+    let mut server = serde_json::Map::new();
+    server.insert("type".into(), json!(remote.transport_type));
+    server.insert("url".into(), json!(remote.url));
+    if !remote.headers.is_empty() {
+        let headers: serde_json::Map<String, Value> =
+            remote.headers.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+        server.insert("headers".into(), Value::Object(headers));
+    }
+    upsert_mcp_server(target, name, Value::Object(server))
+}
+
+/// Shared merge: insert `server` at `mcpServers.<name>` in `.mcp.json`,
+/// preserving any other top-level keys and other servers.
+fn upsert_mcp_server(target: &Path, name: &str, server: Value) -> PluginOutcome {
+    let path = target.join(CLAUDE_MCP_JSON);
+    let mut doc: Value = match std::fs::read_to_string(&path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => json!({}),
+        Err(e) => {
+            return PluginOutcome::Failed {
+                exit_code: None,
+                stderr: format!("read {}: {e}", path.display()),
+            };
+        }
+        Ok(raw) => match serde_json::from_str(&raw) {
+            Ok(v) => v,
+            Err(e) => {
+                return PluginOutcome::Failed {
+                    exit_code: None,
+                    stderr: format!("parse {}: {e}", path.display()),
+                };
+            }
+        },
+    };
+
+    if !doc.is_object() {
+        return PluginOutcome::Failed {
+            exit_code: None,
+            stderr: format!("{}: top-level value must be an object", path.display()),
+        };
+    }
+    let obj = doc.as_object_mut().expect("checked is_object");
+    let servers = obj
+        .entry("mcpServers")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Some(servers) = servers.as_object_mut() else {
+        return PluginOutcome::Failed {
+            exit_code: None,
+            stderr: format!("{}: `mcpServers` must be an object", path.display()),
+        };
+    };
+    servers.insert(name.to_string(), server);
+
+    if let Err(e) = write_pretty_json(&path, &doc) {
+        return PluginOutcome::Failed { exit_code: None, stderr: e.to_string() };
+    }
+    PluginOutcome::Success
+}
+
+/// Remove an MCP server from `<target>/.mcp.json`. No-op if absent.
+pub fn remove_claude_mcp(target: &Path, name: &str) -> Result<()> {
+    let path = target.join(CLAUDE_MCP_JSON);
+    let raw = match std::fs::read_to_string(&path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
+        Ok(r) => r,
+    };
+    let mut doc: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parse {}", path.display()))?;
+    if let Some(servers) = doc.get_mut("mcpServers").and_then(Value::as_object_mut) {
+        servers.remove(name);
+    }
+    write_pretty_json(&path, &doc)
+}
+```
+
+> If `json!`, `Value`, `write_pretty_json`, `PluginOutcome`, `Path`,
+> `Context`/`Result` are not already imported at the top of `ancillary.rs`,
+> add the missing `use` lines (the file already uses all of these for
+> `write_opencode_plugin_uri`).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib ancillary::tests::write_claude_mcp`
+Expected: PASS (both).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ancillary.rs
+git commit -m "feat(ancillary): .mcp.json config-write fallback for MCP servers"
+```
+
+---
+
+## Task 6: Lockfile — `LockedMcp` + lifecycle methods
+
+**Files:**
+
+- Modify: `src/lockfile.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` in `src/lockfile.rs`:
+
+```rust
+#[test]
+fn upsert_mcp_replaces_by_name_and_client() {
+    let mut lock = Lockfile::new();
+    lock.upsert_mcp(LockedMcp {
+        name: "drawio".into(),
+        client: "claude".into(),
+        scope: Some("project".into()),
+        bundle: "with-mcp".into(),
+        status: McpInstallStatus::Installed,
+    });
+    lock.upsert_mcp(LockedMcp {
+        name: "drawio".into(),
+        client: "claude".into(),
+        scope: Some("project".into()),
+        bundle: "with-mcp".into(),
+        status: McpInstallStatus::Skipped,
+    });
+    assert_eq!(lock.mcps.len(), 1);
+    assert_eq!(lock.mcps[0].status, McpInstallStatus::Skipped);
+}
+
+#[test]
+fn remove_mcps_by_name_drops_all_clients() {
+    let mut lock = Lockfile::new();
+    for client in ["claude", "opencode"] {
+        lock.upsert_mcp(LockedMcp {
+            name: "drawio".into(),
+            client: client.into(),
+            scope: None,
+            bundle: "with-mcp".into(),
+            status: McpInstallStatus::Installed,
+        });
+    }
+    lock.remove_mcps_by_name("drawio");
+    assert!(lock.mcps.is_empty());
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib lockfile::tests::upsert_mcp lockfile::tests::remove_mcps_by_name`
+Expected: FAIL — `mcps` field / `LockedMcp` / `upsert_mcp` not found.
+
+- [ ] **Step 3: Add the field, types, and methods**
+
+Add the field to `Lockfile` (after `plugins`):
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub mcps: Vec<LockedMcp>,
+```
+
+Initialize it in `Lockfile::new()`:
+
+```rust
+mcps: Vec::new(),
+```
+
+Add the types (near `LockedPlugin` / `PluginInstallStatus`):
+
+```rust
+/// MCP server entry recorded when a bundle's `mcps:` map is configured
+/// into a client (ADR-0010). One entry per (mcp-name, client) pair so
+/// `remove`/`doctor` can invoke the inverse CLI command.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LockedMcp {
+    /// Upskill-level MCP name (key in the bundle's `mcps:` map).
+    pub name: String,
+    /// Client identifier: `"claude"`, `"opencode"`, etc.
+    pub client: String,
+    /// Install scope (only meaningful for claude: `"project"` or `"user"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    /// Bundle that declared this MCP server.
+    pub bundle: String,
+    /// Configuration outcome recorded at `upskill add` time.
+    #[serde(default)]
+    pub status: McpInstallStatus,
+}
+
+/// Configuration status of an MCP entry in the lockfile (ADR-0010).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum McpInstallStatus {
+    /// Configured successfully (CLI shellout or config-write).
+    #[default]
+    Installed,
+    /// Skipped — the client CLI was not on PATH and no config-write target
+    /// applied (warn-skip outcome). `doctor` surfaces these.
+    Skipped,
+}
+```
+
+Add the methods to `impl Lockfile` (near `upsert_plugin`):
+
+```rust
+    /// Add or replace an MCP entry by `(name, client)`. Sorted for
+    /// deterministic on-disk output.
+    pub fn upsert_mcp(&mut self, mcp: LockedMcp) {
+        self.mcps
+            .retain(|existing| !(existing.name == mcp.name && existing.client == mcp.client));
+        self.mcps.push(mcp);
+        self.mcps.sort();
+    }
+
+    /// Remove all MCP entries matching `name` (across all clients).
+    pub fn remove_mcps_by_name(&mut self, name: &str) {
+        self.mcps.retain(|existing| existing.name != name);
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib lockfile::tests::upsert_mcp lockfile::tests::remove_mcps_by_name`
+Expected: PASS (both).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lockfile.rs
+git commit -m "feat(lockfile): record MCP servers (LockedMcp + lifecycle)"
+```
+
+---
+
+## Task 7: Pipeline — `McpResult` + `install_mcps_from_bundles`
+
+**Files:**
+
+- Modify: `src/pipeline/report.rs`
+- Modify: `src/pipeline/install.rs`
+- Modify: `src/pipeline/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/pipeline_mcp.rs` (new file — full file shown in Task 10; for
+now add this unit-level assertion to `src/pipeline/install.rs` tests, creating
+a `#[cfg(test)] mod tests` if none exists):
+
+```rust
+#[cfg(test)]
+mod mcp_tests {
+    use crate::model::bundle::{Bundle, McpEntry, McpLocal, McpRemote, McpTransport};
+    use crate::model::common::SchemaVersion;
+    use crate::plugin::PluginScope;
+    use std::collections::BTreeMap;
+
+    fn bundle_with_mcp(name: &str, entry: McpEntry) -> Bundle {
+        let mut mcps = BTreeMap::new();
+        mcps.insert(name.to_string(), entry);
+        Bundle {
+            schema: SchemaVersion::new(1),
+            name: "with-mcp".into(),
+            description: "test".into(),
+            license: None,
+            items: Default::default(),
+            requires: vec![],
+            plugins: BTreeMap::new(),
+            mcps,
+            metadata: None,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn install_mcps_records_result_per_server() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = McpEntry {
+            transport: McpTransport::Remote(McpRemote {
+                transport_type: "http".into(),
+                url: "https://example.com/mcp".into(),
+                headers: BTreeMap::new(),
+            }),
+            requires_env: vec![],
+        };
+        let bundles = vec![bundle_with_mcp("drawio", entry)];
+        let results =
+            super::install_mcps_from_bundles(&bundles, PluginScope::Project, tmp.path());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "drawio");
+        assert_eq!(results[0].client, "claude");
+        // No `claude` CLI on PATH in CI → CliNotFound, then config-write
+        // fallback writes .mcp.json and the result is Success.
+        assert!(results[0].outcome.is_success() || results[0].outcome.is_cli_not_found());
+    }
+}
+```
+
+> Adjust the `Bundle { … }` literal field list to match the current struct
+> exactly (run `cargo build` once and fix any field mismatch — e.g. if
+> `license`/`extra` differ). The `McpRemote`/`McpEntry`/`McpLocal` fields are
+> fixed by Task 1.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib pipeline::install::mcp_tests`
+Expected: FAIL — `install_mcps_from_bundles` not found; `mcp_results` not on report.
+
+- [ ] **Step 3: Add `McpResult` to the report**
+
+In `src/pipeline/report.rs`, add the struct (mirror `PluginResult`):
+
+```rust
+/// Result of a single MCP server configuration attempt, for reporting.
+#[derive(Debug, Clone)]
+pub struct McpResult {
+    /// Upskill-level MCP name.
+    pub name: String,
+    /// Client identifier.
+    pub client: String,
+    /// Configuration outcome.
+    pub outcome: crate::plugin::PluginOutcome,
+    /// Bundle that declared this MCP server.
+    pub bundle: String,
+    /// Env vars declared as required (for the `doctor`/warn surface).
+    pub requires_env: Vec<String>,
+}
+```
+
+Add the field to `InstallReport` (next to `plugin_results`):
+
+```rust
+/// Results of MCP server configuration (ADR-0010). Empty when no
+/// bundles with `mcps:` were resolved.
+pub mcp_results: Vec<McpResult>,
+```
+
+Initialize `mcp_results: Vec::new()` everywhere `InstallReport` is constructed
+(search: `grep -rn "plugin_results: Vec::new()" src/`) and add the sibling
+line. Also update the `lockfile.rs:391` test constructor similarly.
+
+- [ ] **Step 4: Add `install_mcps_from_bundles`**
+
+In `src/pipeline/install.rs`, after `install_plugins_from_bundles`:
+
+```rust
+// ---------------------------------------------------------------------------
+// MCP server configuration orchestration (ADR-0010)
+// ---------------------------------------------------------------------------
+
+/// Iterate all resolved bundles and configure each declared MCP server for
+/// Claude Code (v1's only target client). CLI-first: `claude mcp add`; on
+/// CliNotFound, fall back to writing `.mcp.json`. Warn-skip preserved: a
+/// failure never aborts the overall install.
+pub(super) fn install_mcps_from_bundles(
+    bundles: &[crate::model::Bundle],
+    scope: crate::plugin::PluginScope,
+    target: &Path,
+) -> Vec<McpResult> {
+    use crate::model::bundle::McpTransport;
+    use crate::plugin::PluginOutcome;
+
+    let mut results = Vec::new();
+    for bundle in bundles {
+        for (name, entry) in &bundle.mcps {
+            let cli_outcome = match &entry.transport {
+                McpTransport::Local(local) => {
+                    crate::mcp::install_claude_local(name, local, scope)
+                }
+                McpTransport::Remote(remote) => {
+                    crate::mcp::install_claude_remote(name, remote, scope)
+                }
+            };
+
+            // CLI absent → config-write fallback into .mcp.json.
+            let outcome = match cli_outcome {
+                PluginOutcome::CliNotFound => match &entry.transport {
+                    McpTransport::Local(local) => {
+                        crate::ancillary::write_claude_mcp_local(target, name, local)
+                    }
+                    McpTransport::Remote(remote) => {
+                        crate::ancillary::write_claude_mcp_remote(target, name, remote)
+                    }
+                },
+                other => other,
+            };
+
+            results.push(McpResult {
+                name: name.clone(),
+                client: "claude".into(),
+                outcome,
+                bundle: bundle.name.clone(),
+                requires_env: entry.requires_env.clone(),
+            });
+        }
+    }
+    results
+}
+```
+
+Ensure `McpResult` is imported at the top of `install.rs` (it likely already
+`use`s `PluginResult` from `super::report` — add `McpResult` to that list).
+
+- [ ] **Step 5: Wire into orchestration + lockfile recording**
+
+In `src/pipeline/mod.rs`, after the plugin block (`report.plugin_results = …`):
+
+```rust
+// -- MCP server configuration (ADR-0010) --
+let mcp_results = install_mcps_from_bundles(&report.bundles, plugin_scope, target);
+report.mcp_results = mcp_results;
+```
+
+And after the plugin lockfile-recording loop:
+
+```rust
+    // Record configured and warn-skipped MCP servers in the lockfile.
+    for mr in &report.mcp_results {
+        use crate::lockfile::McpInstallStatus;
+        use crate::plugin::PluginOutcome;
+
+        let status = match &mr.outcome {
+            PluginOutcome::Success => McpInstallStatus::Installed,
+            PluginOutcome::CliNotFound => McpInstallStatus::Skipped,
+            // ManualInstructions is unused for MCP; Failed is transient.
+            PluginOutcome::ManualInstructions | PluginOutcome::Failed { .. } => continue,
+        };
+        lock.upsert_mcp(crate::lockfile::LockedMcp {
+            name: mr.name.clone(),
+            client: mr.client.clone(),
+            scope: match plugin_scope {
+                crate::plugin::PluginScope::Project => Some("project".into()),
+                crate::plugin::PluginScope::User => Some("user".into()),
+            },
+            bundle: mr.bundle.clone(),
+            status,
+        });
+    }
+```
+
+Add `install_mcps_from_bundles` to the `use super::install::{…}` import in
+`mod.rs` (next to `install_plugins_from_bundles`).
+
+- [ ] **Step 6: Run the tests + build**
+
+Run: `cargo test --lib pipeline:: && cargo build`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pipeline/report.rs src/pipeline/install.rs src/pipeline/mod.rs src/lockfile.rs
+git commit -m "feat(pipeline): configure MCP servers from bundles + record in lockfile"
+```
+
+---
+
+## Task 8: main.rs — reporting, `remove mcp`, doctor
+
+**Files:**
+
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Add MCP result printing**
+
+Mirror `print_plugin_results`. Find it (`src/main.rs:361`) and add alongside:
+
+```rust
+fn print_mcp_results(report: &InstallReport) {
+    if style::is_quiet() || report.mcp_results.is_empty() {
+        return;
+    }
+    for mr in &report.mcp_results {
+        use crate::plugin::PluginOutcome;
+        match &mr.outcome {
+            PluginOutcome::Success => {
+                println!("  configured MCP server '{}' for {}", mr.name, mr.client);
+            }
+            PluginOutcome::CliNotFound => {
+                eprintln!(
+                    "warn: {} CLI not found and no config target; skipped MCP '{}'.",
+                    mr.client, mr.name
+                );
+            }
+            PluginOutcome::Failed { stderr, .. } => {
+                eprintln!("warn: failed to configure MCP '{}' for {}: {stderr}", mr.name, mr.client);
+            }
+            PluginOutcome::ManualInstructions => {}
+        }
+        // Warn about declared-but-unset secret env vars.
+        for var in &mr.requires_env {
+            if std::env::var_os(var).is_none() {
+                eprintln!(
+                    "warn: MCP '{}' needs env var '{var}'; it is not set in your environment.",
+                    mr.name
+                );
+            }
+        }
+    }
+}
+```
+
+Call it where `print_plugin_results(&report)` is called (`src/main.rs:179`):
+
+```rust
+print_plugin_results(&report);
+print_mcp_results(&report);
+```
+
+- [ ] **Step 2: Wire `upskill remove mcp <name>`**
+
+Find the `remove` command dispatch and the plugin-removal branch (search:
+`remove_plugins_by_name`). Add a parallel MCP branch. For each
+`LockedMcp` matching `name`, call the inverse:
+
+```rust
+// MCP removal: inverse of `claude mcp add`, then drop from lockfile.
+let mcp_scope = if global {
+    crate::plugin::PluginScope::User
+} else {
+    crate::plugin::PluginScope::Project
+};
+for mcp in lock.mcps.iter().filter(|m| m.name == name) {
+    if mcp.client == "claude" {
+        let outcome = crate::mcp::uninstall_claude(&mcp.name, mcp_scope);
+        if outcome.is_cli_not_found() {
+            // CLI gone → config-write removal fallback.
+            crate::ancillary::remove_claude_mcp(target, &mcp.name)?;
+        }
+    }
+}
+lock.remove_mcps_by_name(&name);
+```
+
+> Match the surrounding code's variable names (`global`, `target`, `lock`,
+> `name`) to whatever the existing remove branch uses; the plugin branch
+> immediately above is the template.
+
+- [ ] **Step 3: Add doctor reconciliation**
+
+Find the doctor plugin-reconciliation loop (search: `check_claude_plugin_installed`).
+Add a parallel MCP loop:
+
+```rust
+for mcp in &lock.mcps {
+    if mcp.client == "claude" {
+        match crate::mcp::check_claude_installed(&mcp.name) {
+            crate::plugin::PluginCheckResult::Installed => {}
+            crate::plugin::PluginCheckResult::NotInstalled => {
+                println!(
+                    "  MCP '{}' is in the lockfile but not registered in claude; re-run `upskill update`.",
+                    mcp.name
+                );
+            }
+            crate::plugin::PluginCheckResult::CliNotFound => {
+                println!("  claude CLI not found; cannot verify MCP '{}'.", mcp.name);
+            }
+            crate::plugin::PluginCheckResult::QueryFailed { stderr, .. } => {
+                println!("  could not query claude MCP list for '{}': {stderr}", mcp.name);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build + clippy**
+
+Run: `cargo build && cargo clippy --all-targets -- -D warnings`
+Expected: zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(cli): report, remove, and doctor-reconcile MCP servers"
+```
+
+---
+
+## Task 9: lint — surface `mcps` validation
+
+**Files:**
+
+- Modify: `src/lint.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lint.rs` tests (or `tests/cli_*`): a bundle whose `mcps` has a bad
+transport type should make `upskill lint` fail. If `lint.rs` already loads
+bundles via `parse::bundle::load`, `validate_mcps` (Task 2) already runs and
+this is covered — verify by test:
+
+```rust
+#[test]
+fn lint_flags_invalid_mcp_transport() {
+    // Construct a bundle with an invalid remote type and assert lint reports it.
+    use crate::model::bundle::{Bundle, McpEntry, McpRemote, McpTransport};
+    use crate::model::common::SchemaVersion;
+    use std::collections::BTreeMap;
+
+    let mut mcps = BTreeMap::new();
+    mcps.insert(
+        "x".to_string(),
+        McpEntry {
+            transport: McpTransport::Remote(McpRemote {
+                transport_type: "ftp".into(),
+                url: "https://x".into(),
+                headers: BTreeMap::new(),
+            }),
+            requires_env: vec![],
+        },
+    );
+    let bundle = Bundle {
+        schema: SchemaVersion::new(1),
+        name: "b".into(),
+        description: "d".into(),
+        license: None,
+        items: Default::default(),
+        requires: vec![],
+        plugins: BTreeMap::new(),
+        mcps,
+        metadata: None,
+        extra: BTreeMap::new(),
+    };
+    assert!(bundle.validate_mcps().is_err());
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test --lib lint::tests::lint_flags_invalid_mcp_transport`
+Expected: PASS if `validate_mcps` is reachable (it is — Task 2). If `lint.rs`
+has its own bundle-walk that bypasses `parse::bundle::load`, add a
+`bundle.validate_mcps()` call into that walk and surface the error string.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lint.rs
+git commit -m "test(lint): cover mcps transport validation"
+```
+
+---
+
+## Task 10: Integration tests — CLI add/remove + warn-skip
+
+**Files:**
+
+- Create: `tests/cli_mcp.rs`
+- Create: `tests/pipeline_mcp.rs`
+
+- [ ] **Step 1: Write `tests/cli_mcp.rs`**
+
+```rust
+//! Integration: `upskill add` of a local bundle declaring an MCP server.
+//! In CI no `claude` CLI is on PATH, so the config-write fallback fires and
+//! `.mcp.json` is written.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+/// Build a minimal SSOT registry with one skill and a bundle that declares
+/// a local MCP server, then `upskill add` it from the local path.
+#[test]
+fn add_bundle_with_mcp_writes_claude_mcp_json() {
+    let registry = tempdir().unwrap();
+    // A skill the bundle ships.
+    let skill_dir = registry.path().join("drawio-diagrams");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: drawio-diagrams\ndescription: draw.io diagrams\n---\nbody\n",
+    )
+    .unwrap();
+    // The bundle.
+    fs::write(
+        registry.path().join("drawio.bundle.yaml"),
+        "schema: 1\n\
+         name: drawio\n\
+         description: draw.io skill and MCP\n\
+         items:\n  skills:\n    - drawio-diagrams\n\
+         mcps:\n  drawio:\n    local:\n      command: npx\n      args: [\"-y\", \"drawio-mcp-server\"]\n      env:\n        DRAWIO_TOKEN: \"${DRAWIO_TOKEN}\"\n    requires-env: [DRAWIO_TOKEN]\n",
+    )
+    .unwrap();
+
+    let project = tempdir().unwrap();
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(project.path())
+        .env_remove("PATH") // ensure no `claude` CLI → config-write fallback
+        .env("PATH", "/nonexistent")
+        .args(["add", registry.path().to_str().unwrap(), "--claude"])
+        .assert()
+        .success();
+
+    let mcp_json = fs::read_to_string(project.path().join(".mcp.json")).unwrap();
+    assert!(mcp_json.contains("\"drawio\""), "got: {mcp_json}");
+    assert!(mcp_json.contains("npx"), "got: {mcp_json}");
+    assert!(mcp_json.contains("${DRAWIO_TOKEN}"), "secret reference preserved verbatim");
+
+    // Lockfile records the MCP entry.
+    let lock = fs::read_to_string(project.path().join(".upskill-lock.json")).unwrap();
+    assert!(lock.contains("\"drawio\""));
+    assert!(lock.contains("\"mcps\""));
+}
+```
+
+> If `env_remove("PATH")` then setting `PATH=/nonexistent` is awkward on the
+> CI runner (`upskill` itself was already located by `cargo_bin`, which
+> returns an absolute path, so it still runs), keep both lines. If the test
+> harness needs `git` on PATH for the local-path source, instead point `PATH`
+> at a temp dir containing only a `git` symlink. Verify by running the test.
+
+- [ ] **Step 2: Run it to verify it fails, then passes**
+
+Run: `cargo test --test cli_mcp`
+Expected: After Tasks 1–8, PASS. If it fails on PATH handling, adjust per the
+note above and re-run.
+
+- [ ] **Step 3: Write `tests/pipeline_mcp.rs`**
+
+```rust
+//! Integration: lockfile records MCP servers and `remove` drops them.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+fn make_registry() -> tempfile::TempDir {
+    let registry = tempdir().unwrap();
+    let skill_dir = registry.path().join("s");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "---\nname: s\ndescription: s\n---\nb\n").unwrap();
+    fs::write(
+        registry.path().join("b.bundle.yaml"),
+        "schema: 1\nname: b\ndescription: d\nitems:\n  skills:\n    - s\n\
+         mcps:\n  remote-srv:\n    remote:\n      type: http\n      url: https://example.com/mcp\n",
+    )
+    .unwrap();
+    registry
+}
+
+#[test]
+fn add_then_remove_mcp_updates_lockfile() {
+    let registry = make_registry();
+    let project = tempdir().unwrap();
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(project.path())
+        .env("PATH", "/nonexistent")
+        .args(["add", registry.path().to_str().unwrap(), "--claude"])
+        .assert()
+        .success();
+
+    let lock = fs::read_to_string(project.path().join(".upskill-lock.json")).unwrap();
+    assert!(lock.contains("remote-srv"));
+
+    Command::cargo_bin("upskill")
+        .unwrap()
+        .current_dir(project.path())
+        .env("PATH", "/nonexistent")
+        .args(["remove", "mcp", "remote-srv"])
+        .assert()
+        .success();
+
+    let lock = fs::read_to_string(project.path().join(".upskill-lock.json")).unwrap();
+    assert!(!lock.contains("remote-srv"), "MCP entry removed from lockfile");
+}
+```
+
+> Confirm the exact `remove` sub-command shape against the existing CLI
+> (`upskill remove plugin <name>` is the template — match its noun position
+> for `mcp`). Adjust the args array if the CLI uses `remove --mcp` instead.
+
+- [ ] **Step 4: Run it**
+
+Run: `cargo test --test pipeline_mcp`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/cli_mcp.rs tests/pipeline_mcp.rs
+git commit -m "test(mcp): CLI add config-write + lockfile record + remove"
+```
+
+---
+
+## Task 11: Docs — ADR-0010 + format-spec
+
+**Files:**
+
+- Create: `docs/adr/0010-mcp-config-write.md`
+- Modify: `docs/format-spec.md`
+- Modify: `docs/adr/README.md` (index, if it lists ADRs)
+
+- [ ] **Step 1: Write ADR-0010**
+
+Create `docs/adr/0010-mcp-config-write.md` capturing: context (no MCP support;
+skills need their server), decision (bundle-level `mcps:`, CLI-first with
+config-write fallback, `${VAR}` indirection + `requires-env` declare-and-check,
+lockfile + doctor lifecycle), the trust invariant (upskill never expands
+`${VAR}`, never runs server code), consequences, and the alternatives rejected
+(verbatim from the spec's _Alternatives considered_). Model it on
+`docs/adr/0008-plugin-install-shellout.md`.
+
+- [ ] **Step 2: Document the `mcps:` sub-shape in format-spec**
+
+Add an `mcps:` subsection to `docs/format-spec.md` §3 (next to the `plugins:`
+sub-shape) with the YAML example from the spec, the secret-indirection rule,
+and the lockfile `mcps[]` entry shape (note the `schema` stays `1` — additive).
+
+- [ ] **Step 3: Run docs lint + book build**
+
+Run: `just fmt && just book`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/
+git commit -m "docs(mcp): ADR-0010 and format-spec mcps: sub-shape"
+```
+
+---
+
+## Task 12: Final verification + open issue/PR
+
+- [ ] **Step 1: Full check**
+
+Run: `just fmt && just verify`
+Expected: all green (test + lint + build).
+
+- [ ] **Step 2: Open the epic-linked story and PR**
+
+Per AGENTS.md issue model, ensure a story issue exists (`Epic: #N` first body
+line, `story` + `epic:<name>` labels). Then push the branch and open one PR
+carrying code + tests + docs. Use a Conventional Commit title:
+`feat: configure MCP servers from bundles (v1)`.
+
+- [ ] **Step 3: After CI**
+
+Fix CI failures first, then address review comments. Track v2 (skill
+`requires.mcps` + install agent) as a follow-up story.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Bundle-level `mcps:` descriptor (remote/local) → Tasks 1–2. ✓
+- `${VAR}` indirection, no expansion → upskill never reads env values; passes verbatim (Tasks 4–5). ✓
+- `requires-env` declare-and-check → model (Task 1) + doctor/add warn (Task 8). ✓
+- CLI-first, config-write fallback (Claude) → Tasks 4, 5, 7. ✓
+- Lockfile + remove + doctor lifecycle → Tasks 6, 8. ✓
+- Warn-skip policy preserved → Task 7 (CliNotFound → fallback; Failed → continue) + Task 8 messaging. ✓
+- Trust invariant (no code execution, no secret custody) → no expansion anywhere; only `claude mcp add` shellout + JSON write. ✓
+- Tests (unit + integration) → Tasks 1–10. ✓
+- ADR-0010 + format-spec → Task 11. ✓
+
+**Scope notes / deliberate v1 limits (log, don't silently drop):**
+
+- v1 targets **Claude Code only** for active configuration. opencode/VS Code/Copilot MCP writers are deferred — `install_mcps_from_bundles` records a `claude` result only. If a bundle author expects opencode MCP config in v1, that is **not** delivered; note this in the PR description and the ADR's consequences. (Extending to opencode is a small follow-up: add `write_opencode_mcp` + a branch in `install_mcps_from_bundles`.)
+- v1 has **no `requires.mcps`** skill dependency edge — MCP travels with a skill only by shared bundle membership (v2).
+
+**Placeholder scan:** No "TBD"/"handle appropriately" steps; every code step shows code. The two `> Adjust …` notes (Bundle struct literal field list; CLI remove noun) are real seams against current code, with the exact verification command given — not placeholders.
+
+**Type consistency:** `McpEntry { transport, requires_env }`, `McpTransport::{Remote,Local}`, `McpRemote { transport_type, url, headers }`, `McpLocal { command, args, env }`, `LockedMcp { name, client, scope, bundle, status }`, `McpInstallStatus::{Installed,Skipped}`, `McpResult { name, client, outcome, bundle, requires_env }` — names used identically across Tasks 1, 6, 7, 8, 9, 10. `install_mcps_from_bundles` / `install_claude_local` / `install_claude_remote` / `uninstall_claude` / `check_claude_installed` / `write_claude_mcp_local` / `write_claude_mcp_remote` / `remove_claude_mcp` — consistent across Tasks 4, 5, 7, 8.

--- a/docs/superpowers/specs/2026-06-03-mcp-support-design.md
+++ b/docs/superpowers/specs/2026-06-03-mcp-support-design.md
@@ -1,0 +1,262 @@
+# Design: MCP server support — config-write install + lazy provisioning
+
+**Date**: 2026-06-03
+**Status**: Approved (brainstorming)
+**Relates to**: [ADR-0008](../../adr/0008-plugin-install-shellout.md) (plugin
+shellout — the structural precedent), [ADR-0009](../../adr/0009-coupling-tiers-and-dependencies.md)
+(coupling tiers / `requires` — the v2 dependency model, in flight)
+
+## Problem
+
+upskill distributes rules, skills, and agents from SSOT to per-client output,
+and (since [ADR-0008](../../adr/0008-plugin-install-shellout.md)) installs
+client-native **plugins** by shelling out to client CLIs. It has **no support
+for MCP servers** — the Model Context Protocol servers that give an AI client
+new tools (e.g. the draw.io MCP for diagram generation).
+
+A skill is often only useful when its MCP server is present: a "draw.io
+diagrams" skill that references `DrawIO:create_diagram` tools is dead weight if
+the draw.io MCP was never configured in the client. Today a consumer must
+install the skill via upskill and then _separately, manually_ wire up the MCP
+server in each client's config. The two halves of a coherent capability are
+delivered apart.
+
+This design adds MCP support so a bundle (v1) or a skill dependency (v2) can
+carry its MCP server alongside its content, configured into each targeted
+client through that client's native mechanism.
+
+### What an MCP server actually needs
+
+MCP servers reach a client in one of two transport shapes:
+
+- **Remote** — a hosted server the client connects to over `http` or `sse` at a
+  `url`. Already running; auth is OAuth (client-driven, interactive) or a static
+  token in a header.
+- **Local (stdio)** — the client spawns a local `command` (with `args`/`env`)
+  and speaks MCP over stdio. When the command is a self-fetching launcher
+  (`npx -y <pkg>`, `uvx <pkg>`, `docker run …`) the launcher downloads and
+  caches the server on first run — upskill installs **nothing**.
+
+The only case needing a real install step is a **bare binary with no launcher**
+(a compiled tool, a Homebrew formula) that must be detected → version-checked →
+installed → set up. That heterogeneous case is the motivation for the v2 lazy
+install agent (§ v2), and is explicitly _out of scope for v1_.
+
+## Trust posture (non-negotiable invariant)
+
+Today `upskill add` is **safe-by-construction**: it only (a) writes files into
+known paths and (b) shells out to known client CLIs with declared args. Adding
+an arbitrary fetched bundle cannot execute arbitrary code.
+
+This design **preserves that invariant**. upskill itself never downloads,
+builds, or runs server code. Specifically:
+
+- **v1** writes config (via the client's MCP CLI verb, or a config file) — the
+  same class of action as the existing plugin shellout.
+- **v2's** "install agent" is **generated `agent` SSOT content**, executed by
+  the _client_ (e.g. Claude Code) under the client's own per-command permission
+  prompts — never by the upskill binary. The trust gate is the client's
+  existing "allow this command?" prompt, not a new RCE surface in `upskill`.
+
+Rejected for this reason: upskill running a bundled `install.sh`, or upskill
+"triggering an AI prompt" itself. Both would hand a third-party bundle author a
+shell on the consumer's machine (the npm `postinstall` supply-chain hole). See
+_Alternatives considered_.
+
+## Phasing
+
+| Phase                | Scope                                                                                                                                                                            | Depends on                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **v1**               | MCP as a **bundle-level descriptor** (`mcps:`, sibling of `plugins:`). Eager config-write at `upskill add`, CLI-first. Lockfile + `doctor` lifecycle. Declare-and-check secrets. | Nothing unfinished. Parallels ADR-0008.                                                          |
+| **v2** (fast-follow) | **Skill-coupled lazy provisioning**: `requires.mcps` dependency edge + generated skill-body preflight + the **install agent** for bare-binary provisioning.                      | [ADR-0009](../../adr/0009-coupling-tiers-and-dependencies.md) coupling/`requires` model landing. |
+
+v1 ships on its own. The genuinely novel part (lazy, agent-driven provisioning)
+is parked behind the coupling work it actually needs.
+
+---
+
+## v1 design — bundle-level MCP descriptor, eager config-write
+
+A near-exact parallel of the existing `plugins:` mechanism
+([ADR-0008](../../adr/0008-plugin-install-shellout.md),
+[`src/model/bundle.rs`](../../../src/model/bundle.rs)).
+
+### Model
+
+New `mcps:` map on `Bundle`, keyed by upskill-level MCP name (used in the
+lockfile, CLI output, and `upskill remove mcp <name>`):
+
+```yaml
+schema: 1
+name: drawio-diagrams
+description: Draw.io diagram skill and its MCP server
+items:
+  skills:
+    - drawio-diagrams
+mcps:
+  drawio:
+    # exactly one of `remote` / `local`
+    remote:
+      type: http # http | sse
+      url: https://mcp.draw.io/mcp
+      headers: # optional; values are ${VAR} references only
+        Authorization: "Bearer ${DRAWIO_TOKEN}"
+    # — or —
+    local:
+      command: npx
+      args: ["-y", "drawio-mcp-server"]
+      env: # values are ${VAR} references only
+        DRAWIO_TOKEN: "${DRAWIO_TOKEN}"
+    requires-env: [DRAWIO_TOKEN] # declared so `doctor` can warn on unset vars
+```
+
+- A descriptor carries **exactly one** of `remote` or `local` (validated; both
+  or neither is an error).
+- The map key (`drawio`) is the upskill-level identity.
+- Per-client targeting is implicit in v1: the descriptor is client-agnostic and
+  upskill writes it into each _targeted_ client (the `--claude` / `--copilot` /
+  etc. flags already on `add`). A client that does not support MCP → **warn-skip**
+  (same policy as plugins).
+
+### Secrets — indirection + declare-and-check, never custody
+
+upskill never owns a secret value. The rule:
+
+- Config values that reference secrets use **`${VAR}` indirection only**. upskill
+  writes the reference; the **client** expands it at connect/launch time; the
+  value lives in the user's environment / OS keychain / the client's OAuth store.
+- upskill **never persists a literal secret** — not into a client config file,
+  not into the lockfile, not into SSOT.
+- `requires-env: [VAR, …]` is a **declaration** (not a value). It lets
+  `upskill doctor` warn _"MCP `drawio` needs `DRAWIO_TOKEN`; it is not set in your
+  environment"_ without ever reading the value.
+
+This is the same posture upskill already takes for git auth (tokens come from
+env / `gh` / `glab`, never persisted — see [AGENTS.md](../../../AGENTS.md)
+"Authentication").
+
+### Per-client install contract — CLI-first, config-write fallback
+
+For each targeted client, prefer the client's native MCP CLI verb; fall back to
+writing the client's config file **only** when the CLI is missing (the
+warn-skip path) or cannot express the descriptor. Direct config patching as the
+_primary_ path is rejected — same stance ADR-0008 took against patching
+`settings.json`.
+
+| Client      | Primary (CLI)                                                                                                                                  | Fallback (config-write)                                         |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Claude Code | `claude mcp add <name> --scope <s> [-e KEY=${VAR}] -- <command> [args…]` (stdio); `claude mcp add --transport http\|sse <name> <url>` (remote) | `.mcp.json` (project) / user config                             |
+| opencode    | _(config-only)_                                                                                                                                | `mcp` key in `opencode.json` (ancillary already owns this file) |
+| VS Code     | `code --add-mcp '<json>'`                                                                                                                      | `.vscode/mcp.json`                                              |
+| Copilot CLI | per its MCP verb                                                                                                                               | per its config                                                  |
+
+- Claude `--scope` derives from upskill's project/global flag exactly as plugins
+  do (project→`project`, global→`user`; ADR-0008).
+- Idempotent: re-adding an existing server is a no-op / overwrite, mirroring the
+  `marketplace add` idempotency in [`src/plugin.rs`](../../../src/plugin.rs).
+- CLI-missing → warn-skip with an optional `install_url`-style hint; the rest of
+  the bundle still installs.
+
+### Lifecycle — lockfile + doctor
+
+Mirror `LockedPlugin` ([`src/lockfile.rs`](../../../src/lockfile.rs)):
+
+- `LockedMcp { name, client, identifier, bundle, scope, status }` recorded per
+  `(name, client)` on successful install (or warn-skip / instructions status).
+  Status enum parallels `PluginInstallStatus`.
+- `upsert_mcp` / `remove_mcps_by_name`, sorted, like the plugin equivalents.
+- `upskill remove mcp <name>` runs the inverse CLI (`claude mcp remove <name>
+  --scope <s>`, etc.).
+- `doctor` reconciles: queries the client (`claude mcp list`, etc.) to detect a
+  server present in the lockfile but absent from the client (parallel to
+  `check_*_plugin_installed`), and warns on unset `requires-env` vars.
+- Removal never cascades (the #196 "never auto-delete" ethos).
+
+### Implementation shape
+
+- **model**: `mcps: BTreeMap<String, McpEntry>` on `Bundle`; `McpEntry` with
+  `remote` / `local` variants, `requires_env`. In
+  [`src/model/bundle.rs`](../../../src/model/bundle.rs), beside `PluginEntry`.
+- **parse**: accept + validate the shape in
+  [`src/parse/bundle.rs`](../../../src/parse/bundle.rs) (exactly-one-of
+  remote/local; `${VAR}`-only secret values).
+- **install**: new `src/mcp.rs`, peer to [`src/plugin.rs`](../../../src/plugin.rs)
+  — typed CLI-shellout + config-write functions per client, returning structured
+  outcomes, never writing to stdout/stderr. Reuses the spawn / CLI-not-found
+  helpers' pattern.
+- **ancillary**: extend [`src/ancillary.rs`](../../../src/ancillary.rs) to merge
+  MCP entries into `opencode.json` / `.vscode/mcp.json` / `.mcp.json` without
+  clobbering user-authored entries (richer than the current single-URI append in
+  `write_opencode_plugin_uri`).
+- **pipeline**: `McpResult` + `install_mcps_from_bundles`, mirroring
+  `install_plugins_from_bundles` in [`src/pipeline.rs`](../../../src/pipeline.rs).
+- **lockfile**: `LockedMcp` + upsert/remove + schema note.
+- **main**: reporting, `upskill remove mcp <name>`, `doctor` lines. (Presentation
+  stays in `main.rs` per project convention.)
+- **lint/fmt**: validate/canonicalise the `mcps:` shape.
+
+### Testing
+
+- **Unit**: descriptor parse (exactly-one-of, `${VAR}` enforcement),
+  `requires-env` presence-check, lockfile read/write, scope mapping.
+- **Integration** (`tests/`): shim `claude` / `code` on PATH (the pattern
+  `fetch.rs` tests use for `git`) to assert the right CLI args; assert config-write
+  fallback shape when the shim is absent; assert warn-skip when no CLI; assert
+  `doctor` reconciliation. New `cli_mcp.rs` / `pipeline_mcp.rs`, golden config
+  fixtures in `tests/fixtures/`.
+
+### Docs
+
+- New **ADR-0010** (MCP config-write + secrets posture).
+- `docs/format-spec.md` — `mcps:` sub-shape + lockfile schema bump.
+- Book: commands / recipes / writing-skill-bundles update.
+
+---
+
+## v2 design (fast-follow, sketch — finalized in its own brainstorm)
+
+Once [ADR-0009](../../adr/0009-coupling-tiers-and-dependencies.md) lands:
+
+- **Dependency edge**: add `mcps` to ADR-0009's `requires:` vocabulary
+  (`requires: { rules, skills, agents, mcps }`), resolved by `(kind, name)`, hard
+  - acyclic, with `required_by` provenance. A skill declares
+    `requires: { mcps: [drawio] }`; installing the skill resolves and config-writes
+    its MCP (the v1 machinery). **Open question for the v2 ADR**: whether MCP
+    becomes a first-class _kind_ (resolved by `(kind, name)` like rules/skills) or
+    stays a bundle descriptor referenced by name.
+- **Skill-body preflight** (the runtime trigger): the dependency _generates_ a
+  leading step into the rendered skill — _"Before using draw.io, verify the
+  `drawio` MCP responds; if a local binary is required and missing, dispatch the
+  `mcp-installer` agent."_ Pure, portable content.
+- **Install agent**: an `agent` kind shipped as SSOT content whose job is detect →
+  version-check → install → set up a bare-binary server, reasoning through the
+  heterogeneity a schema cannot. Runs in the client under the client's permission
+  prompts. upskill stays execution-free.
+
+## Alternatives considered (rejected)
+
+- **upskill runs a bundled `install.sh`** — turns `upskill add` into arbitrary
+  remote code execution (npm `postinstall` hole); breaks the safe-by-construction
+  invariant. The install agent (v2) achieves the same provisioning with the
+  client's permission system as the gate.
+- **upskill "triggers an AI prompt" itself** — upskill has no LLM; this means
+  injecting fetched-bundle instructions into the consumer's agent (prompt
+  injection). Same RCE risk wearing a different hat.
+- **upskill as secret manager / storing tokens** — custody risk and redundant;
+  clients already resolve `${VAR}` / run OAuth. upskill stays indirection-only.
+- **Patch client config files as the primary path** — brittle across client
+  versions; ADR-0008 already rejected this for plugins. CLI-first, config-write
+  fallback only.
+- **New top-level `Mcp` kind for v1** — ADR-0008 rejected a parallel `Plugin`
+  kind for the same reason: MCP servers compose with skills and travel in
+  bundles. (v2 may revisit kind-hood as part of the `requires` model.)
+- **Modeling bare-binary install declaratively** (per-platform install command
+  matrix in the descriptor) — too heterogeneous (version pins, build steps, OS
+  branches); the v2 install agent reasons through it instead.
+
+## Open questions
+
+- **v2 only**: MCP as a first-class kind vs. bundle descriptor referenced by
+  `requires.mcps` (defer to the v2 ADR).
+- Exact Copilot CLI MCP verb and VS Code `--add-mcp` payload shape — confirm
+  against current client CLIs during implementation.

--- a/src/ancillary.rs
+++ b/src/ancillary.rs
@@ -31,6 +31,7 @@ use anyhow::{Context, Result};
 use serde_json::{Value, json};
 use std::path::Path;
 
+use crate::model::bundle::{McpLocal, McpRemote};
 use crate::plugin::PluginOutcome;
 
 /// Filename written at the consumer-project root.
@@ -335,6 +336,112 @@ pub fn remove_opencode_plugin_uri(target: &Path, plugin_uri: &str) -> Result<()>
     }
 
     Ok(())
+}
+
+/// Filename Claude Code reads for project-scoped MCP servers.
+const CLAUDE_MCP_JSON: &str = ".mcp.json";
+
+/// Write a local (stdio) MCP server into `<target>/.mcp.json` under
+/// `mcpServers.<name>`. Merge-preserving; creates the file if absent.
+/// Used as the fallback when the `claude` CLI is not on PATH.
+pub fn write_claude_mcp_local(target: &Path, name: &str, local: &McpLocal) -> PluginOutcome {
+    let mut server = serde_json::Map::new();
+    server.insert("command".into(), json!(local.command));
+    if !local.args.is_empty() {
+        server.insert("args".into(), json!(local.args));
+    }
+    if !local.env.is_empty() {
+        let env: serde_json::Map<String, Value> = local
+            .env
+            .iter()
+            .map(|(k, v)| (k.clone(), json!(v)))
+            .collect();
+        server.insert("env".into(), Value::Object(env));
+    }
+    upsert_mcp_server(target, name, Value::Object(server))
+}
+
+/// Write a remote MCP server into `<target>/.mcp.json` under
+/// `mcpServers.<name>`. Merge-preserving; creates the file if absent.
+pub fn write_claude_mcp_remote(target: &Path, name: &str, remote: &McpRemote) -> PluginOutcome {
+    let mut server = serde_json::Map::new();
+    server.insert("type".into(), json!(remote.transport_type));
+    server.insert("url".into(), json!(remote.url));
+    if !remote.headers.is_empty() {
+        let headers: serde_json::Map<String, Value> = remote
+            .headers
+            .iter()
+            .map(|(k, v)| (k.clone(), json!(v)))
+            .collect();
+        server.insert("headers".into(), Value::Object(headers));
+    }
+    upsert_mcp_server(target, name, Value::Object(server))
+}
+
+/// Shared merge: insert `server` at `mcpServers.<name>` in `.mcp.json`,
+/// preserving any other top-level keys and other servers.
+fn upsert_mcp_server(target: &Path, name: &str, server: Value) -> PluginOutcome {
+    let path = target.join(CLAUDE_MCP_JSON);
+    let mut doc: Value = match std::fs::read_to_string(&path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => json!({}),
+        Err(e) => {
+            return PluginOutcome::Failed {
+                exit_code: None,
+                stderr: format!("read {}: {e}", path.display()),
+            };
+        }
+        Ok(raw) => match serde_json::from_str(&raw) {
+            Ok(v) => v,
+            Err(e) => {
+                return PluginOutcome::Failed {
+                    exit_code: None,
+                    stderr: format!("parse {}: {e}", path.display()),
+                };
+            }
+        },
+    };
+
+    if !doc.is_object() {
+        return PluginOutcome::Failed {
+            exit_code: None,
+            stderr: format!("{}: top-level value must be an object", path.display()),
+        };
+    }
+    let obj = doc.as_object_mut().expect("checked is_object");
+    let servers = obj
+        .entry("mcpServers")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Some(servers) = servers.as_object_mut() else {
+        return PluginOutcome::Failed {
+            exit_code: None,
+            stderr: format!("{}: `mcpServers` must be an object", path.display()),
+        };
+    };
+    servers.insert(name.to_string(), server);
+
+    if let Err(e) = write_pretty_json(&path, &doc) {
+        return PluginOutcome::Failed {
+            exit_code: None,
+            stderr: e.to_string(),
+        };
+    }
+    PluginOutcome::Success
+}
+
+/// Remove an MCP server from `<target>/.mcp.json`. No-op if absent.
+pub fn remove_claude_mcp(target: &Path, name: &str) -> Result<()> {
+    let path = target.join(CLAUDE_MCP_JSON);
+    let raw = match std::fs::read_to_string(&path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
+        Ok(r) => r,
+    };
+    let mut doc: Value =
+        serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+    if let Some(servers) = doc.get_mut("mcpServers").and_then(Value::as_object_mut) {
+        servers.remove(name);
+    }
+    write_pretty_json(&path, &doc)
 }
 
 fn write_pretty_json(path: &Path, value: &Value) -> Result<()> {
@@ -709,5 +816,113 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         remove_opencode_plugin_uri(tmp.path(), "sp@git+https://example.com").unwrap();
         assert!(!tmp.path().join("opencode.json").exists());
+    }
+
+    #[test]
+    fn write_claude_mcp_json_adds_local_server() {
+        use crate::model::bundle::McpLocal;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = BTreeMap::new();
+        env.insert("TOK".to_string(), "${TOK}".to_string());
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec!["-y".into(), "srv".into()],
+            env,
+        };
+
+        let outcome = write_claude_mcp_local(tmp.path(), "drawio", &local);
+        assert!(outcome.is_success());
+
+        let raw = std::fs::read_to_string(tmp.path().join(".mcp.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(doc["mcpServers"]["drawio"]["command"], "npx");
+        assert_eq!(doc["mcpServers"]["drawio"]["args"][1], "srv");
+        assert_eq!(doc["mcpServers"]["drawio"]["env"]["TOK"], "${TOK}");
+    }
+
+    #[test]
+    fn write_claude_mcp_json_preserves_existing_servers() {
+        use crate::model::bundle::McpLocal;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".mcp.json"),
+            r#"{"mcpServers":{"existing":{"command":"foo"}}}"#,
+        )
+        .unwrap();
+
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec![],
+            env: BTreeMap::new(),
+        };
+        write_claude_mcp_local(tmp.path(), "drawio", &local);
+
+        let raw = std::fs::read_to_string(tmp.path().join(".mcp.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(doc["mcpServers"]["existing"]["command"], "foo");
+        assert_eq!(doc["mcpServers"]["drawio"]["command"], "npx");
+    }
+
+    #[test]
+    fn write_claude_mcp_json_adds_remote_server() {
+        use crate::model::bundle::McpRemote;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut headers = BTreeMap::new();
+        headers.insert("Authorization".to_string(), "Bearer ${TOKEN}".to_string());
+        let remote = McpRemote {
+            transport_type: "http".into(),
+            url: "https://example.com/mcp".into(),
+            headers,
+        };
+
+        let outcome = write_claude_mcp_remote(tmp.path(), "example", &remote);
+        assert!(outcome.is_success());
+
+        let raw = std::fs::read_to_string(tmp.path().join(".mcp.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(doc["mcpServers"]["example"]["type"], "http");
+        assert_eq!(
+            doc["mcpServers"]["example"]["url"],
+            "https://example.com/mcp"
+        );
+        assert_eq!(
+            doc["mcpServers"]["example"]["headers"]["Authorization"],
+            "Bearer ${TOKEN}"
+        );
+    }
+
+    #[test]
+    fn remove_claude_mcp_removes_server() {
+        use crate::model::bundle::McpLocal;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec![],
+            env: BTreeMap::new(),
+        };
+        write_claude_mcp_local(tmp.path(), "drawio", &local);
+        write_claude_mcp_local(tmp.path(), "other", &local);
+
+        remove_claude_mcp(tmp.path(), "drawio").unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join(".mcp.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(doc["mcpServers"]["drawio"].is_null());
+        assert_eq!(doc["mcpServers"]["other"]["command"], "npx");
+    }
+
+    #[test]
+    fn remove_claude_mcp_noop_when_no_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        remove_claude_mcp(tmp.path(), "drawio").unwrap();
+        assert!(!tmp.path().join(".mcp.json").exists());
     }
 }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -193,6 +193,7 @@ mod tests {
                 })
                 .collect(),
             plugins: Default::default(),
+            mcps: Default::default(),
             metadata: None,
             extra: Default::default(),
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -281,6 +281,29 @@ pub enum Commands {
         /// Item name. Lowercase letters, digits, hyphens; max 64 chars.
         name: String,
     },
+    /// Remove an MCP server configured by a bundle install.
+    ///
+    /// Unregisters the named MCP server from the client (via `claude mcp
+    /// remove` or the config file fallback) and drops the entry from the
+    /// lockfile.
+    #[command(
+        name = "remove-mcp",
+        display_order = 4,
+        after_help = "EXAMPLES:\n  \
+            upskill remove-mcp drawio\n  \
+            upskill remove-mcp drawio --global"
+    )]
+    RemoveMcp {
+        /// MCP server name to remove (as recorded in the lockfile).
+        name: String,
+        /// Operate on `$HOME` instead of the current directory.
+        #[arg(short = 'g', long = "global", conflicts_with = "project")]
+        global: bool,
+        /// Force project scope (current directory). Overrides the auto-detect
+        /// fallback to global when `cwd` is not inside a git repo.
+        #[arg(short = 'p', long = "project")]
+        project: bool,
+    },
     /// Build or manage the local registry index cache.
     #[command(
         display_order = 7,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -184,7 +184,7 @@ pub enum Commands {
     /// Doctor never fetches; remote-source drift detection is
     /// `update --dry-run`. Exit 0 when clean, 1 when any drift is found.
     #[command(
-        display_order = 5,
+        display_order = 6,
         after_help = "EXAMPLES:\n  \
             upskill doctor\n  \
             upskill doctor --global"
@@ -205,7 +205,7 @@ pub enum Commands {
     },
     /// Search the public skills registry and configured registries.
     #[command(
-        display_order = 6,
+        display_order = 7,
         after_help = "EXAMPLES:\n  \
             upskill search code-review\n  \
             upskill search api --limit 5\n  \
@@ -288,7 +288,7 @@ pub enum Commands {
     /// lockfile.
     #[command(
         name = "remove-mcp",
-        display_order = 4,
+        display_order = 5,
         after_help = "EXAMPLES:\n  \
             upskill remove-mcp drawio\n  \
             upskill remove-mcp drawio --global"
@@ -306,7 +306,7 @@ pub enum Commands {
     },
     /// Build or manage the local registry index cache.
     #[command(
-        display_order = 7,
+        display_order = 8,
         after_help = "EXAMPLES:\n  \
             upskill index\n  \
             upskill index --registry corp\n  \

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -92,6 +92,7 @@ mod tests {
                 .collect(),
             bundles: vec![],
             plugins: vec![],
+            mcps: vec![],
         }
     }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -43,6 +43,7 @@ const BUNDLE_KEY_ORDER: &[&str] = &[
     "items",
     "requires",
     "plugins",
+    "mcps",
     "metadata",
 ];
 
@@ -845,6 +846,35 @@ mod tests {
         let after = fs::read_to_string(&item).unwrap();
         // scope must survive the round-trip.
         assert!(after.contains("src/**/*.ts"), "scope.paths lost:\n{after}");
+    }
+
+    #[test]
+    fn reorder_bundle_mcps_after_plugins_before_metadata() {
+        // mcps deliberately placed out of canonical order (before plugins).
+        let input = concat!(
+            "schema: 1\n",
+            "name: test\n",
+            "description: d.\n",
+            "mcps:\n",
+            "  drawio:\n",
+            "    remote:\n",
+            "      type: http\n",
+            "      url: https://example.com/mcp\n",
+            "metadata:\n",
+            "  version: 0.1.0\n",
+            "plugins:\n",
+            "  sp:\n",
+            "    vscode:\n",
+            "      extension: pub.ext\n",
+        );
+        let out = reorder_yaml_keys(input, BUNDLE_KEY_ORDER);
+        let plugins = out.find("plugins:").unwrap();
+        let mcps = out.find("mcps:").unwrap();
+        let metadata = out.find("metadata:").unwrap();
+        assert!(
+            plugins < mcps && mcps < metadata,
+            "bundle key order must be plugins < mcps < metadata:\n{out}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod generate;
 pub mod index;
 pub mod lint;
 pub mod lockfile;
+pub mod mcp;
 pub mod model;
 pub mod parse;
 pub mod pipeline;

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -664,9 +664,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write(
             &tmp.path().join("my-rule/RULE.md"),
-            &format!(
-                "---\nschema: 1\nname: my-rule\ndescription: a test rule.\n---\n\n## Body\n\nText.\n"
-            ),
+            "---\nschema: 1\nname: my-rule\ndescription: a test rule.\n---\n\n## Body\n\nText.\n",
         );
         // Lint the item directory directly (not the parent registry root).
         let item_dir = tmp.path().join("my-rule");
@@ -685,9 +683,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write(
             &tmp.path().join("bad-rule/RULE.md"),
-            &format!(
-                "---\nschema: 1\nname: bad-rule\ndescription: has lint issues.\n---\n\n# Forbidden H1\n"
-            ),
+            "---\nschema: 1\nname: bad-rule\ndescription: has lint issues.\n---\n\n# Forbidden H1\n",
         );
         let item_dir = tmp.path().join("bad-rule");
         let report = lint(&[item_dir], false).unwrap();
@@ -711,7 +707,7 @@ mod tests {
         );
         write(
             &tmp.path().join("multi/AGENT.md"),
-            &format!("---\nschema: 1\nname: multi\ndescription: co-located agent.\n---\n\n## ok\n"),
+            "---\nschema: 1\nname: multi\ndescription: co-located agent.\n---\n\n## ok\n",
         );
         let item_dir = tmp.path().join("multi");
         let report = lint(&[item_dir], false).unwrap();

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -323,6 +323,9 @@ fn parse_kind(raw: &str, kind: FileKind) -> Result<(String, &str)> {
         }
         FileKind::Bundle => {
             let bundle: crate::model::Bundle = serde_yaml_ng::from_str(raw)?;
+            bundle
+                .validate_mcps()
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
             Ok((bundle.name, ""))
         }
     }
@@ -803,6 +806,39 @@ mod tests {
         assert!(
             f.is_some(),
             "missing name-matches-dir finding for bundle: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn lint_flags_invalid_mcps_transport_in_bundle() {
+        // Regression: lint's bundle path must call validate_mcps so an
+        // unsupported transport type is surfaced as a frontmatter error,
+        // not silently accepted.
+        let tmp = tempfile::tempdir().unwrap();
+        let body = concat!(
+            "schema: 1\n",
+            "name: bad-mcp\n",
+            "description: bundle with an invalid MCP transport type.\n",
+            "items:\n",
+            "  skills: []\n",
+            "mcps:\n",
+            "  my-server:\n",
+            "    remote:\n",
+            "      type: ftp\n",
+            "      url: https://example.com/mcp\n",
+        );
+        write(&tmp.path().join("bad-mcp.bundle.yaml"), body);
+        let report = lint(&[tmp.path().to_path_buf()], false).unwrap();
+        let f = report.findings.iter().find(|f| f.rule_id == "frontmatter");
+        assert!(
+            f.is_some(),
+            "expected frontmatter error for invalid mcps transport; got: {:?}",
+            report.findings
+        );
+        assert!(
+            f.unwrap().message.contains("ftp"),
+            "error message should mention the bad transport type; got: {:?}",
             report.findings
         );
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -32,6 +32,8 @@ pub struct Lockfile {
     pub bundles: Vec<LockedBundle>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub plugins: Vec<LockedPlugin>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcps: Vec<LockedMcp>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -121,6 +123,37 @@ pub enum PluginInstallStatus {
     Instructions,
 }
 
+/// MCP server entry recorded when a bundle's `mcps:` map is configured
+/// into a client (ADR-0010). One entry per (mcp-name, client) pair so
+/// `remove`/`doctor` can invoke the inverse CLI command.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LockedMcp {
+    /// Upskill-level MCP name (key in the bundle's `mcps:` map).
+    pub name: String,
+    /// Client identifier: `"claude"`, `"opencode"`, etc.
+    pub client: String,
+    /// Install scope (only meaningful for claude: `"project"` or `"user"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    /// Bundle that declared this MCP server.
+    pub bundle: String,
+    /// Configuration outcome recorded at `upskill add` time.
+    #[serde(default)]
+    pub status: McpInstallStatus,
+}
+
+/// Configuration status of an MCP entry in the lockfile (ADR-0010).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum McpInstallStatus {
+    /// Configured successfully (CLI shellout or config-write).
+    #[default]
+    Installed,
+    /// Skipped — the client CLI was not on PATH and no config-write target
+    /// applied (warn-skip outcome). `doctor` surfaces these.
+    Skipped,
+}
+
 impl Default for Lockfile {
     fn default() -> Self {
         Self::new()
@@ -134,6 +167,7 @@ impl Lockfile {
             items: Vec::new(),
             bundles: Vec::new(),
             plugins: Vec::new(),
+            mcps: Vec::new(),
         }
     }
 
@@ -210,6 +244,20 @@ impl Lockfile {
     /// Remove all plugin entries matching `name` (across all clients).
     pub fn remove_plugins_by_name(&mut self, name: &str) {
         self.plugins.retain(|existing| existing.name != name);
+    }
+
+    /// Add or replace an MCP entry by `(name, client)`. Sorted for
+    /// deterministic on-disk output.
+    pub fn upsert_mcp(&mut self, mcp: LockedMcp) {
+        self.mcps
+            .retain(|existing| !(existing.name == mcp.name && existing.client == mcp.client));
+        self.mcps.push(mcp);
+        self.mcps.sort();
+    }
+
+    /// Remove all MCP entries matching `name` (across all clients).
+    pub fn remove_mcps_by_name(&mut self, name: &str) {
+        self.mcps.retain(|existing| existing.name != name);
     }
 
     /// Persist to `<project_root>/.upskill-lock.json`. Pretty-printed JSON
@@ -580,6 +628,43 @@ mod tests {
         };
         let json = serde_json::to_string(&item).unwrap();
         assert!(!json.contains("source_name"), "{json}");
+    }
+
+    #[test]
+    fn upsert_mcp_replaces_by_name_and_client() {
+        let mut lock = Lockfile::new();
+        lock.upsert_mcp(LockedMcp {
+            name: "drawio".into(),
+            client: "claude".into(),
+            scope: Some("project".into()),
+            bundle: "with-mcp".into(),
+            status: McpInstallStatus::Installed,
+        });
+        lock.upsert_mcp(LockedMcp {
+            name: "drawio".into(),
+            client: "claude".into(),
+            scope: Some("project".into()),
+            bundle: "with-mcp".into(),
+            status: McpInstallStatus::Skipped,
+        });
+        assert_eq!(lock.mcps.len(), 1);
+        assert_eq!(lock.mcps[0].status, McpInstallStatus::Skipped);
+    }
+
+    #[test]
+    fn remove_mcps_by_name_drops_all_clients() {
+        let mut lock = Lockfile::new();
+        for client in ["claude", "opencode"] {
+            lock.upsert_mcp(LockedMcp {
+                name: "drawio".into(),
+                client: client.into(),
+                scope: None,
+                bundle: "with-mcp".into(),
+                status: McpInstallStatus::Installed,
+            });
+        }
+        lock.remove_mcps_by_name("drawio");
+        assert!(lock.mcps.is_empty());
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -437,6 +437,7 @@ mod tests {
         let report = InstallReport {
             bundles: Vec::new(),
             plugin_results: Vec::new(),
+            mcp_results: Vec::new(),
             items: vec![
                 InstalledItem {
                     kind: ItemKind::Skill,

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,11 @@ fn main() {
         Commands::Fmt { paths } => run_fmt(&paths),
         Commands::New { kind, name } => run_new(&kind, &name),
         Commands::Index { registry, clear } => run_index(registry.as_deref(), clear),
+        Commands::RemoveMcp {
+            name,
+            global,
+            project,
+        } => run_remove_mcp(&name, global, project),
     };
 
     if was_interrupted() {
@@ -177,6 +182,7 @@ fn run_add(
         Ok(report) => {
             print_install_report(&report, source);
             print_plugin_results(&report);
+            print_mcp_results(&report);
             EXIT_SUCCESS
         }
         Err(err) => {
@@ -448,6 +454,58 @@ fn print_plugin_results(report: &InstallReport) {
                 exit_code,
                 stderr.trim()
             );
+        }
+    }
+}
+
+/// Print MCP server configuration results after an install.
+/// Success entries go to stdout; warnings (CLI-not-found, failure) go to stderr.
+/// Env-var warnings are emitted for any required vars not set in the environment.
+fn print_mcp_results(report: &InstallReport) {
+    if style::is_quiet() || report.mcp_results.is_empty() {
+        return;
+    }
+
+    use upskill::plugin::PluginOutcome;
+
+    for mr in &report.mcp_results {
+        match &mr.outcome {
+            PluginOutcome::Success => {
+                println!(
+                    "  {} MCP server '{}' for {}",
+                    style::success("configured"),
+                    mr.name,
+                    mr.client
+                );
+            }
+            PluginOutcome::CliNotFound => {
+                eprintln!(
+                    "{} {} CLI not found and no config target; skipped MCP '{}'.",
+                    style::warn("warn:"),
+                    mr.client,
+                    mr.name
+                );
+            }
+            PluginOutcome::Failed { stderr, .. } => {
+                eprintln!(
+                    "{} failed to configure MCP '{}' for {}: {}",
+                    style::warn("warn:"),
+                    mr.name,
+                    mr.client,
+                    stderr.trim()
+                );
+            }
+            PluginOutcome::ManualInstructions => {}
+        }
+        for var in &mr.requires_env {
+            if std::env::var_os(var).is_none() {
+                eprintln!(
+                    "{} MCP '{}' needs env var '{}'; it is not set in your environment.",
+                    style::warn("warn:"),
+                    mr.name,
+                    var
+                );
+            }
         }
     }
 }
@@ -850,6 +908,7 @@ fn print_doctor_report(report: &DoctorReport) {
     }
 
     print_doctor_skipped_plugins(report);
+    print_doctor_mcps(report);
 }
 
 fn print_doctor_skipped_plugins(report: &DoctorReport) {
@@ -873,6 +932,34 @@ fn print_doctor_skipped_plugins(report: &DoctorReport) {
         "  {}",
         style::dim("install the missing CLI then run `upskill update` to install them")
     );
+}
+
+fn print_doctor_mcps(report: &DoctorReport) {
+    use upskill::pipeline::McpDoctorStatus;
+
+    for entry in &report.mcp_entries {
+        match &entry.status {
+            McpDoctorStatus::Ok => {}
+            McpDoctorStatus::NotRegistered => {
+                println!(
+                    "  MCP '{}' is in the lockfile but not registered in claude; re-run `upskill update`.",
+                    entry.name
+                );
+            }
+            McpDoctorStatus::CliNotFound => {
+                println!(
+                    "  claude CLI not found; cannot verify MCP '{}'.",
+                    entry.name
+                );
+            }
+            McpDoctorStatus::QueryFailed { stderr } => {
+                println!(
+                    "  could not query claude MCP list for '{}': {}",
+                    entry.name, stderr
+                );
+            }
+        }
+    }
 }
 
 fn kind_label(kind: ItemKind) -> &'static str {
@@ -1230,6 +1317,66 @@ fn run_search(query: &str, limit: usize, registry: Option<&str>, kind: Option<&s
     if skills_sh_failed && cfg.registries.is_empty() {
         return EXIT_ERROR;
     }
+    EXIT_SUCCESS
+}
+
+fn run_remove_mcp(name: &str, global: bool, project: bool) -> i32 {
+    let target = match install_target(global, project) {
+        Ok(t) => t,
+        Err(err) => {
+            print_error(&err);
+            return EXIT_ERROR;
+        }
+    };
+
+    let mcp_scope = scope_to_plugin_scope(global, project);
+
+    let mut lock = match upskill::lockfile::Lockfile::load(&target) {
+        Ok(l) => l,
+        Err(err) => {
+            print_error_chain(&err);
+            return EXIT_ERROR;
+        }
+    };
+
+    let matching_mcps: Vec<upskill::lockfile::LockedMcp> = lock
+        .mcps
+        .iter()
+        .filter(|m| m.name == name)
+        .cloned()
+        .collect();
+
+    if matching_mcps.is_empty() {
+        print_error(format!("MCP '{}' not found in lockfile", name));
+        return EXIT_ERROR;
+    }
+
+    for mcp in &matching_mcps {
+        if mcp.client == "claude" {
+            let outcome = upskill::mcp::uninstall_claude(&mcp.name, mcp_scope);
+            if outcome.is_cli_not_found()
+                && let Err(err) = upskill::ancillary::remove_claude_mcp(&target, &mcp.name)
+            {
+                print_error_chain(&err);
+                return EXIT_ERROR;
+            }
+        }
+    }
+
+    lock.remove_mcps_by_name(name);
+    if let Err(err) = lock.save(&target) {
+        print_error_chain(&err);
+        return EXIT_ERROR;
+    }
+
+    if !style::is_quiet() {
+        println!(
+            "{} MCP server '{}'",
+            style::success("Removed"),
+            style::name(name)
+        );
+    }
+
     EXIT_SUCCESS
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,17 +481,18 @@ fn print_mcp_results(report: &InstallReport) {
             PluginOutcome::CliNotFound => {
                 eprintln!(
                     "{} {} CLI not found and no config target; skipped MCP '{}'.",
-                    style::warn("warn:"),
+                    style::warn("warning:"),
                     mr.client,
                     mr.name
                 );
             }
-            PluginOutcome::Failed { stderr, .. } => {
+            PluginOutcome::Failed { stderr, exit_code } => {
                 eprintln!(
-                    "{} failed to configure MCP '{}' for {}: {}",
-                    style::warn("warn:"),
+                    "{} failed to configure MCP '{}' for {} (exit {:?}): {}",
+                    style::warn("warning:"),
                     mr.name,
                     mr.client,
+                    exit_code,
                     stderr.trim()
                 );
             }
@@ -501,7 +502,7 @@ fn print_mcp_results(report: &InstallReport) {
             if std::env::var_os(var).is_none() {
                 eprintln!(
                     "{} MCP '{}' needs env var '{}'; it is not set in your environment.",
-                    style::warn("warn:"),
+                    style::warn("warning:"),
                     mr.name,
                     var
                 );
@@ -937,7 +938,23 @@ fn print_doctor_skipped_plugins(report: &DoctorReport) {
 fn print_doctor_mcps(report: &DoctorReport) {
     use upskill::pipeline::McpDoctorStatus;
 
-    for entry in &report.mcp_entries {
+    let non_ok: Vec<&upskill::pipeline::McpDoctorEntry> = report
+        .mcp_entries
+        .iter()
+        .filter(|e| !matches!(e.status, McpDoctorStatus::Ok))
+        .collect();
+
+    if non_ok.is_empty() {
+        return;
+    }
+
+    println!(
+        "{} {} MCP server(s) need attention",
+        style::warn("doctor:"),
+        non_ok.len()
+    );
+
+    for entry in &non_ok {
         match &entry.status {
             McpDoctorStatus::Ok => {}
             McpDoctorStatus::NotRegistered => {
@@ -1354,11 +1371,23 @@ fn run_remove_mcp(name: &str, global: bool, project: bool) -> i32 {
     for mcp in &matching_mcps {
         if mcp.client == "claude" {
             let outcome = upskill::mcp::uninstall_claude(&mcp.name, mcp_scope);
-            if outcome.is_cli_not_found()
-                && let Err(err) = upskill::ancillary::remove_claude_mcp(&target, &mcp.name)
-            {
-                print_error_chain(&err);
-                return EXIT_ERROR;
+            match outcome {
+                upskill::plugin::PluginOutcome::CliNotFound => {
+                    if let Err(err) = upskill::ancillary::remove_claude_mcp(&target, &mcp.name) {
+                        print_error_chain(&err);
+                        return EXIT_ERROR;
+                    }
+                }
+                upskill::plugin::PluginOutcome::Failed { stderr, exit_code } => {
+                    eprintln!(
+                        "{} failed to remove MCP '{}' from claude (exit {:?}): {}",
+                        style::warn("warning:"),
+                        mcp.name,
+                        exit_code,
+                        stderr.trim()
+                    );
+                }
+                _ => {}
             }
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,134 @@
+//! Client-native MCP server configuration (ADR-0010).
+//!
+//! CLI-first: shells out to each client's MCP verb (`claude mcp add`),
+//! falling back to writing the client config file when the CLI is absent.
+//! Reuses the command helpers in [`crate::plugin`]. Never expands `${VAR}`
+//! values — they pass through verbatim, so upskill holds no secret.
+
+use crate::model::bundle::{McpLocal, McpRemote};
+use crate::plugin::{PluginCheckResult, PluginOutcome, PluginScope};
+
+/// Build the argument vector for `claude mcp add` from a local (stdio)
+/// descriptor. Returned as owned strings so the caller can borrow them.
+pub fn claude_add_local_args(name: &str, local: &McpLocal, scope: PluginScope) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        name.to_string(),
+        "--scope".to_string(),
+        scope.as_claude_flag().to_string(),
+    ];
+    for (k, v) in &local.env {
+        args.push("-e".to_string());
+        args.push(format!("{k}={v}"));
+    }
+    args.push("--".to_string());
+    args.push(local.command.clone());
+    args.extend(local.args.iter().cloned());
+    args
+}
+
+/// Build the argument vector for `claude mcp add` from a remote descriptor.
+pub fn claude_add_remote_args(name: &str, remote: &McpRemote, scope: PluginScope) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "--transport".to_string(),
+        remote.transport_type.clone(),
+        name.to_string(),
+        remote.url.clone(),
+        "--scope".to_string(),
+        scope.as_claude_flag().to_string(),
+    ];
+    for (header, value) in &remote.headers {
+        args.push("-H".to_string());
+        args.push(format!("{header}: {value}"));
+    }
+    args
+}
+
+/// Install a local (stdio) MCP server into Claude Code via `claude mcp add`.
+pub fn install_claude_local(name: &str, local: &McpLocal, scope: PluginScope) -> PluginOutcome {
+    let args = claude_add_local_args(name, local, scope);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::plugin::run_command("claude", &arg_refs)
+}
+
+/// Install a remote MCP server into Claude Code via `claude mcp add`.
+pub fn install_claude_remote(name: &str, remote: &McpRemote, scope: PluginScope) -> PluginOutcome {
+    let args = claude_add_remote_args(name, remote, scope);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::plugin::run_command("claude", &arg_refs)
+}
+
+/// Remove an MCP server from Claude Code via `claude mcp remove`.
+pub fn uninstall_claude(name: &str, scope: PluginScope) -> PluginOutcome {
+    crate::plugin::run_command(
+        "claude",
+        &["mcp", "remove", name, "--scope", scope.as_claude_flag()],
+    )
+}
+
+/// Check whether an MCP server is registered in Claude Code via
+/// `claude mcp list` (substring match on the server name).
+pub fn check_claude_installed(name: &str) -> PluginCheckResult {
+    let out = crate::plugin::run_command_output("claude", &["mcp", "list"]);
+    crate::plugin::check_output_for_substring(out, name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn claude_local_args_include_scope_env_and_command() {
+        let mut env = BTreeMap::new();
+        env.insert("DRAWIO_TOKEN".to_string(), "${DRAWIO_TOKEN}".to_string());
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec!["-y".into(), "drawio-mcp-server".into()],
+            env,
+        };
+        let args = claude_add_local_args("drawio", &local, PluginScope::Project);
+        assert_eq!(
+            args,
+            vec![
+                "mcp",
+                "add",
+                "drawio",
+                "--scope",
+                "project",
+                "-e",
+                "DRAWIO_TOKEN=${DRAWIO_TOKEN}",
+                "--",
+                "npx",
+                "-y",
+                "drawio-mcp-server",
+            ]
+        );
+    }
+
+    #[test]
+    fn claude_remote_args_include_transport_and_url() {
+        let remote = McpRemote {
+            transport_type: "http".into(),
+            url: "https://mcp.draw.io/mcp".into(),
+            headers: BTreeMap::new(),
+        };
+        let args = claude_add_remote_args("drawio", &remote, PluginScope::User);
+        assert_eq!(
+            args,
+            vec![
+                "mcp",
+                "add",
+                "--transport",
+                "http",
+                "drawio",
+                "https://mcp.draw.io/mcp",
+                "--scope",
+                "user",
+            ]
+        );
+    }
+}

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -37,6 +37,12 @@ pub struct Bundle {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub plugins: BTreeMap<String, PluginEntry>,
 
+    /// MCP servers configured into each targeted client (ADR-0010, §3.8).
+    /// Map key is the upskill-level MCP name; value carries the transport
+    /// descriptor and declared required env vars.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub mcps: BTreeMap<String, McpEntry>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
 
@@ -199,4 +205,61 @@ pub enum OpencodePluginDescriptor {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         install_url: Option<String>,
     },
+}
+
+/// One entry in the bundle `mcps:` map. Exactly one transport (`remote`
+/// or `local`) is present; `validate_mcps` (Task 2) enforces this.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpEntry {
+    /// Transport descriptor — flattened so YAML carries either a
+    /// `remote:` or a `local:` key directly under the server name.
+    #[serde(flatten)]
+    pub transport: McpTransport,
+
+    /// Environment variables the server requires. Declared (not valued) so
+    /// `upskill doctor` can warn when one is unset. upskill never reads the
+    /// values — secret custody stays with the user's environment.
+    #[serde(
+        default,
+        rename = "requires-env",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub requires_env: Vec<String>,
+}
+
+/// MCP transport: a hosted server reached by URL, or a local process the
+/// client spawns and speaks to over stdio.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum McpTransport {
+    #[serde(rename = "remote")]
+    Remote(McpRemote),
+    #[serde(rename = "local")]
+    Local(McpLocal),
+}
+
+/// Remote (hosted) MCP server descriptor.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpRemote {
+    /// `http` or `sse`.
+    #[serde(rename = "type")]
+    pub transport_type: String,
+    /// Endpoint URL the client connects to.
+    pub url: String,
+    /// Optional headers. Values pass through verbatim (use `${VAR}`
+    /// references for secrets — upskill never expands them).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
+/// Local (stdio) MCP server descriptor.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpLocal {
+    /// Launcher command (e.g. `npx`, `uvx`, `docker`, or a bare binary).
+    pub command: String,
+    /// Arguments passed to the command.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    /// Environment variables. Values pass through verbatim (use `${VAR}`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
 }

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -208,7 +208,7 @@ pub enum OpencodePluginDescriptor {
 }
 
 /// One entry in the bundle `mcps:` map. Exactly one transport (`remote`
-/// or `local`) is present; `validate_mcps` (Task 2) enforces this.
+/// or `local`) is present; `validate_mcps` enforces this at parse time.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct McpEntry {
     /// Transport descriptor — flattened so YAML carries either a

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -37,7 +37,7 @@ pub struct Bundle {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub plugins: BTreeMap<String, PluginEntry>,
 
-    /// MCP servers configured into each targeted client (ADR-0010, §3.8).
+    /// MCP servers configured into each targeted client (ADR-0010, §3.7).
     /// Map key is the upskill-level MCP name; value carries the transport
     /// descriptor and declared required env vars.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -251,6 +251,34 @@ pub struct McpRemote {
     pub headers: BTreeMap<String, String>,
 }
 
+impl Bundle {
+    /// Validate the `mcps:` map beyond what serde enforces. Returns the
+    /// first offending `(server-name, reason)` as an error.
+    pub fn validate_mcps(&self) -> Result<(), String> {
+        for (name, entry) in &self.mcps {
+            match &entry.transport {
+                McpTransport::Remote(r) => {
+                    if r.transport_type != "http" && r.transport_type != "sse" {
+                        return Err(format!(
+                            "mcp `{name}`: transport type `{}` is not one of http, sse",
+                            r.transport_type
+                        ));
+                    }
+                    if r.url.trim().is_empty() {
+                        return Err(format!("mcp `{name}`: remote url must not be empty"));
+                    }
+                }
+                McpTransport::Local(l) => {
+                    if l.command.trim().is_empty() {
+                        return Err(format!("mcp `{name}`: local command must not be empty"));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Local (stdio) MCP server descriptor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct McpLocal {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -8,8 +8,9 @@ pub mod skill;
 
 pub use agent::{Agent, Mode, ToolCap};
 pub use bundle::{
-    Bundle, BundleItems, ClaudePluginDescriptor, CopilotPluginDescriptor, OpencodePluginDescriptor,
-    PluginEntry, Requires, VscodePluginDescriptor,
+    Bundle, BundleItems, ClaudePluginDescriptor, CopilotPluginDescriptor, McpEntry, McpLocal,
+    McpRemote, McpTransport, OpencodePluginDescriptor, PluginEntry, Requires,
+    VscodePluginDescriptor,
 };
 pub use common::{Audience, CURRENT_SCHEMA, License, Metadata, SchemaVersion};
 pub use rule::{Rule, Scope};

--- a/src/parse/bundle.rs
+++ b/src/parse/bundle.rs
@@ -46,6 +46,10 @@ pub fn load(path: &Path) -> Result<Bundle> {
         );
     }
 
+    bundle
+        .validate_mcps()
+        .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+
     Ok(bundle)
 }
 
@@ -100,6 +104,11 @@ fn load_if_bundle(path: &Path) -> Result<Option<Bundle>> {
             bundle.name
         );
     }
+
+    bundle
+        .validate_mcps()
+        .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+
     Ok(Some(bundle))
 }
 
@@ -630,6 +639,51 @@ mcps:
             McpTransport::Remote(_) => panic!("expected local"),
         }
         assert_eq!(local.requires_env, vec!["DRAWIO_TOKEN"]);
+    }
+
+    #[test]
+    fn load_rejects_mcp_remote_with_bad_type() {
+        let content = "schema: 1
+name: bad-type
+description: bad transport type
+items:
+  skills: []
+mcps:
+  x:
+    remote:
+      type: websocket
+      url: https://example.com
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "bad-type.bundle.yaml", content);
+        let err = load(&path).expect_err("must reject unknown transport type");
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("transport type") && msg.contains("websocket"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn load_rejects_mcp_local_empty_command() {
+        let content = "schema: 1
+name: empty-cmd
+description: empty command
+items:
+  skills: []
+mcps:
+  x:
+    local:
+      command: \"\"
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "empty-cmd.bundle.yaml", content);
+        let err = load(&path).expect_err("must reject empty command");
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("command") && msg.contains("empty"),
+            "got: {msg}"
+        );
     }
 
     #[test]

--- a/src/parse/bundle.rs
+++ b/src/parse/bundle.rs
@@ -585,6 +585,54 @@ plugins:
     }
 
     #[test]
+    fn load_parses_mcp_remote_and_local() {
+        use crate::model::bundle::McpTransport;
+
+        let content = "schema: 1
+name: with-mcp
+description: Bundle with MCP servers
+items:
+  skills: []
+mcps:
+  drawio:
+    remote:
+      type: http
+      url: https://mcp.draw.io/mcp
+  local-server:
+    local:
+      command: npx
+      args: [\"-y\", \"drawio-mcp-server\"]
+      env:
+        DRAWIO_TOKEN: \"${DRAWIO_TOKEN}\"
+    requires-env: [DRAWIO_TOKEN]
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "with-mcp.bundle.yaml", content);
+
+        let bundle = load(&path).expect("load");
+        assert_eq!(bundle.mcps.len(), 2);
+
+        match &bundle.mcps["drawio"].transport {
+            McpTransport::Remote(r) => {
+                assert_eq!(r.transport_type, "http");
+                assert_eq!(r.url, "https://mcp.draw.io/mcp");
+            }
+            McpTransport::Local(_) => panic!("expected remote"),
+        }
+
+        let local = &bundle.mcps["local-server"];
+        match &local.transport {
+            McpTransport::Local(l) => {
+                assert_eq!(l.command, "npx");
+                assert_eq!(l.args, vec!["-y", "drawio-mcp-server"]);
+                assert_eq!(l.env["DRAWIO_TOKEN"], "${DRAWIO_TOKEN}");
+            }
+            McpTransport::Remote(_) => panic!("expected local"),
+        }
+        assert_eq!(local.requires_env, vec!["DRAWIO_TOKEN"]);
+    }
+
+    #[test]
     fn load_parses_config_write_plugin() {
         use crate::model::bundle::OpencodePluginDescriptor;
 

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -21,7 +21,7 @@ use super::hash::hash_item_dir;
 use super::output::{
     copy_item_resources, is_dir_backed, output_path, remove_item_outputs, write_output,
 };
-use super::{ALL_CLIENTS, InstallReport, InstalledItem, ItemKind, PluginResult};
+use super::{ALL_CLIENTS, InstallReport, InstalledItem, ItemKind, McpResult, PluginResult};
 use crate::generate::{self, Client};
 use crate::model::{Agent, Audience, Rule, Skill};
 use crate::parse::frontmatter;
@@ -351,6 +351,57 @@ pub(super) fn install_plugins_from_bundles(
     results
 }
 
+// ---------------------------------------------------------------------------
+// MCP server configuration orchestration (ADR-0010)
+// ---------------------------------------------------------------------------
+
+/// Iterate all resolved bundles and configure each declared MCP server for
+/// Claude Code (v1's only target client). CLI-first: `claude mcp add`; on
+/// CliNotFound, fall back to writing `.mcp.json`. Warn-skip preserved: a
+/// failure never aborts the overall install.
+pub(super) fn install_mcps_from_bundles(
+    bundles: &[crate::model::Bundle],
+    scope: crate::plugin::PluginScope,
+    target: &Path,
+) -> Vec<McpResult> {
+    use crate::model::bundle::McpTransport;
+    use crate::plugin::PluginOutcome;
+
+    let mut results = Vec::new();
+    for bundle in bundles {
+        for (name, entry) in &bundle.mcps {
+            let cli_outcome = match &entry.transport {
+                McpTransport::Local(local) => crate::mcp::install_claude_local(name, local, scope),
+                McpTransport::Remote(remote) => {
+                    crate::mcp::install_claude_remote(name, remote, scope)
+                }
+            };
+
+            // CLI absent → config-write fallback into .mcp.json.
+            let outcome = match cli_outcome {
+                PluginOutcome::CliNotFound => match &entry.transport {
+                    McpTransport::Local(local) => {
+                        crate::ancillary::write_claude_mcp_local(target, name, local)
+                    }
+                    McpTransport::Remote(remote) => {
+                        crate::ancillary::write_claude_mcp_remote(target, name, remote)
+                    }
+                },
+                other => other,
+            };
+
+            results.push(McpResult {
+                name: name.clone(),
+                client: "claude".into(),
+                outcome,
+                bundle: bundle.name.clone(),
+                requires_env: entry.requires_env.clone(),
+            });
+        }
+    }
+    results
+}
+
 fn install_items_of_kind(
     kind: ItemKind,
     source: &Path,
@@ -512,5 +563,32 @@ mod tests {
         assert!(targets(Client::Claude, Some(&only_claude)));
         assert!(!targets(Client::Copilot, Some(&only_claude)));
         assert!(!targets(Client::OpenCode, Some(&only_claude)));
+    }
+}
+
+#[cfg(test)]
+mod mcp_tests {
+    use crate::plugin::PluginScope;
+
+    #[test]
+    fn install_mcps_records_result_per_server() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml = "schema: 1
+name: with-mcp
+description: test
+items:
+  skills: []
+mcps:
+  drawio:
+    remote:
+      type: http
+      url: https://example.com/mcp
+";
+        let bundle: crate::model::Bundle = serde_yaml_ng::from_str(yaml).unwrap();
+        let bundles = vec![bundle];
+        let results = super::install_mcps_from_bundles(&bundles, PluginScope::Project, tmp.path());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "drawio");
+        assert_eq!(results[0].client, "claude");
     }
 }

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -359,6 +359,10 @@ pub(super) fn install_plugins_from_bundles(
 /// Claude Code (v1's only target client). CLI-first: `claude mcp add`; on
 /// CliNotFound, fall back to writing `.mcp.json`. Warn-skip preserved: a
 /// failure never aborts the overall install.
+///
+/// Covered by the `tests/pipeline_mcp.rs` integration test, which clears
+/// PATH so the config-write fallback runs deterministically into a tempdir
+/// (an in-process unit test cannot safely force the `claude` CLI off PATH).
 pub(super) fn install_mcps_from_bundles(
     bundles: &[crate::model::Bundle],
     scope: crate::plugin::PluginScope,
@@ -563,32 +567,5 @@ mod tests {
         assert!(targets(Client::Claude, Some(&only_claude)));
         assert!(!targets(Client::Copilot, Some(&only_claude)));
         assert!(!targets(Client::OpenCode, Some(&only_claude)));
-    }
-}
-
-#[cfg(test)]
-mod mcp_tests {
-    use crate::plugin::PluginScope;
-
-    #[test]
-    fn install_mcps_records_result_per_server() {
-        let tmp = tempfile::tempdir().unwrap();
-        let yaml = "schema: 1
-name: with-mcp
-description: test
-items:
-  skills: []
-mcps:
-  drawio:
-    remote:
-      type: http
-      url: https://example.com/mcp
-";
-        let bundle: crate::model::Bundle = serde_yaml_ng::from_str(yaml).unwrap();
-        let bundles = vec![bundle];
-        let results = super::install_mcps_from_bundles(&bundles, PluginScope::Project, tmp.path());
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].name, "drawio");
-        assert_eq!(results[0].client, "claude");
     }
 }

--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -248,6 +248,33 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
         }
     }
 
+    // -- MCP server reconciliation (ADR-0010) --
+    // Walk the lockfile's MCP entries and check whether each is still
+    // registered in the client. Only `claude` client is supported for
+    // query; others are skipped (no list command available).
+    for mcp in &lock.mcps {
+        if mcp.client != "claude" {
+            continue;
+        }
+        use crate::pipeline::report::{McpDoctorEntry, McpDoctorStatus};
+        use crate::plugin::PluginCheckResult;
+
+        let status = match crate::mcp::check_claude_installed(&mcp.name) {
+            PluginCheckResult::Installed => McpDoctorStatus::Ok,
+            PluginCheckResult::NotInstalled => McpDoctorStatus::NotRegistered,
+            PluginCheckResult::CliNotFound => McpDoctorStatus::CliNotFound,
+            PluginCheckResult::QueryFailed { stderr, .. } => {
+                McpDoctorStatus::QueryFailed { stderr }
+            }
+        };
+        report.mcp_entries.push(McpDoctorEntry {
+            name: mcp.name.clone(),
+            client: mcp.client.clone(),
+            bundle: mcp.bundle.clone(),
+            status,
+        });
+    }
+
     Ok(report)
 }
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -40,7 +40,10 @@ use discovery::scan_source_items;
 pub use git::{fetch_ssot, install_from_git_url, install_from_source};
 pub(crate) use hash::hash_item_dir;
 pub use install::install_from_local_path;
-use install::{install_plugins_from_bundles, install_with_name_resolution_from_local};
+use install::{
+    install_mcps_from_bundles, install_plugins_from_bundles,
+    install_with_name_resolution_from_local,
+};
 pub use lifecycle::{doctor, list, remove, update};
 pub use report::*;
 
@@ -227,6 +230,10 @@ pub fn install_with_lockfile(
     let plugin_results = install_plugins_from_bundles(&report.bundles, plugin_scope, target);
     report.plugin_results = plugin_results;
 
+    // -- MCP server configuration (ADR-0010) --
+    let mcp_results = install_mcps_from_bundles(&report.bundles, plugin_scope, target);
+    report.mcp_results = mcp_results;
+
     // -- Apply excludes --
     if !options.excludes.is_empty() {
         report
@@ -322,6 +329,28 @@ pub fn install_with_lockfile(
                 crate::plugin::PluginScope::User => Some("user".into()),
             },
             bundle: pr.bundle.clone(),
+            status,
+        });
+    }
+    // Record configured and warn-skipped MCP servers in the lockfile.
+    for mr in &report.mcp_results {
+        use crate::lockfile::McpInstallStatus;
+        use crate::plugin::PluginOutcome;
+
+        let status = match &mr.outcome {
+            PluginOutcome::Success => McpInstallStatus::Installed,
+            PluginOutcome::CliNotFound => McpInstallStatus::Skipped,
+            // ManualInstructions is unused for MCP; Failed is transient.
+            PluginOutcome::ManualInstructions | PluginOutcome::Failed { .. } => continue,
+        };
+        lock.upsert_mcp(crate::lockfile::LockedMcp {
+            name: mr.name.clone(),
+            client: mr.client.clone(),
+            scope: match plugin_scope {
+                crate::plugin::PluginScope::Project => Some("project".into()),
+                crate::plugin::PluginScope::User => Some("user".into()),
+            },
+            bundle: mr.bundle.clone(),
             status,
         });
     }

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -37,6 +37,9 @@ pub struct InstallReport {
     /// (plugin-name, client) pair attempted. Empty when no bundles with
     /// plugins were resolved.
     pub plugin_results: Vec<PluginResult>,
+    /// Results of MCP server configuration (ADR-0010). Empty when no
+    /// bundles with `mcps:` were resolved.
+    pub mcp_results: Vec<McpResult>,
 }
 
 /// Result of a single plugin install attempt, for reporting to the user.
@@ -58,6 +61,21 @@ pub struct PluginResult {
     pub instructions_url: Option<String>,
     /// Human-readable summary for manual instructions.
     pub summary: Option<String>,
+}
+
+/// Result of a single MCP server configuration attempt, for reporting.
+#[derive(Debug, Clone)]
+pub struct McpResult {
+    /// Upskill-level MCP name.
+    pub name: String,
+    /// Client identifier.
+    pub client: String,
+    /// Configuration outcome.
+    pub outcome: crate::plugin::PluginOutcome,
+    /// Bundle that declared this MCP server.
+    pub bundle: String,
+    /// Env vars declared as required (for the doctor/warn surface).
+    pub requires_env: Vec<String>,
 }
 
 /// What to remove. Per ADR-0004 the user must be explicit — bare

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -172,6 +172,29 @@ pub struct SkippedPlugin {
     pub bundle: String,
 }
 
+/// Reconciliation outcome for a single MCP server during `doctor`.
+#[derive(Debug, Clone, Serialize)]
+pub struct McpDoctorEntry {
+    pub name: String,
+    pub client: String,
+    pub bundle: String,
+    pub status: McpDoctorStatus,
+}
+
+/// The specific condition detected during doctor MCP reconciliation.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum McpDoctorStatus {
+    /// Registered in the client — no action needed.
+    Ok,
+    /// In the lockfile but absent from the client's registered list.
+    NotRegistered,
+    /// Client CLI was not found; cannot verify.
+    CliNotFound,
+    /// CLI returned non-zero when listing MCP servers.
+    QueryFailed { stderr: String },
+}
+
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct DoctorReport {
     pub missing_outputs: Vec<MissingOutput>,
@@ -186,6 +209,11 @@ pub struct DoctorReport {
     /// false or trigger exit 1. Run `upskill update` after installing the
     /// missing CLI to install them.
     pub skipped_plugins: Vec<SkippedPlugin>,
+    /// MCP server reconciliation results. Entries are present for every MCP
+    /// recorded in the lockfile. `McpDoctorStatus::Ok` entries are included
+    /// so callers can distinguish "checked and fine" from "not checked".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_entries: Vec<McpDoctorEntry>,
 }
 
 impl DoctorReport {

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -230,6 +230,10 @@ impl DoctorReport {
             && self.stale_hashes.is_empty()
             && self.orphan_entries.is_empty()
             && self.missing_plugins.is_empty()
+            && !self
+                .mcp_entries
+                .iter()
+                .any(|e| matches!(e.status, McpDoctorStatus::NotRegistered))
     }
 }
 
@@ -356,5 +360,40 @@ mod tests {
             reason: OrphanReason::LocalPathGone,
         });
         assert!(!report.is_clean());
+    }
+
+    #[test]
+    fn doctor_report_not_clean_with_not_registered_mcp() {
+        let mut report = DoctorReport::default();
+        report.mcp_entries.push(McpDoctorEntry {
+            name: "my-mcp".into(),
+            client: "claude".into(),
+            bundle: "my-bundle".into(),
+            status: McpDoctorStatus::NotRegistered,
+        });
+        assert!(!report.is_clean());
+    }
+
+    #[test]
+    fn doctor_report_clean_with_mcp_cli_not_found_or_query_failed() {
+        let mut report = DoctorReport::default();
+        report.mcp_entries.push(McpDoctorEntry {
+            name: "my-mcp".into(),
+            client: "claude".into(),
+            bundle: "my-bundle".into(),
+            status: McpDoctorStatus::CliNotFound,
+        });
+        assert!(report.is_clean());
+
+        let mut report = DoctorReport::default();
+        report.mcp_entries.push(McpDoctorEntry {
+            name: "my-mcp".into(),
+            client: "claude".into(),
+            bundle: "my-bundle".into(),
+            status: McpDoctorStatus::QueryFailed {
+                stderr: "some error".into(),
+            },
+        });
+        assert!(report.is_clean());
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -253,7 +253,7 @@ pub fn check_opencode_plugin_installed(module_name: &str) -> PluginCheckResult {
 // ---------------------------------------------------------------------------
 
 /// Captured result of a CLI invocation.
-enum CommandOutput {
+pub(crate) enum CommandOutput {
     Success {
         stdout: String,
     },
@@ -264,7 +264,7 @@ enum CommandOutput {
     },
 }
 
-fn run_command_output(program: &str, args: &[&str]) -> CommandOutput {
+pub(crate) fn run_command_output(program: &str, args: &[&str]) -> CommandOutput {
     let result = spawn_command(program, args);
     match result {
         Ok(out) if out.status.success() => CommandOutput::Success {
@@ -316,7 +316,7 @@ fn is_command_not_found(output: &std::process::Output) -> bool {
 
 /// Map `CommandOutput` to `PluginCheckResult` by searching for `needle` as
 /// a substring of any stdout line.
-fn check_output_for_substring(output: CommandOutput, needle: &str) -> PluginCheckResult {
+pub(crate) fn check_output_for_substring(output: CommandOutput, needle: &str) -> PluginCheckResult {
     match output {
         CommandOutput::CliNotFound => PluginCheckResult::CliNotFound,
         CommandOutput::Failed { exit_code, stderr } => {
@@ -354,7 +354,7 @@ fn check_output_for_exact_line(output: CommandOutput, needle: &str) -> PluginChe
 }
 
 /// Execute a CLI command and map the result to a `PluginOutcome`.
-fn run_command(program: &str, args: &[&str]) -> PluginOutcome {
+pub(crate) fn run_command(program: &str, args: &[&str]) -> PluginOutcome {
     let output = match spawn_command(program, args) {
         Ok(output) if is_command_not_found(&output) => {
             return PluginOutcome::CliNotFound;

--- a/tests/cli_mangen.rs
+++ b/tests/cli_mangen.rs
@@ -34,12 +34,12 @@ fn every_subcommand_renders_a_man_page() {
         .map(|s| s.get_name().to_string())
         .collect();
 
-    // Sanity: the audit-driven CLI ships nine commands. If this drifts,
+    // Sanity: the CLI ships a fixed number of commands. If this drifts,
     // update the assert and the docs.
     assert_eq!(
         names.len(),
-        10,
-        "expected 10 subcommands, got {}: {names:?}",
+        11,
+        "expected 11 subcommands, got {}: {names:?}",
         names.len()
     );
 

--- a/tests/cli_mcp.rs
+++ b/tests/cli_mcp.rs
@@ -1,0 +1,183 @@
+//! ATDD tests for MCP server config-write install via `upskill add`.
+//!
+//! Drives the full install pipeline with `claude` absent from PATH so the
+//! config-write fallback runs deterministically into the test's tempdir
+//! (never the developer's real home or the worktree root).
+//!
+//! Covered scenario: a bundle declares a local (stdio) MCP server; with
+//! `claude` absent, upskill falls back to writing `.mcp.json` and records
+//! the server in `.upskill-lock.json`.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+/// Minimal SKILL.md for a skill named `drawio-diagrams`.
+const DRAWIO_SKILL_MD: &str = "\
+---
+schema: 1
+name: drawio-diagrams
+description: Create diagrams with Draw.io
+---
+
+# Draw.io diagrams
+
+Use diagrams to communicate architecture.
+";
+
+/// Bundle that declares `drawio-diagrams` and a local MCP server.
+const DRAWIO_BUNDLE_YAML: &str = "\
+schema: 1
+name: drawio
+description: Draw.io bundle with MCP server
+
+items:
+  skills:
+    - drawio-diagrams
+
+mcps:
+  drawio:
+    local:
+      command: npx
+      args:
+        - \"-y\"
+        - drawio-mcp-server
+      env:
+        DRAWIO_TOKEN: \"${DRAWIO_TOKEN}\"
+    requires-env:
+      - DRAWIO_TOKEN
+";
+
+/// Build a minimal SSOT registry in `root`:
+/// - `drawio-diagrams/SKILL.md` — a single skill so `items.skills` resolves.
+/// - `bundles/drawio.bundle.yaml` — declares the skill and an MCP server.
+fn stage_mcp_registry(root: &Path) {
+    let skill_dir = root.join("drawio-diagrams");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), DRAWIO_SKILL_MD).unwrap();
+
+    let bundles_dir = root.join("bundles");
+    fs::create_dir_all(&bundles_dir).unwrap();
+    fs::write(bundles_dir.join("drawio.bundle.yaml"), DRAWIO_BUNDLE_YAML).unwrap();
+}
+
+/// Return a PATH value containing only an empty temp `bin/` directory so
+/// that `claude` is not found (config-write fallback triggers) while
+/// `upskill` itself — resolved by absolute path via `cargo_bin` — still
+/// runs.
+fn empty_bin_path(tmp: &Path) -> String {
+    let bin = tmp.join("empty-bin");
+    fs::create_dir_all(&bin).unwrap();
+    bin.to_str().unwrap().to_string()
+}
+
+#[test]
+fn add_bundle_with_mcp_writes_claude_mcp_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_mcp_registry(&registry);
+    fs::create_dir_all(&project).unwrap();
+    // Mark project as a git repo so upskill selects project scope.
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/drawio.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["add", bundle_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // .mcp.json must exist in the project dir (config-write fallback ran).
+    let mcp_json_path = project.join(".mcp.json");
+    assert!(
+        mcp_json_path.exists(),
+        ".mcp.json must be written by the config-write fallback"
+    );
+
+    let raw = fs::read_to_string(&mcp_json_path).unwrap();
+
+    // Server name is present.
+    assert!(
+        raw.contains("\"drawio\""),
+        ".mcp.json must contain the server name 'drawio': {raw}"
+    );
+
+    // Command is present.
+    assert!(
+        raw.contains("npx"),
+        ".mcp.json must contain the command 'npx': {raw}"
+    );
+
+    // Secret reference is preserved verbatim — upskill must NOT expand it.
+    assert!(
+        raw.contains("${DRAWIO_TOKEN}"),
+        ".mcp.json must carry the literal `${{DRAWIO_TOKEN}}` reference verbatim \
+         (secret custody stays with the user's environment): {raw}"
+    );
+
+    // Lockfile records the MCP entry.
+    let lock_path = project.join(".upskill-lock.json");
+    assert!(lock_path.exists(), ".upskill-lock.json must exist");
+    let lock_raw = fs::read_to_string(&lock_path).unwrap();
+    assert!(
+        lock_raw.contains("\"mcps\""),
+        "lockfile must have a 'mcps' array: {lock_raw}"
+    );
+    assert!(
+        lock_raw.contains("\"drawio\""),
+        "lockfile must record the 'drawio' MCP server: {lock_raw}"
+    );
+}
+
+#[test]
+fn add_bundle_with_mcp_is_deterministic_second_run() {
+    // Running the same add twice must not accumulate duplicate entries
+    // in .mcp.json or .upskill-lock.json (idempotency check).
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_mcp_registry(&registry);
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/drawio.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    for _ in 0..2 {
+        common::upskill_cmd(&home)
+            .current_dir(&project)
+            .env("PATH", &path_val)
+            .args(["add", bundle_path.to_str().unwrap()])
+            .assert()
+            .success();
+    }
+
+    let raw = fs::read_to_string(project.join(".mcp.json")).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let servers = doc["mcpServers"].as_object().expect("mcpServers object");
+    assert_eq!(
+        servers.len(),
+        1,
+        "second add must not duplicate the server entry; got {servers:?}"
+    );
+
+    let lock_raw = fs::read_to_string(project.join(".upskill-lock.json")).unwrap();
+    let lock: serde_json::Value = serde_json::from_str(&lock_raw).unwrap();
+    let mcps = lock["mcps"].as_array().expect("mcps array");
+    assert_eq!(
+        mcps.len(),
+        1,
+        "second add must not duplicate the lockfile mcp entry; got {mcps:?}"
+    );
+}

--- a/tests/pipeline_mcp.rs
+++ b/tests/pipeline_mcp.rs
@@ -1,0 +1,112 @@
+//! ATDD tests for the MCP server install + remove lifecycle.
+//!
+//! Exercises `upskill add` → lockfile records MCP server, then
+//! `upskill remove-mcp <name>` → lockfile drops MCP server.
+//!
+//! `claude` is kept off PATH throughout by setting PATH to an empty
+//! directory, so the config-write fallback runs deterministically into the
+//! test's tempdir.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+/// Minimal SKILL.md for a skill named `s`.
+const SKILL_MD: &str = "\
+---
+schema: 1
+name: s
+description: A minimal skill
+---
+
+# Skill
+
+Minimal body.
+";
+
+/// Bundle with a remote HTTP MCP server.
+const BUNDLE_YAML: &str = "\
+schema: 1
+name: b
+description: Bundle with remote MCP
+
+items:
+  skills:
+    - s
+
+mcps:
+  remote-srv:
+    remote:
+      type: http
+      url: https://example.com/mcp
+";
+
+/// Build a minimal SSOT registry with a single skill and a bundle that
+/// declares a remote MCP server.
+fn stage_remote_mcp_registry(root: &Path) {
+    let skill_dir = root.join("s");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), SKILL_MD).unwrap();
+
+    let bundles_dir = root.join("bundles");
+    fs::create_dir_all(&bundles_dir).unwrap();
+    fs::write(bundles_dir.join("b.bundle.yaml"), BUNDLE_YAML).unwrap();
+}
+
+/// PATH that contains only an empty directory — `claude` absent, local-path
+/// add still works (no external binary needed for local sources).
+fn empty_bin_path(tmp: &Path) -> String {
+    let bin = tmp.join("empty-bin");
+    fs::create_dir_all(&bin).unwrap();
+    bin.to_str().unwrap().to_string()
+}
+
+#[test]
+fn add_then_remove_mcp_updates_lockfile() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_remote_mcp_registry(&registry);
+    fs::create_dir_all(&project).unwrap();
+    // Mark as a git repo so project scope is selected.
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/b.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    // Step 1 — add the bundle; the lockfile must contain the MCP entry.
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["add", bundle_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let lock_raw = fs::read_to_string(project.join(".upskill-lock.json")).unwrap();
+    assert!(
+        lock_raw.contains("\"remote-srv\""),
+        "lockfile must record 'remote-srv' after add: {lock_raw}"
+    );
+    assert!(
+        lock_raw.contains("\"mcps\""),
+        "lockfile must have a 'mcps' key after add: {lock_raw}"
+    );
+
+    // Step 2 — remove the MCP server; the lockfile must no longer contain it.
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["remove-mcp", "remote-srv"])
+        .assert()
+        .success();
+
+    let lock_raw_after = fs::read_to_string(project.join(".upskill-lock.json")).unwrap();
+    assert!(
+        !lock_raw_after.contains("\"remote-srv\""),
+        "lockfile must NOT contain 'remote-srv' after remove-mcp: {lock_raw_after}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds **MCP server support (v1)** to upskill: a bundle can declare `mcps:` servers that `upskill add` configures into Claude Code — CLI-first (`claude mcp add`), with a `.mcp.json` config-write fallback when the `claude` CLI is absent — recorded in the lockfile, with `upskill remove-mcp <name>` and `upskill doctor` reconciliation.

A near-exact parallel of the existing plugin mechanism ([ADR-0008](docs/adr/0008-plugin-install-shellout.md)). Design and plan were brainstormed first:

- Design spec: [docs/superpowers/specs/2026-06-03-mcp-support-design.md](docs/superpowers/specs/2026-06-03-mcp-support-design.md)
- Plan: [docs/superpowers/plans/2026-06-03-mcp-support-v1.md](docs/superpowers/plans/2026-06-03-mcp-support-v1.md)
- ADR: [docs/adr/0010-mcp-config-write.md](docs/adr/0010-mcp-config-write.md)

## What's included

- **Model** — `mcps:` map on `Bundle`; `McpEntry`/`McpTransport`(remote|local)/`McpRemote`/`McpLocal`; `validate_mcps` (transport type ∈ {http, sse}, non-empty url/command).
- **Configure** — `src/mcp.rs` shells out to `claude mcp add/remove/list`; `src/ancillary.rs` writes/merges `.mcp.json` (`{ "mcpServers": { … } }`) as the CLI-missing fallback.
- **Pipeline** — `install_mcps_from_bundles` (CLI-first → CliNotFound config-write fallback → warn-skip on failure); records `LockedMcp` in the lockfile (schema stays `1`, additive).
- **CLI** — install reporting + unset-`requires-env` warnings; `upskill remove-mcp <name>`; `upskill doctor` reconciles each recorded Claude server against `claude mcp list` (a `NotRegistered` server makes doctor exit non-clean).
- **Lint** — `upskill lint` now surfaces invalid `mcps:` declarations (closed a real gap: lint's bundle parse path bypassed `validate_mcps`).
- **Docs** — ADR-0010 + format-spec `mcps:` sub-shape.
- **Tests** — model/parse/validation/config-write/lockfile unit tests; `tests/cli_mcp.rs` + `tests/pipeline_mcp.rs` end-to-end (deterministic via PATH isolation; tempdir-confined).

## Trust posture (security)

upskill stays **safe-by-construction**: it never expands `${VAR}` (secret references pass through verbatim to client config — proven by a test asserting the literal `${DRAWIO_TOKEN}` survives into `.mcp.json`), never persists a literal secret to the lockfile, and never runs fetched server code — the only execution is shelling out to the known `claude` binary. `requires-env` is a presence-check only (never reads values).

## v1 scope / deliberate limits (documented)

- **Claude Code only.** opencode / VS Code / Copilot MCP writers are deferred (warn-skip).
- **No `requires.mcps` skill-dependency edge.** v1 couples an MCP to a skill by shared bundle membership; the dependency edge (riding ADR-0009) + a generated skill-body preflight + an execution-free install agent for bare binaries are the planned **v2 fast-follow**.
- `requires-env` unset warning is emitted at `upskill add` time, not in `doctor`.

## Follow-up debt (non-blocking)

- `run_remove_mcp` derives scope from the `--global`/`--project` flag rather than the lockfile-recorded `mcp.scope`.
- v2: extend config to opencode/VS Code/Copilot; `requires.mcps` edge + install agent.

## Notes

- Merged current `origin/main` (incl. ADR-0009 coupling work) into the branch; conflicts resolved keeping both feature sets. `fmt.rs` updated to canonicalise the `mcps` bundle key.
- `just verify` green (test + clippy + fmt/dprint/markdownlint + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
