### PR TITLE
refactor(skills): namespace-prefix item names with upskill-

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,39 +181,39 @@ Use the skill tool to load a skill when a task matches its description.
 
 <available_skills>
 <skill>
-<name>evaluating-prompts</name>
-<description>Use when setting up the RED-GREEN-REFACTOR cycle for a rule, skill, or subagent — i.e., when the `writing-*` skills tell you to "run a failing test first." Trigger when authoring meta-skills, when validating that an existing rule/skill/subagent actually shapes behavior, or when auditing whether a skill activates correctly. Do NOT trigger for content authoring itself — see writing-rules, writing-skills, writing-subagents.</description>
-<location>skills/evaluating-prompts/SKILL.md</location>
+<name>upskill-evaluating-prompts</name>
+<description>Use when setting up the RED-GREEN-REFACTOR cycle for a rule, skill, or subagent — i.e., when the `writing-*` skills tell you to "run a failing test first." Trigger when authoring meta-skills, when validating that an existing rule/skill/subagent actually shapes behavior, or when auditing whether a skill activates correctly. Do NOT trigger for content authoring itself — see upskill-writing-rules, writing-skills, upskill-writing-subagents.</description>
+<location>skills/upskill-evaluating-prompts/SKILL.md</location>
 </skill>
 <skill>
-<name>prompt-design</name>
-<description>Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to prompt-distilling, writing-rules, writing-skills, writing-subagents, or using-upskill.</description>
-<location>skills/prompt-design/SKILL.md</location>
+<name>upskill-prompt-design</name>
+<description>Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, upskill-writing-subagents, or upskill-using.</description>
+<location>skills/upskill-prompt-design/SKILL.md</location>
 </skill>
 <skill>
-<name>prompt-distilling</name>
-<description>Use BEFORE authoring any rule, skill, or subagent. Trigger when someone says "we should encode X", "the agent keeps forgetting Y", "let's add a rule for Z", or any variant where new behavior needs to live somewhere in the framework. Also trigger when reviewing existing content that is misbehaving — wrong-layer placement is a common silent root cause. Do NOT trigger for refining content already correctly placed; hand off to writing-rules, writing-skills, or writing-subagents.</description>
-<location>skills/prompt-distilling/SKILL.md</location>
+<name>upskill-prompt-distilling</name>
+<description>Use BEFORE authoring any rule, skill, or subagent. Trigger when someone says "we should encode X", "the agent keeps forgetting Y", "let's add a rule for Z", or any variant where new behavior needs to live somewhere in the framework. Also trigger when reviewing existing content that is misbehaving — wrong-layer placement is a common silent root cause. Do NOT trigger for refining content already correctly placed; hand off to upskill-writing-rules, writing-skills, or upskill-writing-subagents.</description>
+<location>skills/upskill-prompt-distilling/SKILL.md</location>
 </skill>
 <skill>
-<name>using-upskill</name>
-<description>Use when working in an upskill-consumer repo and needing to add, modify, vendor, audit, or remove installed content (rules, skills, agents, bundles). Trigger when `upskill lint` or `upskill doctor` reports issues. Trigger when adding a third-party bundle or updating one from upstream. Trigger when generated per-client files (e.g., `.claude/`, `.github/skills/`) look stale or wrong. Do NOT trigger for actual authoring decisions — hand off to prompt-distilling, writing-rules, writing-skills, or writing-subagents. Do NOT trigger for cosmetic typo fixes in skill bodies; raw edits to source registry files plus `upskill lint` are sufficient.</description>
-<location>skills/using-upskill/SKILL.md</location>
+<name>upskill-using</name>
+<description>Use when working in an upskill-consumer repo and needing to add, modify, vendor, audit, or remove installed content (rules, skills, agents, bundles). Trigger when `upskill lint` or `upskill doctor` reports issues. Trigger when adding a third-party bundle or updating one from upstream. Trigger when generated per-client files (e.g., `.claude/`, `.github/skills/`) look stale or wrong. Do NOT trigger for actual authoring decisions — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, or upskill-writing-subagents. Do NOT trigger for cosmetic typo fixes in skill bodies; raw edits to source registry files plus `upskill lint` are sufficient.</description>
+<location>skills/upskill-using/SKILL.md</location>
 </skill>
 <skill>
-<name>writing-rules</name>
-<description>Use when adding or editing rules in CLAUDE.md, AGENTS.md, or any always-loaded instructions file. Trigger when authoring repo conventions, invariants, or behavioral guardrails. Also trigger when an existing rule is being violated despite being present — that means the rule needs refactoring, not the agent. Do NOT trigger for skill or subagent authoring; see writing-skills and writing-subagents.</description>
-<location>skills/writing-rules/SKILL.md</location>
+<name>upskill-writing-rules</name>
+<description>Use when adding or editing rules in CLAUDE.md, AGENTS.md, or any always-loaded instructions file. Trigger when authoring repo conventions, invariants, or behavioral guardrails. Also trigger when an existing rule is being violated despite being present — that means the rule needs refactoring, not the agent. Do NOT trigger for skill or subagent authoring; see writing-skills and upskill-writing-subagents.</description>
+<location>skills/upskill-writing-rules/SKILL.md</location>
 </skill>
 <skill>
