### PR TITLE
feat: upskill fmt formats the source body

### DIFF
--- a/docs/adr/0004-cli-surface.md
+++ b/docs/adr/0004-cli-surface.md
@@ -79,11 +79,15 @@ separate `validate` command. Lint scope is deliberately small (schema +
 structural markdown checks; cross-file consistency); content-quality
 review is delegated to AI workflows outside upskill.
 
-### `fmt` is frontmatter only
+### `fmt` canonicalises frontmatter and body
 
 `upskill fmt` canonicalises YAML frontmatter (key ordering, version
-quoting, indentation). Markdown body formatting is dprint's job. The two
-tools don't overlap.
+quoting, indentation) and formats the markdown body through the same
+dprint pass the generation pipeline uses. `upskill lint` reports a
+`body-format` warning when a body is not canonical, so the check/fix pair
+stays symmetric and CI (`lint --strict`) fails on unformatted source.
+(This supersedes the original "frontmatter only" decision: leaving bodies
+unchecked let authored source drift out of canonical form.)
 
 ### Default scope: `--project`, fall back to `--global`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,19 +4,19 @@
 (run inside a project that consumes AI-assistance content) and
 **author** (run inside a source-registry repo).
 
-| Command      | Role     | Purpose                                             |
-| ------------ | -------- | --------------------------------------------------- |
-| `add`        | Consumer | Install content from any source.                    |
-| `remove`     | Consumer | Remove installed content.                           |
-| `remove-mcp` | Consumer | Unregister an MCP server configured by a bundle.    |
-| `update`     | Consumer | Pull latest, regenerate changed items.              |
-| `list`       | Consumer | Show installed content from the lock file.          |
-| `doctor`     | Consumer | Verify installation consistency.                    |
-| `search`     | Consumer | Look up skills via the public registry.             |
-| `index`      | Consumer | Build or manage the local registry index cache.     |
-| `new`        | Author   | Scaffold a new rule, skill, or agent.               |
-| `lint`       | Author   | Validate SSOT files against the format spec.        |
-| `fmt`        | Author   | Canonicalise YAML frontmatter (key order, quoting). |
+| Command      | Role     | Purpose                                                     |
+| ------------ | -------- | ----------------------------------------------------------- |
+| `add`        | Consumer | Install content from any source.                            |
+| `remove`     | Consumer | Remove installed content.                                   |
+| `remove-mcp` | Consumer | Unregister an MCP server configured by a bundle.            |
+| `update`     | Consumer | Pull latest, regenerate changed items.                      |
+| `list`       | Consumer | Show installed content from the lock file.                  |
+| `doctor`     | Consumer | Verify installation consistency.                            |
+| `search`     | Consumer | Look up skills via the public registry.                     |
+| `index`      | Consumer | Build or manage the local registry index cache.             |
+| `new`        | Author   | Scaffold a new rule, skill, or agent.                       |
+| `lint`       | Author   | Validate SSOT files against the format spec.                |
+| `fmt`        | Author   | Canonicalise YAML frontmatter and format the markdown body. |
 
 ## Global flags
 
@@ -319,6 +319,7 @@ rules ship out of the box:
 | `name-matches-dir` | error    | format-spec §2.1 |
 | `body-h1`          | warning  | format-spec §5.1 |
 | `fence-lang`       | warning  | format-spec §5.2 |
