### PR TITLE
docs: MCP local-install convention (recipe + distilling pattern)

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -95,3 +95,68 @@ upskill lint --strict
 
 `upskill fmt` is idempotent — files already in canonical form aren't
 rewritten, so you can run it on every commit hook without churn.
+
+## Shipping an MCP that needs a local install
+
+A bundle's `mcps:` map configures an MCP server into the consumer's client
+(see [format-spec §3.7](format-spec.md) and
+[ADR-0010](adr/0010-mcp-config-write.md)). For most servers that is all you
+need. This recipe covers the one case that needs more: a **local server that
+is a bare binary with no self-fetching launcher**, so the binary must be
+installed on the consumer machine.
+
+**First — do you even need an installer?**
+
+- Remote server (`remote: { type, url }`) → no installer; it is already
+  running.
+- Local server launched by `npx -y <pkg>`, `uvx <pkg>`, or `docker run …` →
+  no installer; the launcher fetches and caches the server on first run.
+- Local server that is a **bare binary** (a compiled tool, a Homebrew
+  formula) → continue below.
+
+**The pattern.** upskill has no way to install the binary itself — it is a
+CLI, not an agent. Instead, ship the install knowledge as content and let the
+consumer's AI agent run it:
+
+1. **Author a per-MCP installer agent.** Scaffold one with
+   `upskill new agent <name>-mcp-installer`. Its body is the install recipe
+   for that one server — detect the OS, check the version, install via the
+   right channel (`brew install …`, download + `chmod`, `cargo install …`),
+   run any one-time setup. Give it the `Bash` tool, and state in its body
+   that it must get the user's approval before running install commands.
+
+2. **Add a trigger to the skill that uses the MCP.** Near the top of the
+   skill body, add one line of plain prose:
+
+   > If the `<name>` MCP server is not responding (a tool call fails because
+   > the binary is missing), dispatch the `<name>-mcp-installer` agent to
+   > install it, then retry.
+
+3. **Bundle the three together** so one install brings them all:
+
+   ```yaml
+   # <name>-mcp.bundle.yaml
+   schema: 1
+   name: <name>-mcp
+   description: <name> MCP server, its skill, and its local-install agent
+   items:
+     skills: [<name>-diagrams]
+     agents: [<name>-mcp-installer]
+   mcps:
+     <name>:
+       local: { command: <binary>, args: [...] }
+   ```
+
+```bash
+upskill add owner/registry:<name>-mcp.bundle.yaml --claude
+```
+
+This installs the skill, installs the `<name>-mcp-installer` agent into the
+client's agents directory, and configures the MCP — in one step.
+
+**At runtime:** the consumer uses the skill, the model reads the trigger
+line, and if the MCP tool is missing it dispatches `<name>-mcp-installer` —
+which installs the binary under the client's own "allow this command?"
+prompts — then retries. upskill is never in this loop after `add`: it
+configures the server and ships the installer agent as content, but the
+client's agent does the installing, gated by the client's permission prompts.