-<name>writing-skill-bundles</name>
+<name>upskill-writing-bundles</name>
 <description>Use when authoring or editing upskill .bundle.yaml manifests — declaring items, plugins, requires dependencies, naming conventions, or troubleshooting bundle resolution errors. Also use when adding plugin install declarations for client CLIs (Claude Code, Copilot, VS Code, opencode).</description>
-<location>skills/writing-skill-bundles/SKILL.md</location>
+<location>skills/upskill-writing-bundles/SKILL.md</location>
 </skill>
 <skill>
-<name>writing-subagents</name>
-<description>Use when designing a new subagent or modifying an existing one's system prompt, tool surface, or return contract. Trigger when the parent is observed doing work inline that should be delegated, OR when a subagent is observed dumping raw output, OR when subagent scope is drifting. Also trigger when designing managed/project-scoped/user-global subagent tiers with different permission models. Do NOT trigger for skill or rule authoring; see writing-skills and writing-rules.</description>
-<location>skills/writing-subagents/SKILL.md</location>
+<name>upskill-writing-subagents</name>
+<description>Use when designing a new subagent or modifying an existing one's system prompt, tool surface, or return contract. Trigger when the parent is observed doing work inline that should be delegated, OR when a subagent is observed dumping raw output, OR when subagent scope is drifting. Also trigger when designing managed/project-scoped/user-global subagent tiers with different permission models. Do NOT trigger for skill or rule authoring; see writing-skills and upskill-writing-rules.</description>
+<location>skills/upskill-writing-subagents/SKILL.md</location>
 </skill>
 </available_skills>
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -83,6 +83,19 @@ than scanning it for a bundle.
 ([format-spec §2.2](./format-spec.md#22-bundle-files)) and is indifferent
 to which of these two sub-layouts the registry uses.
 
+## Item naming
+
+Item names are **namespace-prefixed** so they stay globally unique within
+each per-client flat directory (`.claude/skills/<name>/`, `.claude/rules/<name>.md`,
+etc.). Two items with the same `(kind, name)` would otherwise collide on disk
+when co-installed from different sources.
+
+Default to **repo/org scope** (`<org>-<descriptor>`); switch to **bundle
+scope** (`<bundle>-<descriptor>`) when one org ships multiple bundles that
+could reuse generic descriptors. This repo uses the `upskill-` prefix — e.g.
+`upskill-writing-rules`, `upskill-prompt-design`. See the
+`upskill-writing-bundles` skill for the full decision rule.
+
 ## Scaffolding under the convention
 
 ```bash

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,29 +12,29 @@ The directory follows the upskill conventional source-registry layout
 
 ```text
 skills/
-├── README.md                            (this file)
-├── NOTICE                               attribution for vendored methodology
-├── prompt-engineering.bundle.yaml       one-shot install of the discipline
-├── prompt-design/                      umbrella / orientation
+├── README.md                       (this file)
+├── NOTICE                          attribution for vendored methodology
+├── prompt-engineering.bundle.yaml  one-shot install of the discipline
+├── upskill-prompt-design/          umbrella / orientation
 │   └── SKILL.md
-├── prompt-distilling/                   decompose authoring intent + place across layers
+├── upskill-prompt-distilling/      decompose authoring intent + place across layers
 │   └── SKILL.md
-├── writing-rules/                       per-layer authoring methodology
+├── upskill-writing-rules/          per-layer authoring methodology
 │   └── SKILL.md
-├── writing-subagents/                   per-layer authoring methodology
+├── upskill-writing-subagents/      per-layer authoring methodology
 │   └── SKILL.md
-├── evaluating-prompts/                  RED-GREEN-REFACTOR cycle + scenario batteries
+├── upskill-evaluating-prompts/     RED-GREEN-REFACTOR cycle + scenario batteries
 │   └── SKILL.md
-├── writing-skill-bundles/               .bundle.yaml authoring + plugin declarations
+├── upskill-writing-bundles/        .bundle.yaml authoring + plugin declarations
 │   └── SKILL.md
-└── using-upskill/                       lifecycle operations
+└── upskill-using/                  lifecycle operations
     └── SKILL.md
 ```
 
 ## Status
 
-All skills are v0.1.0 except `prompt-distilling` (v0.3.0, renamed from
-`picking-the-layer`) and `using-upskill` (v0.2.0, rewritten against the
+All skills are v0.1.0 except `upskill-prompt-distilling` (v0.3.0, renamed from
+`picking-the-layer`) and `upskill-using` (v0.2.0, rewritten against the
 real CLI surface). None have yet been through their own
 RED-GREEN-REFACTOR cycle. Each carries an "Honest caveats" section
 flagging this.
@@ -93,15 +93,15 @@ To install one item without the rest of the bundle, point at the
 registry directory and pass the item name as a filter:
 
 ```bash
-upskill add ./skills prompt-design   # just the umbrella skill
+upskill add ./skills upskill-prompt-design   # just the umbrella skill
 ```
 
-See `using-upskill/SKILL.md` for the full lifecycle.
+See `upskill-using/SKILL.md` for the full lifecycle.
 
 ## Recommended adoption sequence
 
 1. Vendor `writing-skills` from superpowers.
-2. Run `evaluating-prompts`' methodology against `prompt-distilling`
+2. Run `upskill-evaluating-prompts`' methodology against `upskill-prompt-distilling`
    (most-activated skill) to validate the meta-skill methodology.
 3. Iterate based on findings.
 4. Roll out to pilot team(s).

--- a/skills/prompt-engineering.bundle.yaml
+++ b/skills/prompt-engineering.bundle.yaml
@@ -11,13 +11,13 @@ license: MIT
 # registry the bundle lives in.
 items:
   skills:
-    - prompt-design # umbrella entry point
-    - prompt-distilling # placement: intent → layer
-    - writing-rules # authoring: always-loaded invariants
-    - writing-subagents # authoring: bounded sub-task delegation
-    - evaluating-prompts # eval: RED-GREEN-REFACTOR
-    - using-upskill # ops: add / update / audit
-    - writing-skill-bundles # authoring: .bundle.yaml manifests + plugins
+    - upskill-prompt-design # umbrella entry point
+    - upskill-prompt-distilling # placement: intent → layer
+    - upskill-writing-rules # authoring: always-loaded invariants
+    - upskill-writing-subagents # authoring: bounded sub-task delegation
+    - upskill-evaluating-prompts # eval: RED-GREEN-REFACTOR
+    - upskill-using # ops: add / update / audit
+    - upskill-writing-bundles # authoring: .bundle.yaml manifests + plugins
 
 # Client-native plugins required by this bundle's skills.
 plugins:

--- a/skills/upskill-evaluating-prompts/SKILL.md
+++ b/skills/upskill-evaluating-prompts/SKILL.md
@@ -1,7 +1,7 @@
 ---
 schema: 1
-name: evaluating-prompts
-description: Use when setting up the RED-GREEN-REFACTOR cycle for a rule, skill, or subagent — i.e., when the `writing-*` skills tell you to "run a failing test first." Trigger when authoring meta-skills, when validating that an existing rule/skill/subagent actually shapes behavior, or when auditing whether a skill activates correctly. Do NOT trigger for content authoring itself — see writing-rules, writing-skills, writing-subagents.
+name: upskill-evaluating-prompts
+description: Use when setting up the RED-GREEN-REFACTOR cycle for a rule, skill, or subagent — i.e., when the `writing-*` skills tell you to "run a failing test first." Trigger when authoring meta-skills, when validating that an existing rule/skill/subagent actually shapes behavior, or when auditing whether a skill activates correctly. Do NOT trigger for content authoring itself — see upskill-writing-rules, writing-skills, upskill-writing-subagents.
 metadata:
   version: 0.1.0
   author: driftsys
@@ -9,7 +9,7 @@ metadata:
 
 The `writing-*` skills tell you to run a failing test before authoring.
 This skill explains how. It is the eval methodology underneath the
-Iron Laws of writing-rules, writing-skills, and writing-subagents.
+Iron Laws of upskill-writing-rules, writing-skills, and upskill-writing-subagents.
 
 If you are about to author content and the writing-* skill says "RED
 phase: run pressure scenarios" — this is where you find out how to
@@ -95,7 +95,7 @@ The scenario battery shape depends on which layer you are evaluating.
 
 ### Rules — three scenario types
 
-Per `writing-rules`:
+Per `upskill-writing-rules`:
 
 1. **In-scope compliance** — a prompt where the rule should govern.
    RED: does the agent violate without the rule? GREEN: does it
@@ -126,7 +126,7 @@ one that does not activate. Both halves matter.
 
 ### Subagents — two interfaces, separately
 
-Per `writing-subagents`, subagents have two failure surfaces. Test
+Per `upskill-writing-subagents`, subagents have two failure surfaces. Test
 each independently.
 
 1. **Invocation tests** (run on the parent, subagent registered)
@@ -250,7 +250,7 @@ layer. Symptoms:
   skill the parent should load inline.
 
 When this pattern emerges, stop iterating on the prompt and hand off
-to `prompt-distilling` for a fresh layer placement.
+to `upskill-prompt-distilling` for a fresh layer placement.
 
 ## Scenario batteries as artifacts
 
@@ -258,7 +258,7 @@ The scenario battery is reusable. Keep it as a file alongside the
 prompt:
 
 ```text
-skills/writing-rules/
+skills/upskill-writing-rules/
 ├── SKILL.md
 ├── eval/
 │   ├── scenarios.md           # battery (curated, versioned)
@@ -296,7 +296,7 @@ skill.
 
 Each writing-* skill specifies the scenario shape for its layer
 (three scenarios for rules, activation+behavior for skills, two
-interfaces for subagents). `evaluating-prompts` provides the methodology
+interfaces for subagents). `upskill-evaluating-prompts` provides the methodology
 underneath those shapes — harness construction, pressure types,
 rationalization tracking, pass/fail discipline.
 
@@ -315,8 +315,8 @@ methodology has.
 
 This skill has not yet been put through its own RED-GREEN-REFACTOR
 cycle. The most natural way to evaluate it is to use it to evaluate
-the existing meta-skills (`writing-rules`, `writing-subagents`,
-`using-upskill`) — if the methodology produces actionable results
+the existing meta-skills (`upskill-writing-rules`, `upskill-writing-subagents`,
+`upskill-using`) — if the methodology produces actionable results
 when applied to those four, this skill earns its slot. If authors
 end up evaluating prompts the same way regardless of whether this
 skill is present, the skill itself is unjustified.

--- a/skills/upskill-prompt-design/SKILL.md
+++ b/skills/upskill-prompt-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 schema: 1
-name: prompt-design
-description: Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to prompt-distilling, writing-rules, writing-skills, writing-subagents, or using-upskill.
+name: upskill-prompt-design
+description: Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, upskill-writing-subagents, or upskill-using.
 metadata:
   version: 0.1.0
   author: driftsys
@@ -22,9 +22,9 @@ Five layers carry durable agent behavior. Three are managed by upskill:
 
 | Layer          | What it is                                                                | Authored via                               |
 | -------------- | ------------------------------------------------------------------------- | ------------------------------------------ |
-| **Rule**       | A line in CLAUDE.md / AGENTS.md, loaded every turn                        | `writing-rules`                            |
+| **Rule**       | A line in CLAUDE.md / AGENTS.md, loaded every turn                        | `upskill-writing-rules`                    |
 | **Skill**      | A markdown procedure activated on demand by description matching          | `superpowers:writing-skills`               |
-| **Subagent**   | A bounded sub-task with its own system prompt, tools, and return contract | `writing-subagents`                        |
+| **Subagent**   | A bounded sub-task with its own system prompt, tools, and return contract | `upskill-writing-subagents`                |
 | **MCP tool**   | Live capability exposed by an on-prem server                              | Separate MCP server repo authoring process |
 | **RAG corpus** | Searchable static content fronted by an MCP search tool                   | The corpus's MCP tool authoring process    |
 
@@ -36,12 +36,12 @@ processes.
 
 | Situation                                                                  | Activate                                                 |
 | -------------------------------------------------------------------------- | -------------------------------------------------------- |
-| "I want to add a convention / encode behavior / shape what the agent does" | `prompt-distilling`                                      |
-| "I know it's a rule, how do I write it well"                               | `writing-rules`                                          |
+| "I want to add a convention / encode behavior / shape what the agent does" | `upskill-prompt-distilling`                              |
+| "I know it's a rule, how do I write it well"                               | `upskill-writing-rules`                                  |
 | "I know it's a skill, how do I write it well"                              | `superpowers:writing-skills`                             |
-| "I know it's a subagent, how do I write it well"                           | `writing-subagents`                                      |
-| "I need to run upskill commands / vendor a bundle / audit content"         | `using-upskill`                                          |
-| "I need to set up the RED-GREEN-REFACTOR cycle for something I authored"   | `evaluating-prompts`                                     |
+| "I know it's a subagent, how do I write it well"                           | `upskill-writing-subagents`                              |
+| "I need to run upskill commands / vendor a bundle / audit content"         | `upskill-using`                                          |
+| "I need to set up the RED-GREEN-REFACTOR cycle for something I authored"   | `upskill-evaluating-prompts`                             |
 | "I want to write an MCP server"                                            | `mcp-builder` (vendored) — out of upskill's direct scope |
 | "I want to write good one-shot prompts to send to Claude Code"             | Not this framework — see onboarding doc                  |
 
@@ -95,12 +95,12 @@ invocation overhead plus return payload. MCP tool definitions are paid
 every turn (the schemas, not the responses). Description quality is the
 dominant cost variable for skills, not body length — a vague
 description silently fails to activate, which is worse than no skill
-at all. `writing-rules` carries the full token-budget discipline.
+at all. `upskill-writing-rules` carries the full token-budget discipline.
 
 ### Composition patterns
 
 Most authoring intents span multiple layers (rule + skill, skill +
-MCP tool, subagent + skill, and so on). `prompt-distilling`
+MCP tool, subagent + skill, and so on). `upskill-prompt-distilling`
 enumerates the recurring patterns and handles the decomposition. If
 your intent fits one, route to every relevant writing-\* skill, not
 just one.