+| `body-format`      | warning  | format-spec §3.8 |
 | `directive`        | error    | format-spec §6.3 |
 
 ```bash
@@ -330,16 +331,17 @@ upskill lint --strict       # CI mode: warnings become errors
 ### `upskill fmt [paths...]`
 
 Canonicalise YAML frontmatter (key order, indentation, alphabetised
-unknown keys). Markdown body formatting is left to dprint — the two
-tools don't overlap.
+unknown keys) and format the markdown body via dprint (the same formatter
+the generation pipeline uses). The frontmatter↔body seam is normalised to
+a single blank line; YAML comments and prose wrapping are preserved.
 
 ```bash
 upskill fmt                  # format everything in the working tree
 upskill fmt my-skill/        # format a single item directory
 ```
 
-Files whose frontmatter is already canonical are left untouched (no
-`mtime` thrash).
+Files whose frontmatter and body are already canonical are left untouched
+(no `mtime` thrash).
 
 ## State files
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -823,8 +823,11 @@ solving.
 ### 3.8 Frontmatter canonicalisation
 
 An implementation MAY provide a formatting command (e.g., `upskill fmt`) that canonicalises SSOT
-frontmatter. Canonicalisation produces a deterministic key order, making diffs predictable and
-reducing merge conflicts.
+frontmatter and the markdown body. Frontmatter canonicalisation produces a deterministic key
+order, making diffs predictable and reducing merge conflicts. Body canonicalisation applies the
+same markdown formatter used for generated output (§7.4) and normalises the frontmatter↔body seam
+to a single blank line, so authored source matches generated output. A linter MAY report a
+`body-format` finding when a body is not canonical.
 
 **Canonical key order.** When canonicalising frontmatter, implementations MUST emit keys in the
 following order (unlisted keys appear at the end in their original relative order):

--- a/docs/superpowers/plans/2026-06-04-fmt-format-body.md
+++ b/docs/superpowers/plans/2026-06-04-fmt-format-body.md
@@ -1,0 +1,860 @@
+# `upskill fmt` formats the source body — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `upskill fmt` canonicalize the markdown body of item files via the shared dprint pass (in addition to reordering YAML keys), and make `upskill lint` flag a non-canonical body with a new `body-format` warning.
+
+**Architecture:** A single shared helper `fmt::canonical_body(frontmatter, body)` formats the combined `---\n{yaml}---\n{body}` string with `generate::format::format_markdown` (dprint treats the `---…---` block as opaque frontmatter — YAML content, comments, key order, and wrapping are preserved byte-for-byte; only the body is formatted and the seam is normalized to one blank line) and strips the frontmatter prefix back off, returning the canonical body region including its leading blank-line separator. `fmt` uses it to write; `lint` uses it to detect drift — so checker and fixer can never disagree. Bundles are pure YAML with no body and are unaffected.
+
+**Tech Stack:** Rust (edition 2024), `dprint-plugin-markdown` `=0.21.1`, `anyhow`, `serde_yaml_ng`; integration tests with `assert_cmd` + `tempfile`.
+
+**Reference spec:** [docs/superpowers/specs/2026-06-04-fmt-format-body-design.md](../specs/2026-06-04-fmt-format-body-design.md)
+
+---
+
+## Pre-flight (already verified during design — do not re-investigate)
+
+- `generate::assemble` does `body.trim_start_matches('\n')` then `---\n{fm}---\n\n{body}`. Feeding the combined string to `format_markdown` preserves the frontmatter region byte-for-byte and normalizes the seam to exactly one blank line.
+- dprint default config: `*` bullets → `-`, collapses multiple blank lines, strips a leading blank line from an isolated body.
+- All four fixture item bodies in `tests/fixtures/items/` are **already dprint-clean**, so `lint_clean_fixture_corpus_exits_zero` will keep passing.
+- The existing `body-h1` and `fence-lang` ATDD fixtures in `tests/cli_lint.rs` are already dprint-clean, so they will not gain a `body-format` finding.
+- `crate::generate::format::format_markdown` is already `pub` — no visibility change needed.
+
+---
+
+## File Structure
+
+- `src/fmt.rs` — add `pub(crate) fn canonical_body`, call it from `canonicalise_item`, update module doc. Unit tests in the same file's `#[cfg(test)] mod tests`.
+- `src/lint.rs` — add `fn check_body_format`, wire it into `check_file`, add the rule-table row in the module header. Unit tests in the same file.
+- `tests/cli_fmt.rs` — add one ATDD test; update the file header doc comment.
+- `tests/cli_lint.rs` — add ATDD tests for the warning and `--strict` promotion.
+- `docs/adr/0004-cli-surface.md` — replace the "`fmt` is frontmatter only" section.
+- `docs/commands.md` — update the `fmt` description, the `fmt` section prose, and the lint rule table.
+- `docs/format-spec.md` — note body canonicalisation in §3.8.
+
+---
+
+## Task 1: `fmt::canonical_body` helper + `canonicalise_item`
+
+**Files:**
+
+- Modify: `src/fmt.rs` (function `canonicalise_item`; add `canonical_body`; replace one unit test)
+- Test: `src/fmt.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Replace the now-wrong unit test with a failing one**
+
+In `src/fmt.rs`, find the existing test `canonicalise_preserves_body_byte_for_byte` (it asserts the body is untouched — that contract is being removed) and replace the entire test function with:
+
+```rust
+#[test]
+fn canonicalise_formats_body() {
+    // `*` bullets become `-`, extra blank lines collapse, and the
+    // single blank-line separator after the frontmatter is kept.
+    let raw = concat!(
+        "---\n",
+        "schema: 1\n",
+        "name: dirty\n",
+        "description: body needs formatting.\n",
+        "---\n",
+        "\n",
+        "## Body\n",
+        "\n",
+        "\n",
+        "* one\n",
+        "* two\n",
+    );
+    let out = canonicalise(raw, Path::new("dirty/SKILL.md")).unwrap();
+    assert!(
+        out.ends_with("---\n\n## Body\n\n- one\n- two\n"),
+        "body not formatted canonically:\n{out}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib fmt::tests::canonicalise_formats_body`
+Expected: FAIL — the current `canonicalise_item` returns the body verbatim, so `out` ends with `* one\n* two\n`.
+
+- [ ] **Step 3: Add the `canonical_body` helper**
+
+In `src/fmt.rs`, immediately after the `canonicalise_item` function, add:
+
+```rust
+/// Canonical body region for an item file, given its on-disk
+/// frontmatter string and body. Formats via dprint the same way the
+/// generation pipeline does: dprint treats `---…---` as opaque
+/// frontmatter, so the YAML (content, comments, key order, wrapping) is
+/// preserved byte-for-byte and only the body is formatted, with the seam
+/// normalised to a single blank line. Returns the region after the
+/// closing `---`, including that leading blank-line separator. Empty when
+/// the body is blank. Used by both `fmt` (to write) and `lint::check_body_format`
+/// (to detect drift) so checker and fixer never disagree.
+pub(crate) fn canonical_body(frontmatter: &str, body: &str) -> Result<String> {
+    if body.trim().is_empty() {
+        return Ok(String::new());
+    }
+    let prefix = format!("---\n{frontmatter}---\n");
+    let combined = format!("{prefix}{body}");
+    let formatted =
+        crate::generate::format::format_markdown(&combined).context("format item body")?;
+    formatted
+        .strip_prefix(&prefix)
+        .map(|region| region.to_string())
+        .ok_or_else(|| anyhow!("dprint altered the frontmatter region while formatting the body"))
+}
+```
+
+- [ ] **Step 4: Call the helper from `canonicalise_item`**
+
+In `src/fmt.rs`, change the body of `canonicalise_item`. Replace this exact block:
+
+```rust
+    let reordered_yaml = reorder_yaml_keys(yaml_str, key_order);
+
+    // Validate the reordered YAML parses correctly.
+    serde_yaml_ng::from_str::<T>(&reordered_yaml)
+        .with_context(|| format!("validate frontmatter {}", path.display()))?;
+
+    Ok(format!("---\n{reordered_yaml}---\n{body}"))
+```
+
+with:
+
+```rust
+    let reordered_yaml = reorder_yaml_keys(yaml_str, key_order);
+
+    // Validate the reordered YAML parses correctly.
+    serde_yaml_ng::from_str::<T>(&reordered_yaml)
+        .with_context(|| format!("validate frontmatter {}", path.display()))?;
+
+    let body_region = canonical_body(&reordered_yaml, body)
+        .with_context(|| format!("format body {}", path.display()))?;
+
+    Ok(format!("---\n{reordered_yaml}---\n{body_region}"))
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test --lib fmt::tests::canonicalise_formats_body`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole fmt unit test module to catch regressions**
+
+Run: `cargo test --lib fmt::tests`
+Expected: PASS. (The existing `canonicalise_is_idempotent` and comment/wrapping tests must still pass — frontmatter handling is unchanged and their bodies are already clean.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fmt.rs
+git commit -m "feat(fmt): format item markdown body via shared canonical_body helper"
+```
+
+---
+
+## Task 2: fmt unit tests — seam preservation, idempotence, directive survival
+
+**Files:**
+
+- Test: `src/fmt.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write three failing/guard tests**
+
+In `src/fmt.rs` `mod tests`, after `canonicalise_formats_body`, add:
+
+```rust
+    #[test]
+    fn canonicalise_preserves_clean_body_seam() {
+        // An already-clean body with one blank line after `---` is left
+        // exactly as-is — the separator is preserved, not stripped.
+        let raw = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: clean\n",
+            "description: already canonical body.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "- one\n",
+            "- two\n",
+        );
+        let out = canonicalise(raw, Path::new("clean/SKILL.md")).unwrap();
+        assert_eq!(out, raw, "clean body must round-trip unchanged:\n{out}");
+    }
+
+    #[test]
+    fn canonicalise_body_is_idempotent() {
+        let raw = concat!(
+            "---\n",
+            "name: dirty\n",
+            "schema: 1\n",
+            "description: scrambled keys and bullets.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "* one\n",
+            "* two\n",
+        );
+        let path = Path::new("dirty/SKILL.md");
+        let pass1 = canonicalise(raw, path).unwrap();
+        let pass2 = canonicalise(&pass1, path).unwrap();
+        assert_eq!(pass1, pass2, "fmt must be idempotent over the body too");
+    }
+
+    #[test]
+    fn canonicalise_preserves_directives() {
+        let raw = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: cond\n",
+            "description: body has client directives.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "<!-- @client:claude -->\n",
+            "Claude-only line.\n",
+            "<!-- @endclient -->\n",
+        );
+        let out = canonicalise(raw, Path::new("cond/SKILL.md")).unwrap();
+        assert!(
+            out.contains("<!-- @client:claude -->"),
+            "open directive lost:\n{out}"
+        );
+        assert!(
+            out.contains("<!-- @endclient -->"),
+            "close directive lost:\n{out}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run them**
+
+Run: `cargo test --lib fmt::tests`
+Expected: PASS for all three (the helper from Task 1 already produces this behavior; these lock it in).
+
+If `canonicalise_preserves_clean_body_seam` fails because dprint emits a slightly different clean form, fix the test's expected `raw` to match the canonical form rather than changing the implementation — dprint's output is the source of truth.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/fmt.rs
+git commit -m "test(fmt): cover body seam preservation, idempotence, directive survival"
+```
+
+---
+
+## Task 3: fmt ATDD + doc-comment updates
+
+**Files:**
+
+- Test: `tests/cli_fmt.rs` (add one test)
+- Modify: `tests/cli_fmt.rs` (header doc comment)
+- Modify: `src/fmt.rs` (module doc + `fmt` fn doc)
+
+- [ ] **Step 1: Write the failing ATDD test**
+
+In `tests/cli_fmt.rs`, after the existing `fmt_reorders_frontmatter_keys_canonically` test, add:
+
+```rust
+#[test]
+fn fmt_formats_markdown_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let item = tmp.path().join("dirty/SKILL.md");
+    write(
+        &item,
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: dirty\n",
+            "description: A skill whose body needs formatting.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "\n",
+            "* one\n",
+            "* two\n",
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .success();
+
+    let after = fs::read_to_string(&item).unwrap();
+    assert!(
+        after.ends_with("---\n\n## Body\n\n- one\n- two\n"),
+        "body not formatted:\n{after}"
+    );
+}
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+Run: `cargo test --test cli_fmt fmt_formats_markdown_body`
+Expected: PASS (Task 1 already implemented the behavior; this is the acceptance-level proof through the real CLI).
+
+- [ ] **Step 3: Update the `tests/cli_fmt.rs` header doc comment**
+
+Replace this exact block at the top of `tests/cli_fmt.rs`:
+
+```rust
+//! ATDD tests for `upskill fmt`.
+//!
+//! Canonicalises YAML frontmatter in place. Body content is dprint's job;
+//! this command does not touch it. Author command — refuses to run inside
+//! a consumer project (`.upskill-lock.json` at the path's root) per
+//! ADR-0004.
+```
+
+with:
+
+```rust
+//! ATDD tests for `upskill fmt`.
+//!
+//! Canonicalises YAML frontmatter in place and formats the markdown body
+//! via the shared dprint pass (same formatter the generation pipeline
+//! uses). Author command — refuses to run inside a consumer project
+//! (`.upskill-lock.json` at the path's root) per ADR-0004.
+```
+
+- [ ] **Step 4: Update the `src/fmt.rs` module doc**
+
+Replace this exact block at the top of `src/fmt.rs`:
+
+```rust
+//! `upskill fmt` — canonicalise YAML key order in SSOT files.
+//!
+//! Per [ADR-0004](../../docs/adr/0004-cli-surface.md), `fmt` and `lint`
+//! are sibling author commands. `fmt` operates on YAML frontmatter and
+//! bundle files; markdown body content is dprint's job and is preserved
+//! byte-for-byte. Like `lint`, this command refuses to run inside a
+//! consumer project (`.upskill-lock.json` at the path's root).
+//!
+//! What gets canonicalised:
+//!
+//! - **Key order** — fixed by priority tables derived from the
+//!   [`crate::model`] struct field order.
+//! - Unknown top-level keys (extras) sort alphabetically after all
+//!   known keys.
+//!
+//! What is **preserved**:
+//!
+//! - YAML comments (both standalone and inline)
+//! - Author formatting (indentation, line wrapping)
+//! - Nested/indented content (travels with its parent key block)
+```
+
+with:
+
+```rust
+//! `upskill fmt` — canonicalise YAML key order and markdown body in SSOT files.
+//!
+//! Per [ADR-0004](../../docs/adr/0004-cli-surface.md), `fmt` and `lint`
+//! are sibling author commands. `fmt` reorders YAML frontmatter keys and
+//! formats the markdown body through the same dprint pass the generation
+//! pipeline uses (see [`canonical_body`]); `lint` reports a `body-format`
+//! finding when a body is not canonical. Like `lint`, this command
+//! refuses to run inside a consumer project (`.upskill-lock.json` at the
+//! path's root).
+//!
+//! What gets canonicalised:
+//!
+//! - **Key order** — fixed by priority tables derived from the
+//!   [`crate::model`] struct field order.
+//! - Unknown top-level keys (extras) sort alphabetically after all
+//!   known keys.
+//! - **Markdown body** — formatted via dprint; the frontmatter↔body seam
+//!   is normalised to a single blank line.
+//!
+//! What is **preserved**:
+//!
+//! - YAML comments (both standalone and inline)
+//! - Author frontmatter formatting (indentation, line wrapping)
+//! - Nested/indented YAML content (travels with its parent key block)
+//! - Prose wrapping inside the body (dprint `text_wrap: Maintain`)
+//! - HTML-comment directives (`<!-- @client:X -->`)
+```
+
+- [ ] **Step 5: Update the `fmt` function doc comment**
+
+In `src/fmt.rs`, find the doc comment on `pub fn fmt` and replace this exact line:
+
+```rust
+/// Files whose content was already canonical are left untouched
+/// (no `mtime` thrash). Body content is preserved byte-for-byte.
+/// Comments and author formatting are preserved.
+```
+
+with:
+
+```rust
+/// Files whose content was already canonical are left untouched
+/// (no `mtime` thrash). The body is formatted via dprint; YAML comments
+/// and author frontmatter formatting are preserved.
+```
+
+- [ ] **Step 6: Verify the existing key-order ATDD test still passes**
+
+The `fmt_reorders_frontmatter_keys_canonically` test asserts `after.contains("\n\n## Body\n\nUntouched.\n")`. Its body is already clean and uses one blank line after `---`, so it stays valid.
+
+Run: `cargo test --test cli_fmt`
+Expected: PASS (all tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/cli_fmt.rs src/fmt.rs
+git commit -m "test(fmt): ATDD for body formatting; update fmt docs"
+```
+
+---
+
+## Task 4: lint `check_body_format`
+
+**Files:**
+
+- Modify: `src/lint.rs` (`check_file`; add `check_body_format`; rule-table header)
+- Test: `src/lint.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write failing unit tests**
+
+In `src/lint.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn lint_flags_unformatted_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("dirty/SKILL.md");
+        write(&item, &skill("dirty", "\n## Body\n\n* one\n* two\n"));
+        let report = lint(&[tmp.path().to_path_buf()], false).unwrap();
+        let f = report
+            .findings
+            .iter()
+            .find(|f| f.rule_id == "body-format")
+            .expect("expected a body-format finding");
+        assert_eq!(f.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn lint_clean_body_has_no_body_format_finding() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("clean/SKILL.md");
+        write(&item, &skill("clean", "\n## Body\n\n- one\n- two\n"));
+        let report = lint(&[tmp.path().to_path_buf()], false).unwrap();
+        assert!(
+            report.findings.iter().all(|f| f.rule_id != "body-format"),
+            "unexpected body-format finding: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn lint_strict_promotes_body_format_to_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("dirty/SKILL.md");
+        write(&item, &skill("dirty", "\n## Body\n\n* one\n* two\n"));
+        let report = lint(&[tmp.path().to_path_buf()], true).unwrap();
+        let f = report
+            .findings
+            .iter()
+            .find(|f| f.rule_id == "body-format")
+            .expect("expected a body-format finding");
+        assert_eq!(f.severity, Severity::Error);
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --lib lint::tests::lint_flags_unformatted_body lint::tests::lint_strict_promotes_body_format_to_error`
+Expected: FAIL — `body-format` does not exist yet, so `.expect(...)` panics.
+
+- [ ] **Step 3: Add the `check_body_format` function**
+
+In `src/lint.rs`, after `check_directives`, add:
+
+```rust
+/// Compare the body against its canonical dprint-formatted form. A
+/// mismatch means the author has not run `upskill fmt`. Uses the same
+/// `fmt::canonical_body` helper that `fmt` writes with, so checker and
+/// fixer never disagree. The on-disk frontmatter is passed through dprint
+/// as an opaque prefix, so this is independent of frontmatter key order
+/// (which `lint` does not check — only `fmt` reorders).
+fn check_body_format(file: &Path, frontmatter: &str, body: &str, out: &mut Vec<Finding>) {
+    let Ok(canonical) = crate::fmt::canonical_body(frontmatter, body) else {
+        // A dprint failure is rare and surfaced by `fmt` itself; don't
+        // double-report it here.
+        return;
+    };
+    if canonical != body {
+        out.push(Finding {
+            rule_id: "body-format",
+            severity: Severity::Warning,
+            path: file.to_path_buf(),
+            line: None,
+            message: "body is not formatted — run `upskill fmt`".into(),
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Wire it into `check_file`**
+
+In `src/lint.rs`, find this block in `check_file`:
+
+```rust
+check_body_h1(file, body, out);
+check_fence_lang(file, body, out);
+check_directives(file, body, out);
+Ok(())
+```
+
+and replace it with:
+
+```rust
+check_body_h1(file, body, out);
+check_fence_lang(file, body, out);
+check_directives(file, body, out);
+let frontmatter = frontmatter::split(&raw).map(|(fm, _)| fm).unwrap_or("");
+check_body_format(file, frontmatter, body, out);
+Ok(())
+```
+
+(`raw` is the `String` already read at the top of `check_file`; `frontmatter::split` is already imported via `use crate::parse::frontmatter;`. For bundles, `body` is `""` so the check is a no-op regardless of `frontmatter`.)
+
+- [ ] **Step 5: Run the unit tests to verify they pass**
+
+Run: `cargo test --lib lint::tests`
+Expected: PASS for the three new tests and all existing ones (existing `body-h1`/`fence-lang` test bodies are already dprint-clean).
+
+- [ ] **Step 6: Add the rule-table row in the module header**
+
+In `src/lint.rs`, find this table in the module doc comment:
+
+```rust
+//! | `body-h1`         | warning  | §5.1               |
+//! | `fence-lang`      | warning  | §5.2               |
+//! | `directive`       | error    | §6.3 (any imbalance, unknown client, nesting) |
+//! | `name-collision`  | error    | cross-file (bundle vs item name) |
+```
+
+and add a `body-format` row after `fence-lang`:
+
+```rust
+//! | `body-h1`         | warning  | §5.1               |
+//! | `fence-lang`      | warning  | §5.2               |
+//! | `body-format`     | warning  | §3.8 (dprint canonical body) |
+//! | `directive`       | error    | §6.3 (any imbalance, unknown client, nesting) |
+//! | `name-collision`  | error    | cross-file (bundle vs item name) |
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lint.rs
+git commit -m "feat(lint): add body-format rule using shared canonical_body helper"
+```
+
+---
+
+## Task 5: lint ATDD
+
+**Files:**
+
+- Test: `tests/cli_lint.rs` (add two tests)
+
+- [ ] **Step 1: Write the ATDD tests**
+
+In `tests/cli_lint.rs`, after `lint_flags_h1_in_body_as_warning`, add:
+
+```rust
+#[test]
+fn lint_flags_unformatted_body_as_warning() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let item = tmp.path().join("dirty/SKILL.md");
+    write(
+        &item,
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: dirty\n",
+            "description: Body uses asterisk bullets that dprint rewrites.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "* one\n",
+            "* two\n",
+        ),
+    );
+
+    let assert = common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["lint"])
+        .assert()
+        .success(); // warnings only, exit 0 by default
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(out.contains("body-format"), "expected body-format finding: {out}");
+    assert!(out.contains("warning"), "expected warning level: {out}");
+}
+
+#[test]
+fn lint_strict_fails_on_unformatted_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let item = tmp.path().join("dirty/SKILL.md");
+    write(
+        &item,
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: dirty\n",
+            "description: Body uses asterisk bullets that dprint rewrites.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "* one\n",
+            "* two\n",
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["lint", "--strict"])
+        .assert()
+        .failure(); // --strict promotes the warning to an error → non-zero exit
+}
+```
+
+- [ ] **Step 2: Run them**
+
+Run: `cargo test --test cli_lint lint_flags_unformatted_body_as_warning lint_strict_fails_on_unformatted_body`
+Expected: PASS.
+
+- [ ] **Step 3: Run the whole lint ATDD suite to confirm no regressions**
+
+Run: `cargo test --test cli_lint`
+Expected: PASS — including `lint_clean_fixture_corpus_exits_zero` (fixture bodies are already dprint-clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/cli_lint.rs
+git commit -m "test(lint): ATDD for body-format warning and --strict failure"
+```
+
+---
+
+## Task 6: Documentation + fixture corpus guard
+
+**Files:**
+
+- Modify: `docs/adr/0004-cli-surface.md`
+- Modify: `docs/commands.md`
+- Modify: `docs/format-spec.md`
+
+- [ ] **Step 1: Update ADR-0004**
+
+In `docs/adr/0004-cli-surface.md`, replace this exact block:
+
+```markdown
+### `fmt` is frontmatter only
+
+`upskill fmt` canonicalises YAML frontmatter (key ordering, version
+quoting, indentation). Markdown body formatting is dprint's job. The two
+tools don't overlap.
+```
+
+with:
+
+```markdown
+### `fmt` canonicalises frontmatter and body
+
+`upskill fmt` canonicalises YAML frontmatter (key ordering, version
+quoting, indentation) and formats the markdown body through the same
+dprint pass the generation pipeline uses. `upskill lint` reports a
+`body-format` warning when a body is not canonical, so the check/fix pair
+stays symmetric and CI (`lint --strict`) fails on unformatted source.
+(This supersedes the original "frontmatter only" decision: leaving bodies
+unchecked let authored source drift out of canonical form.)
+```
+
+- [ ] **Step 2: Update `docs/commands.md` — fmt one-liner**
+
+In `docs/commands.md`, replace this exact line:
+
+```markdown
+| `fmt` | Author | Canonicalise YAML frontmatter (key order, quoting). |
+```
+
+with:
+
+```markdown
+| `fmt` | Author | Canonicalise YAML frontmatter and format the markdown body. |
+```
+
+- [ ] **Step 3: Update `docs/commands.md` — lint rule table**
+
+In `docs/commands.md`, replace this exact block:
+
+```markdown
+| `body-h1` | warning | format-spec §5.1 |
+| `fence-lang` | warning | format-spec §5.2 |
+| `directive` | error | format-spec §6.3 |
+```
+
+with:
+
+```markdown
+| `body-h1` | warning | format-spec §5.1 |
+| `fence-lang` | warning | format-spec §5.2 |
+| `body-format` | warning | format-spec §3.8 |
+| `directive` | error | format-spec §6.3 |
+```
+
+- [ ] **Step 4: Update `docs/commands.md` — fmt section prose**
+
+In `docs/commands.md`, replace this exact block:
+
+```markdown
+Canonicalise YAML frontmatter (key order, indentation, alphabetised
+unknown keys). Markdown body formatting is left to dprint — the two
+tools don't overlap.
+```
+
+with:
+
+```markdown
+Canonicalise YAML frontmatter (key order, indentation, alphabetised
+unknown keys) and format the markdown body via dprint (the same formatter
+the generation pipeline uses). The frontmatter↔body seam is normalised to
+a single blank line; YAML comments and prose wrapping are preserved.
+```
+
+Then replace this exact line in the same section:
+
+```markdown
+Files whose frontmatter is already canonical are left untouched (no
+`mtime` thrash).
+```
+
+with:
+
+```markdown
+Files whose frontmatter and body are already canonical are left untouched
+(no `mtime` thrash).
+```
+
+- [ ] **Step 5: Update `docs/format-spec.md` §3.8**
+
+In `docs/format-spec.md`, find the `### 3.8 Frontmatter canonicalisation` section and replace this exact paragraph:
+
+```markdown
+An implementation MAY provide a formatting command (e.g., `upskill fmt`) that canonicalises SSOT
+frontmatter. Canonicalisation produces a deterministic key order, making diffs predictable and
+reducing merge conflicts.
+```
+
+with:
+
+```markdown
+An implementation MAY provide a formatting command (e.g., `upskill fmt`) that canonicalises SSOT
+frontmatter and the markdown body. Frontmatter canonicalisation produces a deterministic key
+order, making diffs predictable and reducing merge conflicts. Body canonicalisation applies the
+same markdown formatter used for generated output (§7.4) and normalises the frontmatter↔body seam
+to a single blank line, so authored source matches generated output. A linter MAY report a
+`body-format` finding when a body is not canonical.
+```
+
+- [ ] **Step 6: Verify fixtures are still clean (guard the corpus assertion)**
+
+Build the binary and dry-run `fmt` against a copy of the fixtures to confirm nothing changes (they were verified clean during design; this guards against drift):
+
+```bash
+cargo build --quiet
+TMP=$(mktemp -d)
+cp -R tests/fixtures/items "$TMP/items"
+./target/debug/upskill fmt "$TMP/items"
+git --no-pager -C /dev/null diff --no-index tests/fixtures/items "$TMP/items" || true
+```
+
+Expected: no differences reported. If any fixture body changed, copy the formatted version back into `tests/fixtures/items/...`, then run `cargo test --test generate_skills --test generate_rules --test generate_agents` and confirm the generation golden tests still pass before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/adr/0004-cli-surface.md docs/commands.md docs/format-spec.md
+git commit -m "docs: fmt formats the body; add body-format lint rule"
+```
+
+---
+
+## Task 7: Final verification + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format everything**
+
+Run: `just fmt`
+Expected: success; review any reformatting it applies (commit it if so).
+
+- [ ] **Step 2: Full verification**
+
+Run: `just verify`
+Expected: PASS — clippy clean (zero warnings), all tests green, docs tooling clean.
+
+- [ ] **Step 3: Commit any formatting changes**
+
+```bash
+git add -A
+git commit -m "chore: just fmt" || true
+```
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin feat/fmt-format-body
+gh pr create --base main --title "feat: upskill fmt formats the source body" --body "$(cat <<'BODY'
+## What
+
+`upskill fmt` now formats the markdown body of item files (SKILL/RULE/AGENT)
+through the same dprint pass the generation pipeline uses, in addition to
+reordering YAML frontmatter keys. `upskill lint` gains a `body-format`
+warning that fires when a body is not canonical (promoted to an error under
+`--strict`), so the check/fix pair stays symmetric.
+
+A shared `fmt::canonical_body(frontmatter, body)` helper is the single
+source of truth used by both `fmt` (to write) and `lint` (to detect drift).
+The frontmatter↔body seam is normalised to one blank line; YAML comments,
+key order, frontmatter wrapping, prose wrapping, and HTML-comment
+directives are preserved.
+
+Reverses ADR-0004's original "fmt is frontmatter only" decision (recorded
+in the ADR).
+
+## Tests
+
+- fmt unit: body formatting, seam preservation, idempotence, directive survival
+- fmt ATDD: `upskill fmt` formats a dirty body end-to-end
+- lint unit + ATDD: `body-format` warning, clean body has none, `--strict` fails
+
+Spec: docs/superpowers/specs/2026-06-04-fmt-format-body-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+Expected: PR created against `main`. Then fix any CI findings first, per AGENTS.md.

--- a/docs/superpowers/specs/2026-06-04-fmt-format-body-design.md
+++ b/docs/superpowers/specs/2026-06-04-fmt-format-body-design.md
@@ -46,28 +46,75 @@ markers. Directive processing happens at generation time on the
 generation pipeline's own format pass is a no-op on already-formatted
 bodies.
 
+## Correctness note: the frontmatter↔body seam
+
+The body returned by `frontmatter::split` includes the blank-line
+separator that follows the closing `---` (e.g. `"\n## Body\n…"`). dprint
+**strips** a leading blank line when a body is formatted in isolation, so
+naively reassembling `format_markdown(body)` would delete the
+conventional separator and churn nearly every file.
+
+Generation already solved this. `generate::assemble` does
+`body.trim_start_matches('\n')` and re-inserts **exactly one** blank
+line: `---\n{frontmatter}---\n\n{body}`. When the whole string is fed to
+`format_markdown`, dprint treats `---…---` as **opaque frontmatter** (YAML
+content, comments, wrapping, and key order are all preserved
+byte-for-byte) and only formats the body, normalizing the seam to a
+single blank line.
+
+The canonical form of an item file is therefore
+`---\n{yaml}---\n\n{formatted_body}`. `fmt` must reproduce exactly this,
+and `lint` must compare against exactly this — so both go through one
+shared helper.
+
 ## Implementation
+
+### `src/fmt.rs` — shared `canonical_body` helper
+
+A single, drift-proof helper produces the canonical body region for an
+item. It formats the combined `frontmatter + body` string exactly as the
+generation pipeline does (frontmatter opaque to dprint), then strips the
+frontmatter prefix back off, returning the canonical body region
+**including** its leading blank-line separator. Both `fmt` (to write) and
+`lint` (to detect drift) call it, so they can never disagree.
+
+```rust
+/// Canonical body region for an item file, given its on-disk
+/// frontmatter string and body. Formats via dprint the same way the
+/// generation pipeline does — frontmatter is opaque to dprint, so the
+/// body region is independent of frontmatter key order. Returns the
+/// region after the closing `---`, including the single blank-line
+/// separator (empty when the body is blank).
+pub(crate) fn canonical_body(frontmatter: &str, body: &str) -> Result<String> {
+    let prefix = format!("---\n{frontmatter}---\n");
+    let combined = format!("{prefix}{body}");
+    let formatted = crate::generate::format::format_markdown(&combined)
+        .context("format item body")?;
+    Ok(formatted
+        .strip_prefix(&prefix)
+        .unwrap_or(&formatted)
+        .to_string())
+}
+```
+
+`format_markdown` is already `pub` under `pub mod generate` /
+`pub mod format` — no visibility changes needed.
 
 ### `src/fmt.rs` — `canonicalise_item`
 
-After splitting frontmatter/body and reordering the YAML keys, run the
-body through the shared formatter before reassembling. Only the body is
-formatted; the custom-reordered YAML frontmatter is left exactly as the
-reorder produced it (dprint never touches frontmatter).
+After reordering and validating the YAML, build the body region with the
+helper and reassemble:
 
 ```rust
 let reordered_yaml = reorder_yaml_keys(yaml_str, key_order);
 serde_yaml_ng::from_str::<T>(&reordered_yaml)
     .with_context(|| format!("validate frontmatter {}", path.display()))?;
 
-let formatted_body = crate::generate::format::format_markdown(body)
+let body_region = canonical_body(&reordered_yaml, body)
     .with_context(|| format!("format body {}", path.display()))?;
 
-Ok(format!("---\n{reordered_yaml}---\n{formatted_body}"))
+Ok(format!("---\n{reordered_yaml}---\n{body_region}"))
 ```
-
-`format_markdown` is already `pub` under `pub mod generate` /
-`pub mod format` — no visibility changes needed.
 
 The existing `format_file` already skips files whose canonical form
 equals the on-disk content, so already-formatted files cause no `mtime`
@@ -75,25 +122,33 @@ thrash.
 
 ### `src/lint.rs` — `check_body_format`
 
-A new body check slotted beside the existing ones in `check_file`:
+`check_file` already has the raw file content; it splits the frontmatter
+once and passes it alongside the body to the new check, slotted beside
+the existing body checks:
 
 ```rust
 check_body_h1(file, body, out);
 check_fence_lang(file, body, out);
 check_directives(file, body, out);
-check_body_format(file, body, out);   // new
+check_body_format(file, frontmatter, body, out);   // new
 ```
 
-`check_body_format` compares `body` to `format_markdown(body)`; on
-mismatch it pushes a `Finding`:
+`check_body_format` compares `body` to
+`crate::fmt::canonical_body(frontmatter, body)`; on mismatch it pushes a
+`Finding`:
 
 - `rule_id: "body-format"`
 - `severity: Severity::Warning` — matches the cosmetic `body-h1` /
   `fence-lang` checks; `--strict` promotes it to error in CI.
-- `message`: `"body is not formatted — run`upskill fmt`"`
+- message: "body is not formatted — run `upskill fmt`"
 
-Bundles already return an empty body from `parse_kind`, so the check is a
-natural no-op for them.
+Bundles already return an empty body from `parse_kind` (and pass an empty
+frontmatter), so the check is a natural no-op for them.
+
+Because the helper passes the on-disk frontmatter through dprint as an
+opaque prefix and strips it back, the body comparison is independent of
+whether the author also got the key order right — key order stays
+unchecked by `lint` (only `fmt` reorders), exactly as today.
 
 ## Docs to update
 
@@ -115,12 +170,23 @@ natural no-op for them.
   with `canonicalise_formats_body`: an unformatted body (e.g. `*` bullets
   that should become `-`, collapsed extra blank lines) comes out
   dprint-clean.
-- **Add** an `fmt` body idempotence test (format twice → identical).
+- **Add** a seam-preservation test: an item whose body is already clean
+  with a single blank line after `---` is left **unchanged** (the
+  separator is preserved, not stripped), and `report.files_changed` is
+  empty.
+- **Add** an `fmt` body idempotence test (format twice → identical),
+  covering both a dirty and an already-clean body.
 - **Add** a directive-survival test: a body containing
   `<!-- @client:claude -->` … `<!-- @endclient -->` keeps the markers
   after a format pass.
-- **Add** lint tests: a dirty body yields a `body-format` warning; a
-  clean body yields none; `--strict` promotes the warning to error.
+- **Add** lint tests: a dirty body yields exactly one `body-format`
+  warning; a clean body yields none; a bundle yields none; `--strict`
+  promotes the warning to error.
+- **Guard the fixture corpus:** the existing
+  `lint_clean_fixture_corpus_exits_zero` test asserts "0 findings", so
+  `tests/fixtures/items` bodies must be dprint-clean. Run `upskill fmt`
+  over the fixtures (or hand-fix) and confirm the generation golden tests
+  (`generate_*`) still pass before relying on that assertion.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-04-fmt-format-body-design.md
+++ b/docs/superpowers/specs/2026-06-04-fmt-format-body-design.md
@@ -1,0 +1,129 @@
+# `upskill fmt` formats the source body
+
+**Date:** 2026-06-04
+**Status:** Approved (brainstorm), pending implementation plan
+
+## Problem
+
+`upskill fmt` today has a deliberately narrow contract: it reorders YAML
+frontmatter keys and preserves the markdown body **byte-for-byte**. Per
+[ADR-0004](../../adr/0004-cli-surface.md), body formatting was considered
+"dprint's job" and left out of scope. As a result, authored source bodies
+can drift out of canonical form, and nothing fixes or flags this — even
+though the generation pipeline already runs every emitted body through
+dprint (`generate::format::format_markdown`).
+
+We want `upskill fmt` to mean "fully canonicalize the source," body
+included, and `upskill lint` to flag a non-canonical body so CI fails on
+unformatted source.
+
+## Decisions
+
+1. **Default on (no flag).** `upskill fmt` always formats the body. One
+   command, fully canonical source — matching how `cargo fmt` / `prettier`
+   behave. No opt-out flag (consistent with the project's "no back-compat
+   until 1.0" stance).
+2. **Same dprint pass as generation.** Reuse
+   `crate::generate::format::format_markdown` (default config,
+   `text_wrap: Maintain` — prose is not re-wrapped). This keeps `fmt`
+   idempotent: generation already formats bodies with the same function,
+   so source body ≈ generated body.
+3. **lint checks the body.** `upskill lint` emits a finding when an item's
+   body is not dprint-clean. `fmt` is the fixer; `lint` is the checker — a
+   symmetric pair, mirroring the project's "format before commit" rule.
+4. **Items only.** Body formatting applies to item files (`SKILL.md`,
+   `RULE.md`, `AGENT.md`). Bundles (`*.bundle.yaml`) are pure YAML with no
+   markdown body (§2.2, ADR-0007) and are unaffected.
+
+## Correctness note: directives survive
+
+Conditional-content directives are HTML comments
+(`<!-- @client:X -->` … `<!-- @endclient -->`, see
+`generate::directives`). dprint-plugin-markdown leaves HTML comments
+untouched, so formatting the source body does not mangle directive
+markers. Directive processing happens at generation time on the
+(now-formatted) source body; because dprint is idempotent, the
+generation pipeline's own format pass is a no-op on already-formatted
+bodies.
+
+## Implementation
+
+### `src/fmt.rs` — `canonicalise_item`
+
+After splitting frontmatter/body and reordering the YAML keys, run the
+body through the shared formatter before reassembling. Only the body is
+formatted; the custom-reordered YAML frontmatter is left exactly as the
+reorder produced it (dprint never touches frontmatter).
+
+```rust
+let reordered_yaml = reorder_yaml_keys(yaml_str, key_order);
+serde_yaml_ng::from_str::<T>(&reordered_yaml)
+    .with_context(|| format!("validate frontmatter {}", path.display()))?;
+
+let formatted_body = crate::generate::format::format_markdown(body)
+    .with_context(|| format!("format body {}", path.display()))?;
+
+Ok(format!("---\n{reordered_yaml}---\n{formatted_body}"))
+```
+
+`format_markdown` is already `pub` under `pub mod generate` /
+`pub mod format` — no visibility changes needed.
+
+The existing `format_file` already skips files whose canonical form
+equals the on-disk content, so already-formatted files cause no `mtime`
+thrash.
+
+### `src/lint.rs` — `check_body_format`
+
+A new body check slotted beside the existing ones in `check_file`:
+
+```rust
+check_body_h1(file, body, out);
+check_fence_lang(file, body, out);
+check_directives(file, body, out);
+check_body_format(file, body, out);   // new
+```
+
+`check_body_format` compares `body` to `format_markdown(body)`; on
+mismatch it pushes a `Finding`:
+
+- `rule_id: "body-format"`
+- `severity: Severity::Warning` — matches the cosmetic `body-h1` /
+  `fence-lang` checks; `--strict` promotes it to error in CI.
+- `message`: `"body is not formatted — run`upskill fmt`"`
+
+Bundles already return an empty body from `parse_kind`, so the check is a
+natural no-op for them.
+
+## Docs to update
+
+- **[ADR-0004](../../adr/0004-cli-surface.md)** — remove the "body is
+  preserved byte-for-byte / dprint's job" statement; record that `fmt`
+  now canonicalizes the body and `lint` checks it via `body-format`.
+- **`src/fmt.rs` module doc** — update the "What is preserved" list: the
+  body is now formatted, not preserved verbatim. YAML comments,
+  frontmatter author formatting, and nested content are still preserved.
+- **lint rule table** (`src/lint.rs` header) — add the `body-format`
+  (warning, §5) row.
+- **[docs/format-spec.md](../../format-spec.md)** and
+  **[docs/commands.md](../../commands.md)** — note the new `fmt`/`lint`
+  behavior for bodies.
+
+## Tests
+
+- **Replace** `canonicalise_preserves_body_byte_for_byte` (now wrong)
+  with `canonicalise_formats_body`: an unformatted body (e.g. `*` bullets
+  that should become `-`, collapsed extra blank lines) comes out
+  dprint-clean.
+- **Add** an `fmt` body idempotence test (format twice → identical).
+- **Add** a directive-survival test: a body containing
+  `<!-- @client:claude -->` … `<!-- @endclient -->` keeps the markers
+  after a format pass.
+- **Add** lint tests: a dirty body yields a `body-format` warning; a
+  clean body yields none; `--strict` promotes the warning to error.
+
+## Out of scope
+
+- No `--no-body` / `--body` flag (decision 1).
+- No change to bundle handling.
+- No change to the generation pipeline (it already formats bodies).

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -742,6 +742,72 @@ mod tests {
     }
 
     #[test]
+    fn canonicalise_preserves_clean_body_seam() {
+        // An already-clean body with one blank line after `---` is left
+        // exactly as-is — the separator is preserved, not stripped.
+        let raw = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: clean\n",
+            "description: already canonical body.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "- one\n",
+            "- two\n",
+        );
+        let out = canonicalise(raw, Path::new("clean/SKILL.md")).unwrap();
+        assert_eq!(out, raw, "clean body must round-trip unchanged:\n{out}");
+    }
+
+    #[test]
+    fn canonicalise_body_is_idempotent() {
+        let raw = concat!(
+            "---\n",
+            "name: dirty\n",
+            "schema: 1\n",
+            "description: scrambled keys and bullets.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "* one\n",
+            "* two\n",
+        );
+        let path = Path::new("dirty/SKILL.md");
+        let pass1 = canonicalise(raw, path).unwrap();
+        let pass2 = canonicalise(&pass1, path).unwrap();
+        assert_eq!(pass1, pass2, "fmt must be idempotent over the body too");
+    }
+
+    #[test]
+    fn canonicalise_preserves_directives() {
+        let raw = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: cond\n",
+            "description: body has client directives.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "<!-- @client:claude -->\n",
+            "Claude-only line.\n",
+            "<!-- @endclient -->\n",
+        );
+        let out = canonicalise(raw, Path::new("cond/SKILL.md")).unwrap();
+        assert!(
+            out.contains("<!-- @client:claude -->"),
+            "open directive lost:\n{out}"
+        );
+        assert!(
+            out.contains("<!-- @endclient -->"),
+            "close directive lost:\n{out}"
+        );
+    }
+
+    #[test]
     fn canonicalise_is_idempotent() {
         let raw = concat!(
             "---\n",

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -209,8 +209,9 @@ fn canonicalise_item<T: DeserializeOwned>(
 /// preserved byte-for-byte and only the body is formatted, with the seam
 /// normalised to a single blank line. Returns the region after the
 /// closing `---`, including that leading blank-line separator. Empty when
-/// the body is blank. Used by both `fmt` (to write) and `lint::check_body_format`
-/// (to detect drift) so checker and fixer never disagree.
+/// the body is blank. Used by both `fmt` (to write) and
+/// `lint::check_body_format` (to detect drift) so checker and fixer
+/// never disagree.
 pub(crate) fn canonical_body(frontmatter: &str, body: &str) -> Result<String> {
     if body.trim().is_empty() {
         return Ok(String::new());
@@ -219,6 +220,9 @@ pub(crate) fn canonical_body(frontmatter: &str, body: &str) -> Result<String> {
     let combined = format!("{prefix}{body}");
     let formatted =
         crate::generate::format::format_markdown(&combined).context("format item body")?;
+    // dprint preserves the `---\n{frontmatter}---\n` prefix byte-for-byte
+    // because it treats the frontmatter delimiters as opaque. If this ever
+    // fires, a dprint version or config change violated that contract.
     formatted
         .strip_prefix(&prefix)
         .map(|region| region.to_string())
@@ -808,6 +812,32 @@ mod tests {
     }
 
     #[test]
+    fn canonicalise_preserves_html_comment_and_code_fence() {
+        let raw = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: fences\n",
+            "description: code fences and html comments survive.\n",
+            "---\n",
+            "\n",
+            "```rust\n",
+            "fn x() {}\n",
+            "```\n",
+            "\n",
+            "<!-- a comment -->\n",
+        );
+        let out = canonicalise(raw, Path::new("fences/SKILL.md")).unwrap();
+        assert!(
+            out.contains("```rust\nfn x() {}\n```"),
+            "code fence altered:\n{out}"
+        );
+        assert!(
+            out.contains("<!-- a comment -->"),
+            "html comment stripped:\n{out}"
+        );
+    }
+
+    #[test]
     fn canonicalise_is_idempotent() {
         let raw = concat!(
             "---\n",
@@ -818,6 +848,8 @@ mod tests {
             "## body\n",
         );
         let path = Path::new("out/SKILL.md");
+        // The first pass normalises the body seam, so pass1 differs from
+        // raw; idempotency means pass2 == pass1.
         let pass1 = canonicalise(raw, path).unwrap();
         let pass2 = canonicalise(&pass1, path).unwrap();
         assert_eq!(pass1, pass2, "fmt must be idempotent");

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -196,7 +196,33 @@ fn canonicalise_item<T: DeserializeOwned>(
     serde_yaml_ng::from_str::<T>(&reordered_yaml)
         .with_context(|| format!("validate frontmatter {}", path.display()))?;
 
-    Ok(format!("---\n{reordered_yaml}---\n{body}"))
+    let body_region = canonical_body(&reordered_yaml, body)
+        .with_context(|| format!("format body {}", path.display()))?;
+
+    Ok(format!("---\n{reordered_yaml}---\n{body_region}"))
+}
+
+/// Canonical body region for an item file, given its on-disk
+/// frontmatter string and body. Formats via dprint the same way the
+/// generation pipeline does: dprint treats `---…---` as opaque
+/// frontmatter, so the YAML (content, comments, key order, wrapping) is
+/// preserved byte-for-byte and only the body is formatted, with the seam
+/// normalised to a single blank line. Returns the region after the
+/// closing `---`, including that leading blank-line separator. Empty when
+/// the body is blank. Used by both `fmt` (to write) and `lint::check_body_format`
+/// (to detect drift) so checker and fixer never disagree.
+pub(crate) fn canonical_body(frontmatter: &str, body: &str) -> Result<String> {
+    if body.trim().is_empty() {
+        return Ok(String::new());
+    }
+    let prefix = format!("---\n{frontmatter}---\n");
+    let combined = format!("{prefix}{body}");
+    let formatted =
+        crate::generate::format::format_markdown(&combined).context("format item body")?;
+    formatted
+        .strip_prefix(&prefix)
+        .map(|region| region.to_string())
+        .ok_or_else(|| anyhow!("dprint altered the frontmatter region while formatting the body"))
 }
 
 /// Parse YAML string into `T` for validation only. Discards the result.
@@ -692,21 +718,27 @@ mod tests {
     }
 
     #[test]
-    fn canonicalise_preserves_body_byte_for_byte() {
-        let body = concat!(
+    fn canonicalise_formats_body() {
+        // `*` bullets become `-`, extra blank lines collapse, and the
+        // single blank-line separator after the frontmatter is kept.
+        let raw = concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: dirty\n",
+            "description: body needs formatting.\n",
+            "---\n",
             "\n",
-            "## A heading\n",
+            "## Body\n",
             "\n",
-            "```rust\n",
-            "fn x() {}\n",
-            "```\n",
             "\n",
-            "<!-- a comment -->\n",
+            "* one\n",
+            "* two\n",
         );
-        let raw =
-            format!("---\nschema: 1\nname: preserve\ndescription: do not touch body.\n---\n{body}");
-        let out = canonicalise(&raw, Path::new("preserve/SKILL.md")).unwrap();
-        assert!(out.ends_with(body), "body changed:\n{out}");
+        let out = canonicalise(raw, Path::new("dirty/SKILL.md")).unwrap();
+        assert!(
+            out.ends_with("---\n\n## Body\n\n- one\n- two\n"),
+            "body not formatted canonically:\n{out}"
+        );
     }
 
     #[test]
@@ -799,6 +831,7 @@ mod tests {
             "name: clean\n",
             "description: already canonical.\n",
             "---\n",
+            "\n",
             "## body\n",
         );
         write(&item, canonical);

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,10 +1,12 @@
-//! `upskill fmt` — canonicalise YAML key order in SSOT files.
+//! `upskill fmt` — canonicalise YAML key order and markdown body in SSOT files.
 //!
 //! Per [ADR-0004](../../docs/adr/0004-cli-surface.md), `fmt` and `lint`
-//! are sibling author commands. `fmt` operates on YAML frontmatter and
-//! bundle files; markdown body content is dprint's job and is preserved
-//! byte-for-byte. Like `lint`, this command refuses to run inside a
-//! consumer project (`.upskill-lock.json` at the path's root).
+//! are sibling author commands. `fmt` reorders YAML frontmatter keys and
+//! formats the markdown body through the same dprint pass the generation
+//! pipeline uses (see [`canonical_body`]); `lint` reports a `body-format`
+//! finding when a body is not canonical. Like `lint`, this command
+//! refuses to run inside a consumer project (`.upskill-lock.json` at the
+//! path's root).
 //!
 //! What gets canonicalised:
 //!
@@ -12,12 +14,16 @@
 //!   [`crate::model`] struct field order.
 //! - Unknown top-level keys (extras) sort alphabetically after all
 //!   known keys.
+//! - **Markdown body** — formatted via dprint; the frontmatter↔body seam
+//!   is normalised to a single blank line.
 //!
 //! What is **preserved**:
 //!
 //! - YAML comments (both standalone and inline)
-//! - Author formatting (indentation, line wrapping)
-//! - Nested/indented content (travels with its parent key block)
+//! - Author frontmatter formatting (indentation, line wrapping)
+//! - Nested/indented YAML content (travels with its parent key block)
+//! - Prose wrapping inside the body (dprint `text_wrap: Maintain`)
+//! - HTML-comment directives (`<!-- @client:X -->`)
 //!
 //! Implementation: line-level block reordering. The YAML is split into
 //! top-level key blocks (each key + preceding comments + indented
@@ -111,8 +117,8 @@ pub struct FmtReport {
 /// working directory.
 ///
 /// Files whose content was already canonical are left untouched
-/// (no `mtime` thrash). Body content is preserved byte-for-byte.
-/// Comments and author formatting are preserved.
+/// (no `mtime` thrash). The body is formatted via dprint; YAML comments
+/// and author frontmatter formatting are preserved.
 pub fn fmt(paths: &[PathBuf]) -> Result<FmtReport> {
     let owned_cwd: Vec<PathBuf>;
     let roots: &[PathBuf] = if paths.is_empty() {

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -301,10 +301,16 @@ fn check_file(file: &Path, out: &mut Vec<Finding>) -> Result<()> {
     check_body_h1(file, body, out);
     check_fence_lang(file, body, out);
     check_directives(file, body, out);
-    // Bodyless entrypoints (bundles) have nothing to format; skip the
-    // redundant frontmatter split for them.
-    if !body.is_empty() {
-        let frontmatter = frontmatter::split(&raw).map(|(fm, _)| fm).unwrap_or("");
+    // Bodyless entrypoints (bundles) have nothing to format. A non-empty
+    // body implies `parse_kind` already split the frontmatter, so `split`
+    // returns `Some` here — if it ever did not, skip rather than fabricate
+    // an empty frontmatter (which would change the dprint prefix).
+    let item_frontmatter = if body.is_empty() {
+        None
+    } else {
+        frontmatter::split(&raw).map(|(fm, _)| fm)
+    };
+    if let Some(frontmatter) = item_frontmatter {
         check_body_format(file, frontmatter, body, out);
     }
     Ok(())

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -301,8 +301,12 @@ fn check_file(file: &Path, out: &mut Vec<Finding>) -> Result<()> {
     check_body_h1(file, body, out);
     check_fence_lang(file, body, out);
     check_directives(file, body, out);
-    let frontmatter = frontmatter::split(&raw).map(|(fm, _)| fm).unwrap_or("");
-    check_body_format(file, frontmatter, body, out);
+    // Bodyless entrypoints (bundles) have nothing to format; skip the
+    // redundant frontmatter split for them.
+    if !body.is_empty() {
+        let frontmatter = frontmatter::split(&raw).map(|(fm, _)| fm).unwrap_or("");
+        check_body_format(file, frontmatter, body, out);
+    }
     Ok(())
 }
 

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -15,6 +15,7 @@
 //! | `name-matches-dir`| error    | §2.1               |
 //! | `body-h1`         | warning  | §5.1               |
 //! | `fence-lang`      | warning  | §5.2               |
+//! | `body-format`     | warning  | §3.8 (dprint canonical body) |
 //! | `directive`       | error    | §6.3 (any imbalance, unknown client, nesting) |
 //! | `name-collision`  | error    | cross-file (bundle vs item name) |
 //!
@@ -300,6 +301,8 @@ fn check_file(file: &Path, out: &mut Vec<Finding>) -> Result<()> {
     check_body_h1(file, body, out);
     check_fence_lang(file, body, out);
     check_directives(file, body, out);
+    let frontmatter = frontmatter::split(&raw).map(|(fm, _)| fm).unwrap_or("");
+    check_body_format(file, frontmatter, body, out);
     Ok(())
 }
 
@@ -458,6 +461,29 @@ fn check_directives(file: &Path, body: &str, out: &mut Vec<Finding>) {
             path: file.to_path_buf(),
             line: None,
             message: format!("{:#}", err),
+        });
+    }
+}
+
+/// Compare the body against its canonical dprint-formatted form. A
+/// mismatch means the author has not run `upskill fmt`. Uses the same
+/// `fmt::canonical_body` helper that `fmt` writes with, so checker and
+/// fixer never disagree. The on-disk frontmatter is passed through dprint
+/// as an opaque prefix, so this is independent of frontmatter key order
+/// (which `lint` does not check — only `fmt` reorders).
+fn check_body_format(file: &Path, frontmatter: &str, body: &str, out: &mut Vec<Finding>) {
+    let Ok(canonical) = crate::fmt::canonical_body(frontmatter, body) else {
+        // A dprint failure is rare and surfaced by `fmt` itself; don't
+        // double-report it here.
+        return;
+    };
+    if canonical != body {
+        out.push(Finding {
+            rule_id: "body-format",
+            severity: Severity::Warning,
+            path: file.to_path_buf(),
+            line: None,
+            message: "body is not formatted — run `upskill fmt`".into(),
         });
     }
 }
@@ -830,6 +856,47 @@ mod tests {
             "missing name-matches-dir finding for bundle: {:?}",
             report.findings
         );
+    }
+
+    #[test]
+    fn lint_flags_unformatted_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("dirty/SKILL.md");
+        write(&item, &skill("dirty", "\n## Body\n\n* one\n* two\n"));
+        let report = lint(&[tmp.path().to_path_buf()], false).unwrap();
+        let f = report
+            .findings
+            .iter()
+            .find(|f| f.rule_id == "body-format")
+            .expect("expected a body-format finding");
+        assert_eq!(f.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn lint_clean_body_has_no_body_format_finding() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("clean/SKILL.md");
+        write(&item, &skill("clean", "\n## Body\n\n- one\n- two\n"));
+        let report = lint(&[tmp.path().to_path_buf()], false).unwrap();
+        assert!(
+            report.findings.iter().all(|f| f.rule_id != "body-format"),
+            "unexpected body-format finding: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn lint_strict_promotes_body_format_to_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let item = tmp.path().join("dirty/SKILL.md");
+        write(&item, &skill("dirty", "\n## Body\n\n* one\n* two\n"));
+        let report = lint(&[tmp.path().to_path_buf()], true).unwrap();
+        let f = report
+            .findings
+            .iter()
+            .find(|f| f.rule_id == "body-format")
+            .expect("expected a body-format finding");
+        assert_eq!(f.severity, Severity::Error);
     }
 
     #[test]

--- a/tests/cli_fmt.rs
+++ b/tests/cli_fmt.rs
@@ -1,9 +1,9 @@
 //! ATDD tests for `upskill fmt`.
 //!
-//! Canonicalises YAML frontmatter in place. Body content is dprint's job;
-//! this command does not touch it. Author command — refuses to run inside
-//! a consumer project (`.upskill-lock.json` at the path's root) per
-//! ADR-0004.
+//! Canonicalises YAML frontmatter in place and formats the markdown body
+//! via the shared dprint pass (same formatter the generation pipeline
+//! uses). Author command — refuses to run inside a consumer project
+//! (`.upskill-lock.json` at the path's root) per ADR-0004.
 
 mod common;
 
@@ -67,6 +67,42 @@ fn fmt_reorders_frontmatter_keys_canonically() {
 }
 
 #[test]
+fn fmt_formats_markdown_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let item = tmp.path().join("dirty/SKILL.md");
+    write(
+        &item,
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: dirty\n",
+            "description: A skill whose body needs formatting.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "\n",
+            "* one\n",
+            "* two\n",
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["fmt"])
+        .assert()
+        .success();
+
+    let after = fs::read_to_string(&item).unwrap();
+    assert!(
+        after.ends_with("---\n\n## Body\n\n- one\n- two\n"),
+        "body not formatted:\n{after}"
+    );
+}
+
+#[test]
 fn fmt_is_idempotent() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");
@@ -106,16 +142,20 @@ fn fmt_is_idempotent() {
 }
 
 #[test]
-fn fmt_does_not_touch_body() {
+fn fmt_preserves_already_canonical_body_structure() {
+    // dprint normalises `*italic*` → `_italic_`; code fences and HTML
+    // comments are preserved. The test uses already-canonical dprint output
+    // so the body should survive the round-trip unchanged.
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");
     fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("preserve-body/SKILL.md");
+    // Body already in dprint canonical form (underscores, not asterisks).
     let body = concat!(
         "\n",
         "## A heading\n",
         "\n",
-        "Some prose with *italic* and **bold**.\n",
+        "Some prose with _italic_ and **bold**.\n",
         "\n",
         "```rust\n",
         "fn main() {}\n",
@@ -172,6 +212,7 @@ fn fmt_reports_files_changed_count() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");
     fs::create_dir_all(&home).unwrap();
+    // needs-fmt: frontmatter out of order — will be changed.
     write(
         &tmp.path().join("needs-fmt/SKILL.md"),
         concat!(
@@ -180,9 +221,12 @@ fn fmt_reports_files_changed_count() {
             "schema: 1\n",
             "description: Out-of-order frontmatter.\n",
             "---\n",
+            "\n",
             "## body\n",
         ),
     );
+    // clean: already in fully canonical form (correct key order + blank-line
+    // seam) — must not be changed.
     write(
         &tmp.path().join("clean/SKILL.md"),
         concat!(
@@ -191,6 +235,7 @@ fn fmt_reports_files_changed_count() {
             "name: clean\n",
             "description: Already canonical.\n",
             "---\n",
+            "\n",
             "## body\n",
         ),
     );

--- a/tests/cli_fmt.rs
+++ b/tests/cli_fmt.rs
@@ -62,7 +62,7 @@ fn fmt_reorders_frontmatter_keys_canonically() {
         "keys not in canonical order:\n{yaml}"
     );
 
-    // Body must be byte-for-byte preserved.
+    // This body is already dprint-canonical, so it must survive unchanged.
     assert!(after.contains("\n\n## Body\n\nUntouched.\n"), "{after}");
 }
 

--- a/tests/cli_lint.rs
+++ b/tests/cli_lint.rs
@@ -72,6 +72,70 @@ fn lint_flags_h1_in_body_as_warning() {
 }
 
 #[test]
+fn lint_flags_unformatted_body_as_warning() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let item = tmp.path().join("dirty/SKILL.md");
+    write(
+        &item,
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: dirty\n",
+            "description: Body uses asterisk bullets that dprint rewrites.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "* one\n",
+            "* two\n",
+        ),
+    );
+
+    let assert = common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["lint"])
+        .assert()
+        .success(); // warnings only, exit 0 by default
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        out.contains("body-format"),
+        "expected body-format finding: {out}"
+    );
+    assert!(out.contains("warning"), "expected warning level: {out}");
+}
+
+#[test]
+fn lint_strict_fails_on_unformatted_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let item = tmp.path().join("dirty/SKILL.md");
+    write(
+        &item,
+        concat!(
+            "---\n",
+            "schema: 1\n",
+            "name: dirty\n",
+            "description: Body uses asterisk bullets that dprint rewrites.\n",
+            "---\n",
+            "\n",
+            "## Body\n",
+            "\n",
+            "* one\n",
+            "* two\n",
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(tmp.path())
+        .args(["lint", "--strict"])
+        .assert()
+        .failure(); // --strict promotes the warning to an error → non-zero exit
+}
+
+#[test]
 fn lint_flags_fence_without_language_as_warning() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");

--- a/tests/cli_lint.rs
+++ b/tests/cli_lint.rs
@@ -13,6 +13,19 @@ use std::path::Path;
 
 const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
+const UNFORMATTED_SKILL_MD: &str = concat!(
+    "---\n",
+    "schema: 1\n",
+    "name: dirty\n",
+    "description: Body uses asterisk bullets that dprint rewrites.\n",
+    "---\n",
+    "\n",
+    "## Body\n",
+    "\n",
+    "* one\n",
+    "* two\n",
+);
+
 fn write(path: &Path, contents: &str) {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).unwrap();
@@ -77,21 +90,7 @@ fn lint_flags_unformatted_body_as_warning() {
     let home = tmp.path().join("home");
     fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("dirty/SKILL.md");
-    write(
-        &item,
-        concat!(
-            "---\n",
-            "schema: 1\n",
-            "name: dirty\n",
-            "description: Body uses asterisk bullets that dprint rewrites.\n",
-            "---\n",
-            "\n",
-            "## Body\n",
-            "\n",
-            "* one\n",
-            "* two\n",
-        ),
-    );
+    write(&item, UNFORMATTED_SKILL_MD);
 
     let assert = common::upskill_cmd(&home)
         .current_dir(tmp.path())
@@ -112,21 +111,7 @@ fn lint_strict_fails_on_unformatted_body() {
     let home = tmp.path().join("home");
     fs::create_dir_all(&home).unwrap();
     let item = tmp.path().join("dirty/SKILL.md");
-    write(
-        &item,
-        concat!(
-            "---\n",
-            "schema: 1\n",
-            "name: dirty\n",
-            "description: Body uses asterisk bullets that dprint rewrites.\n",
-            "---\n",
-            "\n",
-            "## Body\n",
-            "\n",
-            "* one\n",
-            "* two\n",
-        ),
-    );
+    write(&item, UNFORMATTED_SKILL_MD);
 
     common::upskill_cmd(&home)
         .current_dir(tmp.path())

--- a/tests/fixtures/items/api-conventions/RULE.md
+++ b/tests/fixtures/items/api-conventions/RULE.md
@@ -7,11 +7,11 @@ scope:
   paths:
     - "src/api/**/*.ts"
     - "src/handlers/**/*.ts"
-copilot:
-  excludeAgent: code-review
 metadata:
   version: "2.1.0"
   author: platform-api
+copilot:
+  excludeAgent: code-review
 ---
 
 ## API handler conventions

--- a/tests/fixtures/items/security-reviewer/AGENT.md
+++ b/tests/fixtures/items/security-reviewer/AGENT.md
@@ -12,8 +12,6 @@ tools:
   - bash
 preload-skills:
   - security-baseline
-opencode:
-  temperature: 0.2
 metadata:
   version: "1.0.0"
   author: platform-security
@@ -21,6 +19,8 @@ metadata:
     - claude
     - copilot
     - opencode
+opencode:
+  temperature: 0.2
 ---
 
 ## Security reviewer


### PR DESCRIPTION
## What

`upskill fmt` now formats the markdown **body** of item files (`SKILL.md`/`RULE.md`/`AGENT.md`) through the same dprint pass the generation pipeline uses, in addition to reordering YAML frontmatter keys. `upskill lint` gains a **`body-format`** warning that fires when a body is not canonical (promoted to an error under `--strict`), so the check/fix pair stays symmetric and CI fails on unformatted source.

This reverses ADR-0004's original "`fmt` is frontmatter only" decision (recorded in the ADR).

## How

A single shared helper `fmt::canonical_body(frontmatter, body)` is the source of truth used by **both** `fmt` (to write) and `lint::check_body_format` (to detect drift), so the fixer and checker can never disagree. It formats the combined `---\n{yaml}---\n{body}` string — dprint treats the `---…---` block as opaque frontmatter (YAML content, comments, key order, and wrapping preserved byte-for-byte) and only formats the body, normalising the frontmatter↔body seam to a single blank line. Bundles (pure YAML, no body) are unaffected.

Preserved: YAML comments, frontmatter author formatting, prose wrapping (`text_wrap: Maintain`), and HTML-comment directives (`<!-- @client:X -->`).

## Tests

- **fmt unit:** body formatting, clean-seam round-trip, idempotence, directive survival, code-fence + HTML-comment preservation.
- **fmt ATDD:** `upskill fmt` formats a dirty body end-to-end.
- **lint unit + ATDD:** `body-format` warning fires on a dirty body, clean body has none, `--strict` exits non-zero.
- Two fixtures (`api-conventions/RULE.md`, `security-reviewer/AGENT.md`) had their YAML key order canonicalised; generation golden tests unchanged.

`just verify` green: all tests pass, clippy clean (`-D warnings`), `cargo fmt --check`, `dprint check`, markdownlint, shellcheck.

## Design docs

- Spec: `docs/superpowers/specs/2026-06-04-fmt-format-body-design.md`
- Plan: `docs/superpowers/plans/2026-06-04-fmt-format-body.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
