### PR TITLE
test(harness): enforce fake-$HOME via guard test (#202)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,12 +155,22 @@ Token resolution order:
   exhaustively. Other unit tests cover flag resolution, lockfile read/write,
   hash computation, env-var precedence, fetch with subfolder, etc.
 - **Integration tests** live in `tests/` as `cli_*.rs` files and use
-  `assert_cmd` + `tempfile`. Pattern:
+  `assert_cmd` + `tempfile`. Construct the binary through
+  `common::upskill_cmd(&fake_home)` — never a raw `Command::cargo_bin("upskill")`.
+  The harness points `HOME`/`USERPROFILE` at a tempdir so a stray global-scope
+  write can't land in the developer's real `$HOME` (`add` defaults to global
+  outside a git repo). `tests/cli_test_harness_guard.rs` enforces this; a file
+  that must control `HOME` itself opts out with an
+  `upskill-allow-raw-cargo-bin: <reason>` comment. Pattern:
 
   ```rust
-  Command::cargo_bin("upskill")
-      .unwrap()
-      .current_dir(&tmp)
+  mod common;
+
+  let tmp = tempfile::tempdir().unwrap();
+  let home = tmp.path().join("home");
+  std::fs::create_dir_all(&home).unwrap();
+  common::upskill_cmd(&home)
+      .current_dir(tmp.path())
       .args(["add", "owner/repo", "--claude"])
       .assert()
       .success();
@@ -171,6 +181,8 @@ Token resolution order:
   - **Pipeline:** `pipeline_local`, `pipeline_source`, `pipeline_lockfile`.
   - **Generation (v0.2 pipeline):** `generate_skills`, `generate_rules`,
     `generate_agents`. Golden fixtures in `tests/fixtures/`.
+  - **Harness:** `tests/common/mod.rs` (`upskill_cmd`) and
+    `cli_test_harness_guard` (enforces the fake-`$HOME` convention).
   - When adding behavior, prefer extending the matching file or creating
     a new `cli_<area>.rs` / `pipeline_<area>.rs` / `generate_<area>.rs`.
 

--- a/tests/cli_conflict.rs
+++ b/tests/cli_conflict.rs
@@ -1,6 +1,7 @@
 //! Integration tests for item conflict detection and resolution flags.
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use tempfile::TempDir;
 
@@ -41,10 +42,11 @@ fn setup_conflict(tmp: &std::path::Path) {
 #[test]
 fn add_from_different_source_errors_without_force() {
     let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     setup_conflict(tmp.path());
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "./source"])
         .assert()
@@ -55,10 +57,11 @@ fn add_from_different_source_errors_without_force() {
 #[test]
 fn add_from_different_source_succeeds_with_force() {
     let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
     setup_conflict(tmp.path());
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "./source", "--force"])
         .assert()
@@ -68,6 +71,8 @@ fn add_from_different_source_succeeds_with_force() {
 #[test]
 fn add_from_same_source_succeeds_without_force() {
     let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
     let skill_dir = tmp.path().join("source/test-skill");
     fs::create_dir_all(&skill_dir).unwrap();
@@ -80,8 +85,7 @@ fn add_from_same_source_succeeds_without_force() {
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     // First install records the canonical (absolutized) `local:` source label.
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "./source"])
         .assert()
@@ -90,8 +94,7 @@ fn add_from_same_source_succeeds_without_force() {
     // Re-adding from the SAME source must succeed without --force: the
     // recomputed source label matches the recorded one (issue #212 ensures
     // both spellings canonicalize identically).
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "./source"])
         .assert()
@@ -101,6 +104,8 @@ fn add_from_same_source_succeeds_without_force() {
 #[test]
 fn add_with_exclude_skips_named_item() {
     let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
     let skill_a = tmp.path().join("source/skill-a");
     let skill_b = tmp.path().join("source/skill-b");
@@ -119,8 +124,7 @@ fn add_with_exclude_skips_named_item() {
 
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "./source", "--exclude", "skill-b"])
         .assert()
@@ -140,6 +144,8 @@ fn add_with_exclude_skips_named_item() {
 #[test]
 fn add_with_alias_installs_under_alternate_name() {
     let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
     // Existing lockfile with item from different source (creates conflict)
     let lockfile = serde_json::json!({
@@ -171,8 +177,7 @@ fn add_with_alias_installs_under_alternate_name() {
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     // Install with alias to avoid conflict
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["add", "./source", "--as", "test-skill-v2"])
         .assert()
@@ -193,6 +198,8 @@ fn add_with_alias_installs_under_alternate_name() {
 #[test]
 fn update_handles_aliased_items() {
     let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
     // Create source with a skill
     let skill_dir = tmp.path().join("source/original-skill");
@@ -225,8 +232,7 @@ fn update_handles_aliased_items() {
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     // Update should succeed (finds original-skill in source, installs as my-alias)
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["update"])
         .assert()
@@ -247,6 +253,8 @@ fn update_handles_aliased_items() {
 #[test]
 fn update_dry_run_handles_aliased_items() {
     let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
 
     let skill_dir = tmp.path().join("source/original-skill");
     fs::create_dir_all(&skill_dir).unwrap();
@@ -277,8 +285,7 @@ fn update_dry_run_handles_aliased_items() {
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
 
     // Dry-run should detect changes (hash differs)
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&home)
         .current_dir(tmp.path())
         .args(["update", "--dry-run"])
         .assert()

--- a/tests/cli_global_scope.rs
+++ b/tests/cli_global_scope.rs
@@ -4,6 +4,12 @@
 //! kicks in when `-g/--global` is passed OR when `cwd` is not inside a git
 //! repo. `-p/--project` forces project regardless. `-g` and `-p` are
 //! mutually exclusive at the clap layer.
+//!
+//! upskill-allow-raw-cargo-bin: this suite tests global scope itself — each
+//! test sets `HOME`/`USERPROFILE` to a tempdir (or deliberately removes them to
+//! exercise the fallback/error paths), so it cannot route through
+//! `common::upskill_cmd`, which always sets both. The exemption is enforced by
+//! `tests/cli_test_harness_guard.rs`.
 
 use assert_cmd::Command;
 use std::fs;

--- a/tests/cli_test_harness_guard.rs
+++ b/tests/cli_test_harness_guard.rs
@@ -1,0 +1,77 @@
+//! Guard test: enforce the fake-`$HOME` test harness.
+//!
+//! Every integration test that launches the `upskill` binary MUST go through
+//! [`common::upskill_cmd`], which points `HOME`/`USERPROFILE` at a tempdir so a
+//! stray global-scope write can never land in the developer's real `$HOME`.
+//! `add` defaults to global scope outside a git repo, so a raw
+//! `Command::cargo_bin("upskill")` that forgets a `.git` marker silently
+//! pollutes the real home. This has bitten twice (issues #193 and #199).
+//!
+//! This test scans every top-level `tests/*.rs` source file and fails if it
+//! constructs the binary directly instead of through the harness. A file that
+//! legitimately needs raw construction — e.g. one that tests global scope by
+//! setting `HOME`/`USERPROFILE` itself, or by deliberately leaving them unset
+//! — opts out with a comment containing the marker
+//! `upskill-allow-raw-cargo-bin: <reason>`.
+//!
+//! See <https://github.com/driftsys/upskill/issues/202>.
+
+use std::fs;
+use std::path::Path;
+
+/// Marker a test file places in a comment to opt out of the harness check,
+/// e.g. `// upskill-allow-raw-cargo-bin: tests global scope, sets HOME itself`.
+const OPT_OUT_MARKER: &str = "upskill-allow-raw-cargo-bin";
+
+/// Substrings that indicate the binary is being constructed directly rather
+/// than through `common::upskill_cmd`.
+const RAW_PATTERNS: [&str; 2] = ["cargo_bin(\"upskill\")", "cargo_bin!(\"upskill\")"];
+
+#[test]
+fn integration_tests_use_fake_home_harness() {
+    let tests_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut violations: Vec<String> = Vec::new();
+
+    for entry in fs::read_dir(&tests_dir).expect("tests/ directory is readable") {
+        let path = entry.expect("readable dir entry").path();
+        // Only top-level `*.rs` files. The harness itself lives in
+        // `tests/common/` (a subdirectory, skipped by the extension filter).
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
+        // This guard names the raw patterns in string literals; skip itself.
+        if file_name == "cli_test_harness_guard.rs" {
+            continue;
+        }
+
+        let src = fs::read_to_string(&path).expect("test source is readable");
+        if src.contains(OPT_OUT_MARKER) {
+            continue;
+        }
+
+        let hits: Vec<usize> = src
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| RAW_PATTERNS.iter().any(|p| line.contains(p)))
+            .map(|(i, _)| i + 1)
+            .collect();
+
+        if !hits.is_empty() {
+            violations.push(format!(
+                "  {file_name}: line(s) {hits:?} construct the binary directly"
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "integration tests must launch `upskill` via `common::upskill_cmd` \
+         (fake $HOME), not a raw `Command::cargo_bin(\"upskill\")`:\n{}\n\n\
+         Fix: route the command through `common::upskill_cmd(&fake_home)`. If a \
+         file legitimately needs raw construction (e.g. it tests global scope \
+         and controls HOME/USERPROFILE itself), add a comment containing \
+         `{OPT_OUT_MARKER}: <reason>`.",
+        violations.join("\n"),
+    );
+}

--- a/tests/cli_update_bundle.rs
+++ b/tests/cli_update_bundle.rs
@@ -10,7 +10,8 @@
 //! network is involved, and pin every command to `--project` scope so the
 //! consumer tempdir is the only lockfile touched (never the real `$HOME`).
 
-use assert_cmd::Command;
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -41,9 +42,17 @@ fn setup_registry(registry: &Path) -> PathBuf {
     bundle
 }
 
+/// Fake `$HOME` for a consumer: a `home/` subdir inside the consumer tempdir.
+/// Commands are `--project`-scoped, so this is purely the belt-and-suspenders
+/// safety net that keeps any stray global write out of the real `$HOME`.
+fn fake_home(consumer: &Path) -> PathBuf {
+    let home = consumer.join("home");
+    fs::create_dir_all(&home).unwrap();
+    home
+}
+
 fn add_bundle(consumer: &Path, bundle: &Path) {
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&fake_home(consumer))
         .current_dir(consumer)
         .args(["add", bundle.to_str().unwrap(), "--project"])
         .assert()
@@ -58,8 +67,7 @@ fn update_dry_run_does_not_report_bundle_items_as_removed() {
 
     add_bundle(consumer.path(), &bundle);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&fake_home(consumer.path()))
         .current_dir(consumer.path())
         .args(["update", "--dry-run", "--project"])
         .assert()
@@ -84,8 +92,7 @@ fn update_dry_run_named_bundle_item_is_not_removed() {
 
     add_bundle(consumer.path(), &bundle);
 
-    let assert = Command::cargo_bin("upskill")
-        .unwrap()
+    let assert = common::upskill_cmd(&fake_home(consumer.path()))
         .current_dir(consumer.path())
         .args(["update", "--dry-run", "--project", "alpha"])
         .assert()
@@ -107,8 +114,7 @@ fn update_apply_does_not_delete_bundle_items() {
     add_bundle(consumer.path(), &bundle);
 
     // A real (apply) update must reinstall the bundle, not delete its items.
-    Command::cargo_bin("upskill")
-        .unwrap()
+    common::upskill_cmd(&fake_home(consumer.path()))
         .current_dir(consumer.path())
         .args(["update", "--yes", "--project"])
         .assert()


### PR DESCRIPTION
## Summary

Closes #202.

Integration tests must launch the binary through `common::upskill_cmd`, which points `HOME`/`USERPROFILE` at a tempdir. A raw `Command::cargo_bin("upskill")` silently writes into the developer's real `$HOME` because `add` defaults to global scope outside a git repo — this bit twice (#193, #199). The convention was opt-in; this PR makes it a hard CI gate.

## Changes

- **Add `tests/cli_test_harness_guard.rs`** — scans every top-level `tests/*.rs` and fails if it constructs the binary directly. Files that must control `HOME` themselves opt out with an `upskill-allow-raw-cargo-bin: <reason>` comment.
- **Convert `cli_conflict.rs` and `cli_update_bundle.rs`** to `common::upskill_cmd` — these were genuinely at risk (no `HOME` override).
- **Mark `cli_global_scope.rs` exempt** — it sets/unsets `HOME`/`USERPROFILE` itself to test global scope and the fallback/error paths, so it cannot route through the harness (which always sets both).
- **Update AGENTS.md** testing guidance to the harness pattern.

## Verification (TDD)

1. Wrote the guard first; confirmed RED — it flagged `cli_conflict.rs`, `cli_update_bundle.rs`, `cli_global_scope.rs`.
2. Converted the two at-risk files + marked the legit one; guard now GREEN.
3. `just verify` (full test suite + fmt/dprint/markdownlint/shellcheck/build) and `cargo clippy --all-targets -- -D warnings` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