@@ -115,7 +115,7 @@ prompt survives realistic pressure). Prompts that have not been
 pressure-tested look identical on the page to ones that have, and
 fail silently in production. The evaluation discipline is what
 distinguishes durable agent content from wishful thinking;
-`evaluating-prompts` covers the methodology in detail.
+`upskill-evaluating-prompts` covers the methodology in detail.
 
 ## The lifecycle in one paragraph
 
@@ -126,7 +126,7 @@ per-client files in the consumer project at install time.
 registries; `upskill doctor` verifies installed state against
 `.upskill-lock.json`. Generated per-client files are never hand-edited
 — drift is silent. Vendored bundles (like `superpowers`) carry NOTICE
-files and attribution. `using-upskill` covers the workflows.
+files and attribution. `upskill-using` covers the workflows.
 
 ## Symptoms that suggest framework-level problems
 
@@ -135,19 +135,19 @@ diagnosis:
 
 - "The agent keeps doing X even though we have a rule against it" →
   rule under-firing or being rationalized. Activate
-  `evaluating-prompts` for diagnosis, then `writing-rules` for
+  `upskill-evaluating-prompts` for diagnosis, then `upskill-writing-rules` for
   revision.
 - "We have a skill for that but nobody uses it" → description not
   activating. Activate `superpowers:writing-skills` or hand off via
