### PR TITLE
docs(spec): fix broken ADR-0010 relative link in MCP v2 spec

### DIFF
--- a/docs/superpowers/specs/2026-06-03-mcp-v2-convention-design.md
+++ b/docs/superpowers/specs/2026-06-03-mcp-v2-convention-design.md
@@ -107,7 +107,7 @@ Add a recipe section _"Shipping an MCP that needs a local install."_ Structure:
   need no installer; only a launcher-less bare binary does.
 - The 4 steps above, with the bundle YAML example.
 - The runtime-flow + trust paragraphs.
-- A pointer to [ADR-0010](../adr/0010-mcp-config-write.md) and the v1 `mcps:`
+- A pointer to [ADR-0010](../../adr/0010-mcp-config-write.md) and the v1 `mcps:`
   format-spec section.
 
 Match the existing recipe style in `docs/recipes.md` (read a sibling recipe for


### PR DESCRIPTION
## What

Fixes a broken relative link to ADR-0010 in the MCP v2 convention design spec.

The Deliverable-1 pointer at line 110 used `../adr/0010-mcp-config-write.md`,
which resolves to `docs/superpowers/adr/` — a directory that does not exist
(the ADRs live at `docs/adr/`, two levels up). The same file's header link
(line 5) already uses the correct `../../adr/...`, so this restores internal
consistency.

## Why

Surfaced by a `/code-review` pass over the spec. A cold-start executor copying
the Deliverable-1 link verbatim into `docs/recipes.md` would also produce a
dead link; the already-merged recipe correctly used `adr/0010-...`, so this is
the only remaining stale reference.

## Scope

One-line docs change. `just fmt` clean; push hook `just verify` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