--- a/docs/superpowers/specs/2026-06-03-mcp-v2-convention-design.md
+++ b/docs/superpowers/specs/2026-06-03-mcp-v2-convention-design.md
@@ -1,0 +1,155 @@
+# Design: MCP local-install convention (v2 — docs only)
+
+**Date**: 2026-06-03
+**Status**: Approved (brainstorming)
+**Builds on**: v1 MCP support ([spec](2026-06-03-mcp-support-design.md), [ADR-0010](../../adr/0010-mcp-config-write.md), PR #218)
+
+## TL;DR for a cold-start executor
+
+**This is a documentation-only deliverable. No Rust. No new upskill capability.**
+v2 is an _authoring convention_ that already works on v1 + existing
+rule/skill/agent/bundle primitives. Ship exactly two content edits:
+
+1. A recipe in `docs/recipes.md` — _"Shipping an MCP that needs a local install."_
+2. A short subsection in `skills/prompt-distilling/SKILL.md` — _"Provisioning an
+   MCP server"_ — naming the placement decision and linking to the recipe.
+
+Follow the `writing-skills` discipline for edit #2 (it is SSOT skill content in
+this repo). Edit #1 is ordinary user-guide prose.
+
+## Why this is docs-only (the reasoning, so it isn't re-litigated)
+
+The v1 design sketched a larger "v2": a `requires: { mcps }` dependency edge, an
+auto-injected skill-body "preflight," and a generic install agent. We
+pressure-tested all of it and dropped it:
+
+- **upskill cannot trigger/dispatch a subagent.** It is a ~3 MB CLI with no LLM
+  and no agent runtime. Only the _client's_ model (e.g. Claude Code) can dispatch
+  a subagent. upskill's only lever is producing content the model reads. So any
+  "auto-install" mechanism reduces to _content the model acts on_ — which authors
+  can write directly.
+- **No auto-injection needed.** The trigger line ("if the MCP is missing, run its
+  installer agent") can be authored in the skill body. upskill auto-injecting it
+  would be optional sugar, not a requirement — so it is out of scope.
+- **Per-MCP installer agent, not a generic one.** Bare-binary install is too
+  heterogeneous for a declarative matrix or a generic agent guessing from hints.
+  A per-MCP `<name>-mcp-installer` _agent_ lets the author encode the exact recipe
+  in prose. That is just `agent` SSOT content — already a first-class kind.
+- **MCP stays a v1 bundle descriptor.** No MCP-as-a-kind, no `requires.mcps`, no
+  migration. Keeping v1 as-is is a deliberate decision.
+
+Everything the pattern needs already ships in v1: a bundle can carry
+`items.skills`, `items.agents`, and an `mcps:` config simultaneously, and one
+`upskill add <bundle>` installs all three.
+
+## The convention (what the recipe documents)
+
+Goal: ship an MCP server whose local binary has no self-fetching launcher, so it
+must be installed/verified on the consumer machine.
+
+1. **Configure the MCP** with v1's bundle `mcps:` descriptor.
+   - Remote server → `remote: { type, url }`. No installer needed.
+   - Local server launched by `npx -y <pkg>` / `uvx <pkg>` / `docker run …` →
+     `local: { command, args }`. **No installer needed** — the launcher
+     self-fetches on first run. State this prominently: most local servers need
+     nothing.
+   - Local server that is a **bare binary** with no launcher → `local: { command:
+     <binary>, … }`, and proceed to step 2.
+2. **Author a per-MCP installer agent** `<name>-mcp-installer` (an `agent` item).
+   Its system prompt is the install recipe for that one server: detect the OS,
+   check the version (`<binary> --version` ≥ X), install via the right channel
+   (`brew install …` / download+chmod / `cargo install …`), and run any one-time
+   setup. Scaffold a stub with `upskill new agent <name>-mcp-installer`.
+   - Give it a narrow tool surface (it needs `Bash`).
+   - Its body should be explicit that it must obtain user approval before running
+     install commands (the client's permission prompts are the real gate).
+3. **Add the trigger to the consuming skill.** In the skill that teaches using the
+   MCP, add one authored line near the top, e.g.:
+   > If the `<name>` MCP server is not responding (a tool call fails because the
+   > server/binary is missing), dispatch the `<name>-mcp-installer` agent to
+   > install it, then retry.
+   > This is plain authored prose — upskill injects nothing.
+4. **Bundle the three together** so they install as a unit:
+
+   ```yaml
+   # <name>-mcp.bundle.yaml
+   schema: 1
+   name: <name>-mcp
+   description: <name> MCP server, its skill, and its local-install agent
+   items:
+     skills: [<name>-diagrams] # the skill that uses + triggers
+     agents: [<name>-mcp-installer] # the per-MCP installer
+   mcps:
+     <name>:
+       local: { command: <binary>, args: [...] }
+       requires-env: [...] # if any
+   ```
+
+   `upskill add <source>` then installs the skill, installs the installer agent
+   into `.claude/agents/`, and configures the MCP — all at once.
+
+**Runtime flow:** the consumer uses the skill → the model reads the trigger line
+→ if the MCP tool is missing, the model dispatches `<name>-mcp-installer` → the
+agent installs the binary under the client's permission prompts → the model
+retries. upskill is never in this loop after `add`.
+
+**Trust framing to state in the recipe:** upskill never downloads, builds, or
+runs server/binary code. It configures the MCP (CLI/config-write) and installs
+the installer agent as content. The _client's_ agent runs the install, gated by
+the client's own "allow this command?" prompts. No new RCE surface.
+
+## Deliverable 1 — `docs/recipes.md` recipe
+
+Add a recipe section _"Shipping an MCP that needs a local install."_ Structure:
+
+- One-paragraph problem statement (bare binary, no launcher).
+- "First, do you even need this?" — remote and `npx -y`/`uvx`/`docker` servers
+  need no installer; only a launcher-less bare binary does.
+- The 4 steps above, with the bundle YAML example.
+- The runtime-flow + trust paragraphs.
+- A pointer to [ADR-0010](../adr/0010-mcp-config-write.md) and the v1 `mcps:`
+  format-spec section.
+
+Match the existing recipe style in `docs/recipes.md` (read a sibling recipe for
+heading level, voice, and code-fence conventions). If `docs/recipes.md` is in the
+mdBook `SUMMARY.md`, no new entry is needed (it is an in-page section); confirm.
+
+## Deliverable 2 — `skills/prompt-distilling/SKILL.md` subsection
+
+Add a short subsection — _"Provisioning an MCP server"_ — that frames the
+**placement decision**:
+
+- The _install logic_ is heterogeneous reasoning → it belongs in a **subagent**
+  (a per-MCP `<name>-mcp-installer`), not a rule, a skill, or a declarative
+  config.
+- The _trigger_ belongs in the **skill** that uses the MCP (one authored line).
+- The _MCP config_ belongs in the **bundle** (`mcps:`), which also bundles the
+  skill + installer agent.
+- Link to the `docs/recipes.md` recipe for the full how-to.
+
+Keep it brief — prompt-distilling is about _where behavior lives_, so this is a
+placement rule plus a pointer, not a tutorial. Follow `writing-skills`: this is
+SSOT content; after editing, run `upskill lint` (and `just fmt`) on the skill.
+An optional one-line cross-reference may be added to `skills/prompt-design/SKILL.md`
+(the framework entry point) pointing at the distilling subsection — author's
+discretion.
+
+## Out of scope (explicitly)
+
+- Any Rust/binary change. MCP config stays exactly as v1 ships it.
+- `requires: { mcps }`, MCP-as-a-kind, auto-injected preflights, a generic
+  installer agent, add-time dispatch hints. All considered and rejected above.
+
+## Testing / acceptance
+
+- `just fmt` clean; `upskill lint` clean on the edited skill; mdBook builds
+  (`just book`) if the recipe touches anything the book renders.
+- Manual read-through: a third-party author could follow the recipe end-to-end
+  and produce a working bundle without reading any source code.
+
+## Branching / sequencing note
+
+These edits reference v1's `mcps:`, which ships in **PR #218** (still in CI at
+authoring time). Execute **after #218 merges**, on a fresh branch off updated
+`main` (avoids a stacked PR). A new session can pick this up cold from this
+document.

--- a/skills/prompt-distilling/SKILL.md
+++ b/skills/prompt-distilling/SKILL.md
@@ -126,6 +126,16 @@ A quick reference for recurring multi-layer authoring intents:
   Vault").
 - **Skill + MCP tool** — procedure that calls live tools ("how to
   triage a Jira incident" plus `jira_search`).
+- **MCP + installer Subagent + Skill** — an MCP server whose local
+  binary must be installed on the consumer machine (no `npx`/`uvx`
+  launcher). Configure the server in a bundle's `mcps:`; put the
+  install recipe — detect OS, version-check, install the binary — in a
+  per-MCP `<name>-mcp-installer` subagent (the HOW); put the trigger in
+  the skill that uses the MCP, as one authored line ("if the `<name>`
+  MCP is not responding, run the `<name>-mcp-installer` subagent
+  first"). upskill never runs the installer — the client's agent does,
+  under its own permission prompts. See the recipe "Shipping an MCP
+  that needs a local install".
 - **Subagent + Skill** — subagent loads skills inside its own context
   (test-runner subagent plus a "how to interpret cargo-nextest
   failures" skill).


### PR DESCRIPTION
## Summary

Documents the **v2 MCP local-install convention** — the fast-follow to v1 MCP support ([#218](https://github.com/driftsys/upskill/pull/218)). This is **docs-only**: no Rust, no new upskill capability. The pattern already works on v1 + existing rule/skill/agent/bundle primitives.

The convention: ship an MCP whose local binary has no self-fetching launcher by bundling three authored pieces together —
- the **MCP config** (v1's bundle `mcps:`),
- a per-MCP **`<name>-mcp-installer` agent** holding the install recipe (the HOW),
- a one-line **trigger** in the skill that uses the MCP ("if the MCP is missing, run its installer").

One `upskill add <bundle>` installs all three. At runtime the consumer's model dispatches the installer agent when it hits a missing tool, under the client's permission prompts. **upskill never runs the installer** — it's a CLI with no agent runtime; it only ships content.

## What's included

- **`docs/recipes.md`** — recipe *"Shipping an MCP that needs a local install"*: the "do you even need an installer?" decision (remote / `npx -y` / `uvx` / `docker` need none), the 4-step pattern with a bundle example, and the runtime/trust framing.
- **`skills/prompt-distilling/SKILL.md`** — a bullet in *Common decomposition patterns* naming the placement decision (install logic → subagent, trigger → skill, config → bundle).
- **`docs/superpowers/specs/2026-06-03-mcp-v2-convention-design.md`** — the design doc (captures why this is docs-only, and what larger "v2" ideas — MCP-as-a-kind, `requires.mcps`, auto-injected preflights, a generic installer — were considered and rejected).

## Validation

- `just fmt` clean
- `upskill lint skills/prompt-distilling` → 0 findings
- `just book` builds clean

## Notes

- Stacks on v1 (merged in #218); branched off current `main`.
- The `prompt-distilling` edit follows skill-authoring principles (concise, placement-framed, portable by-name reference rather than a fragile relative link, since the skill is distributed to consumers) and is validated by `upskill lint`; the full subagent RED-GREEN cycle was judged disproportionate for a one-bullet reference addition to an existing framework skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