-  `prompt-distilling` (the skill may be in the wrong layer).
+  `upskill-prompt-distilling` (the skill may be in the wrong layer).
 - "The subagent's output is bigger than what the parent would have
-  done inline" → return-contract failure. Activate `writing-subagents`.
+  done inline" → return-contract failure. Activate `upskill-writing-subagents`.
 - "We added a rule and now every interaction feels slower" → token
-  budget exceeded. Activate `using-upskill` (`doctor`) and
-  `prompt-distilling` (the content may not deserve to be a rule).
+  budget exceeded. Activate `upskill-using` (`doctor`) and
+  `upskill-prompt-distilling` (the content may not deserve to be a rule).
 - "Different teams handle the same situation differently" →
   cross-cutting convention without a home. Route via
-  `prompt-distilling`.
+  `upskill-prompt-distilling`.
 
 ## Composition with onboarding
 

--- a/skills/upskill-prompt-distilling/SKILL.md
+++ b/skills/upskill-prompt-distilling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 schema: 1
-name: prompt-distilling
-description: Use BEFORE authoring any rule, skill, or subagent. Trigger when someone says "we should encode X", "the agent keeps forgetting Y", "let's add a rule for Z", or any variant where new behavior needs to live somewhere in the framework. Also trigger when reviewing existing content that is misbehaving — wrong-layer placement is a common silent root cause. Do NOT trigger for refining content already correctly placed; hand off to writing-rules, writing-skills, or writing-subagents.
+name: upskill-prompt-distilling
+description: Use BEFORE authoring any rule, skill, or subagent. Trigger when someone says "we should encode X", "the agent keeps forgetting Y", "let's add a rule for Z", or any variant where new behavior needs to live somewhere in the framework. Also trigger when reviewing existing content that is misbehaving — wrong-layer placement is a common silent root cause. Do NOT trigger for refining content already correctly placed; hand off to upskill-writing-rules, writing-skills, or upskill-writing-subagents.
 metadata:
   version: 0.3.0
   author: driftsys
@@ -237,9 +237,9 @@ re-distillation, not content editing.
 
 Once distilled and placed, hand off:
 
-- Rule → `writing-rules`
+- Rule → `upskill-writing-rules`
 - Skill → `superpowers:writing-skills`
-- Subagent → `writing-subagents`
+- Subagent → `upskill-writing-subagents`
 - MCP tool → the MCP server repo's authoring process (out of scope here)
 - RAG corpus → the corpus that the relevant `search_*` MCP tool fronts
   (out of scope here)

--- a/skills/upskill-using/SKILL.md
+++ b/skills/upskill-using/SKILL.md
@@ -1,7 +1,7 @@
 ---
 schema: 1
-name: using-upskill
-description: Use when working in an upskill-consumer repo and needing to add, modify, vendor, audit, or remove installed content (rules, skills, agents, bundles). Trigger when `upskill lint` or `upskill doctor` reports issues. Trigger when adding a third-party bundle or updating one from upstream. Trigger when generated per-client files (e.g., `.claude/`, `.github/skills/`) look stale or wrong. Do NOT trigger for actual authoring decisions — hand off to prompt-distilling, writing-rules, writing-skills, or writing-subagents. Do NOT trigger for cosmetic typo fixes in skill bodies; raw edits to source registry files plus `upskill lint` are sufficient.
+name: upskill-using
+description: Use when working in an upskill-consumer repo and needing to add, modify, vendor, audit, or remove installed content (rules, skills, agents, bundles). Trigger when `upskill lint` or `upskill doctor` reports issues. Trigger when adding a third-party bundle or updating one from upstream. Trigger when generated per-client files (e.g., `.claude/`, `.github/skills/`) look stale or wrong. Do NOT trigger for actual authoring decisions — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, or upskill-writing-subagents. Do NOT trigger for cosmetic typo fixes in skill bodies; raw edits to source registry files plus `upskill lint` are sufficient.
 metadata:
   version: 0.2.0
   author: driftsys
@@ -10,7 +10,7 @@ metadata:
 upskill manages the lifecycle of installable agent content. It does not make
 authoring decisions for you. This skill covers operations: add, update,
 remove, list, doctor, lint, fmt, new. For authoring decisions (where does
-this go, how do I write it), hand off to `prompt-distilling` and the
+this go, how do I write it), hand off to `upskill-prompt-distilling` and the
 writing-* skills.
 
 ## Two sides of the workflow
@@ -41,13 +41,13 @@ SKILLS FOR AUTHORING DECISIONS.
 
 This Iron Law is a routing law, not a discipline law (no "NO X
 WITHOUT Y FIRST" shape like the other meta-skills), because
-`using-upskill` governs which tool to reach for, not whether to
+`upskill-using` governs which tool to reach for, not whether to
 pressure-test content before shipping it.
 
 The boundary is sharp. upskill handles fetching, frontmatter
 canonicalization, per-client generation, validation, and lockfile tracking.
 It does not decide whether a piece of content should be a rule, skill, or
-agent — that is `prompt-distilling`'s job. Mixing these concerns is the most
+agent — that is `upskill-prompt-distilling`'s job. Mixing these concerns is the most
 common usage error.
 
 ## When to use upskill vs raw edits
@@ -70,7 +70,7 @@ on content you authored and understand, and always lint after.
 
 ### Authoring a new skill in a source registry
 
-1. Run `prompt-distilling` first to confirm the content belongs in a skill
+1. Run `upskill-prompt-distilling` first to confirm the content belongs in a skill
    (not a rule, agent, or MCP tool).
 2. Hand off to `superpowers:writing-skills` to draft the SKILL.md.
 3. From inside the registry's `skills/` directory, run
@@ -144,7 +144,7 @@ alongside the install.
    `upskill update`).
 3. If `doctor` surfaces a content-shape concern (vague description,
    oversized rule), the fix lives in the source registry — hand off to
-   `prompt-distilling`'s audit section there.
+   `upskill-prompt-distilling`'s audit section there.
 
 ## Interpreting upskill output
 
@@ -226,15 +226,15 @@ this skill does not assume one exists.
 
 | Situation                                              | Hand off to                                              |
 | ------------------------------------------------------ | -------------------------------------------------------- |
-| Newcomer to the framework needing orientation          | `prompt-design`                                          |
-| Deciding where new content belongs                     | `prompt-distilling`                                      |
-| Authoring a new rule                                   | `writing-rules`                                          |
+| Newcomer to the framework needing orientation          | `upskill-prompt-design`                                  |
+| Deciding where new content belongs                     | `upskill-prompt-distilling`                              |
+| Authoring a new rule                                   | `upskill-writing-rules`                                  |
 | Authoring a new skill                                  | `superpowers:writing-skills`                             |
-| Authoring a new subagent / agent                       | `writing-subagents`                                      |
-| Setting up RED-GREEN-REFACTOR for any authored content | `evaluating-prompts`                                     |
+| Authoring a new subagent / agent                       | `upskill-writing-subagents`                              |
+| Setting up RED-GREEN-REFACTOR for any authored content | `upskill-evaluating-prompts`                             |
 | Authoring a new MCP server                             | the MCP server repo's authoring process (out of scope)   |
 | Adding to a RAG corpus                                 | the corpus's MCP tool's authoring process (out of scope) |
-| Routing decision on existing content showing drift     | `prompt-distilling` audit section                        |
+| Routing decision on existing content showing drift     | `upskill-prompt-distilling` audit section                |
 
 ## Red flags — STOP
 

--- a/skills/upskill-writing-bundles/SKILL.md
+++ b/skills/upskill-writing-bundles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 schema: 1
-name: writing-skill-bundles
+name: upskill-writing-bundles
 description: Use when authoring or editing upskill .bundle.yaml manifests — declaring items, plugins, requires dependencies, naming conventions, or troubleshooting bundle resolution errors. Also use when adding plugin install declarations for client CLIs (Claude Code, Copilot, VS Code, opencode).
 metadata:
   version: 0.1.0
@@ -23,9 +23,9 @@ dependencies.
 ## When NOT to Use
 
 - Authoring individual skill content → `writing-skills`
-- Authoring rules → `writing-rules`
-- Authoring subagents → `writing-subagents`
-- Lifecycle operations (add/update/remove) → `using-upskill`
+- Authoring rules → `upskill-writing-rules`
+- Authoring subagents → `upskill-writing-subagents`
+- Lifecycle operations (add/update/remove) → `upskill-using`
 
 ## Bundle YAML Schema
 
@@ -82,7 +82,32 @@ metadata: # optional — freeform
 
 **Name collision prevention:** If your bundle is called `prompt-engineering`,
 don't have a skill directory also called `prompt-engineering/`. Use a
-distinct name for one of them (e.g., rename the skill to `prompt-design`).
+distinct name for one of them (e.g., rename the skill to `upskill-prompt-design`).
+
+### Choosing the namespace prefix
+
+Every item name (skill, rule, agent) shares one flat per-client directory
+per kind, so two items with the same `(kind, name)` collide on disk when
+co-installed from different sources. Prefix every item name with a
+**namespace** to keep it globally unique. Pick the scope by how the content
+is distributed:
+
+| Scope        | Prefix form             | Use when                                                                                                                                                      |
+| ------------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Repo/org** | `<org>-<descriptor>`    | The repo ships one cohesive suite of first-party content. Shortest; reads as provenance.                                                                      |
+| **Bundle**   | `<bundle>-<descriptor>` | One repo/org ships **multiple** bundles that could reuse generic descriptors (`using`, `evaluating`). The bundle is the collision unit — strongest guarantee. |
+
+Rules of thumb:
+
+- **Default to repo/org scope** — it is shorter and signals who ships the
+  content. This repo uses the `upskill-` prefix (e.g. `upskill-writing-rules`).
+- The namespace token SHOULD be short (≤ 10 characters) and stable. Prefer the
+  project name over a long topic name (`upskill-`, not `prompt-engineering-`).
+- Co-located entrypoints keep one prefixed base name and differ only by kind
+  (`upskill-writing-rules` skill + rule) — the resolver allows same `name`
+  across different kinds.
+- Pre-1.0, if a second bundle later collides on a descriptor, just rename one.
+  No migration path needed.
 
 ## Plugin Declarations
 

--- a/skills/upskill-writing-rules/SKILL.md
+++ b/skills/upskill-writing-rules/SKILL.md
@@ -1,7 +1,7 @@
 ---
 schema: 1
-name: writing-rules
-description: Use when adding or editing rules in CLAUDE.md, AGENTS.md, or any always-loaded instructions file. Trigger when authoring repo conventions, invariants, or behavioral guardrails. Also trigger when an existing rule is being violated despite being present — that means the rule needs refactoring, not the agent. Do NOT trigger for skill or subagent authoring; see writing-skills and writing-subagents.
+name: upskill-writing-rules
+description: Use when adding or editing rules in CLAUDE.md, AGENTS.md, or any always-loaded instructions file. Trigger when authoring repo conventions, invariants, or behavioral guardrails. Also trigger when an existing rule is being violated despite being present — that means the rule needs refactoring, not the agent. Do NOT trigger for skill or subagent authoring; see writing-skills and upskill-writing-subagents.
 metadata:
   version: 0.1.0
   author: driftsys
@@ -10,7 +10,7 @@ metadata:
 A rule is a line that costs tokens on every turn in exchange for shaping
 behavior across the whole scope. If you cannot justify the per-turn cost,
 it is a skill, not a rule. Confirm the routing decision via
-`prompt-distilling` before continuing here.
+`upskill-prompt-distilling` before continuing here.
 
 ## The Iron Law
 
@@ -51,7 +51,7 @@ Rules need three test scenarios, not one. Run each with a subagent.
    team merges without this check"). Does the agent rationalize?
 
 Document every rationalization verbatim. Those become your counters in
-the GREEN phase. `evaluating-prompts` covers harness construction,
+the GREEN phase. `upskill-evaluating-prompts` covers harness construction,
 pressure typology, and rationalization tracking — activate it before
 running the scenarios.
 
@@ -116,7 +116,7 @@ rule layer.
 ## Composition with other layers
 
 - A rule states an invariant. The skill explaining the procedure that
-  respects that invariant goes alongside it. Pair `writing-rules` work
+  respects that invariant goes alongside it. Pair `upskill-writing-rules` work
   with `superpowers:writing-skills` when both apply.
 - A rule cannot describe live state. If the invariant references "today's
   classification policy" or "the current owner of repo X", the live part

--- a/skills/upskill-writing-subagents/SKILL.md
+++ b/skills/upskill-writing-subagents/SKILL.md
@@ -1,7 +1,7 @@
 ---
 schema: 1
-name: writing-subagents
-description: Use when designing a new subagent or modifying an existing one's system prompt, tool surface, or return contract. Trigger when the parent is observed doing work inline that should be delegated, OR when a subagent is observed dumping raw output, OR when subagent scope is drifting. Also trigger when designing managed/project-scoped/user-global subagent tiers with different permission models. Do NOT trigger for skill or rule authoring; see writing-skills and writing-rules.
+name: upskill-writing-subagents
+description: Use when designing a new subagent or modifying an existing one's system prompt, tool surface, or return contract. Trigger when the parent is observed doing work inline that should be delegated, OR when a subagent is observed dumping raw output, OR when subagent scope is drifting. Also trigger when designing managed/project-scoped/user-global subagent tiers with different permission models. Do NOT trigger for skill or rule authoring; see writing-skills and upskill-writing-rules.
 metadata:
   version: 0.1.0
   author: driftsys
@@ -11,7 +11,7 @@ A subagent earns its overhead only if it (a) does bounded work and
 (b) returns a digest small enough that the parent's context is cleaner
 than if the parent had done the work inline. If either fails, you have
 a tool call dressed up as a subagent. Confirm the routing decision via
-`prompt-distilling` before continuing here.
+`upskill-prompt-distilling` before continuing here.
 
 ## The two interfaces
 
@@ -20,7 +20,9 @@ must be tested.
 
 1. **Invocation interface** — the name, description, and tool
    advertisement that the parent sees. This determines whether the
-   parent decides to call the subagent.
+   parent decides to call the subagent. Namespace-prefix the name so it
+   does not collide in the flat per-client agents directory (see
+   `upskill-writing-bundles` → "Choosing the namespace prefix").
 2. **Return interface** — what the subagent emits when it finishes.
    This determines whether the parent's context stays clean after
    invocation.
@@ -158,7 +160,7 @@ The three tiers each carry additional design requirements:
 ## Composition with other layers
 
 - A subagent often loads skills inside its own context. Pair
-  `writing-subagents` work with `superpowers:writing-skills` when the
+  `upskill-writing-subagents` work with `superpowers:writing-skills` when the
   subagent has a non-trivial procedure.
 - A subagent that needs live data uses MCP tools — those go through
   the MCP server authoring process, not here.


### PR DESCRIPTION
## Why

Item names share one **flat per-client directory per kind** (`.claude/skills/<name>/`, `.claude/rules/<name>.md`, `.claude/agents/<name>.md`). Two items with the same `(kind, name)` collide on disk when co-installed from different sources — and nothing catches it at generation time. Generic names like `writing-rules` are especially exposed.

This adopts a **namespace prefix** convention to keep item names globally unique, and documents the rule so future content follows it.

## What

**Renamed all 7 `prompt-engineering` skills with the `upskill-` (repo/org) prefix:**

| Old | New |
| --- | --- |
| `prompt-design` | `upskill-prompt-design` |
| `prompt-distilling` | `upskill-prompt-distilling` |
| `writing-rules` | `upskill-writing-rules` |
| `writing-subagents` | `upskill-writing-subagents` |
| `writing-skill-bundles` | `upskill-writing-bundles` |
| `evaluating-prompts` | `upskill-evaluating-prompts` |
| `using-upskill` | `upskill-using` |

**Documented the convention (single source of truth + mirror):**

- New **"Choosing the namespace prefix"** section in `upskill-writing-bundles/SKILL.md` — repo/org vs bundle scope decision table and rules of thumb.
- Mirror **"Item naming"** section in `docs/conventions.md` pointing at the skill.
- One pointer from `upskill-writing-subagents` (where it discusses the invocation name).
- Updated the `AGENTS.md` skill catalog, `README.md` tree, and bundle `items:` list to match.

**Deliberately preserved:** superpowers' `writing-skills` (plural) references in shared "hand off to…" lists. **Left untouched:** `CHANGELOG.md` and `docs/superpowers/specs/*` (historical records; CHANGELOG is generated from commits at release).

## Verification

- `upskill lint skills --strict` → 8 files, **0 findings**
- Bundle install into a clean repo → **all 7 prefixed skills resolve** across claude/copilot/opencode
- `just lint` (fmt, dprint, markdownlint, shellcheck, clippy) + `just test` → all green
- `just verify` ran on push → passed

## Notes

`upskill add` already exposes `--as original=alias` — the consumer-side collision escape hatch that complements this author-side prefix convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
