### PR TITLE
fix(generate): match percent-encoded resource links; harden walkers (#203)

### DIFF
--- a/src/generate/link_rewrite.rs
+++ b/src/generate/link_rewrite.rs
@@ -31,11 +31,15 @@ pub fn rewrite_resource_links(
     // (absolute byte range of the destination token, replacement string).
     let mut edits: Vec<(Range<usize>, String)> = Vec::new();
 
+    // A single parse serves both passes: `OffsetIter` exposes the reference
+    // definitions gathered during construction, and yields the inline link
+    // and image events when iterated.
+    let parser = Parser::new_ext(rendered, Options::empty()).into_offset_iter();
+
     // Reference definitions (`[id]: dest "title"`) are consumed during the
     // initial scan and are not emitted as link events, so collect them
     // separately. `RefDef.span` covers the whole definition line.
-    let ref_parser = Parser::new_ext(rendered, Options::empty());
-    for (_label, def) in ref_parser.reference_definitions().iter() {
+    for (_label, def) in parser.reference_definitions().iter() {
         if let Some(new_dest) = rewritten_dest(&def.dest, name, copied)
             && let Some(off) = locate_dest(&rendered[def.span.clone()], &def.dest, true)
         {
@@ -45,8 +49,7 @@ pub fn rewrite_resource_links(
     }
 
     // Inline links and images.
-    let parser = Parser::new_ext(rendered, Options::empty());
-    for (event, range) in parser.into_offset_iter() {
+    for (event, range) in parser {
         let dest = match &event {
             Event::Start(Tag::Link { dest_url, .. })
             | Event::Start(Tag::Image { dest_url, .. }) => dest_url.to_string(),
@@ -102,13 +105,19 @@ fn rewritten_dest(dest: &str, name: &str, copied: &HashSet<PathBuf>) -> Option<S
         return None;
     }
     let normalized = path_part.strip_prefix("./").unwrap_or(path_part);
-    if Path::new(normalized)
+    // pulldown-cmark does not percent-decode `dest_url`, so a link like
+    // `[n](my%20notes.md)` arrives literally. Decode for the path-semantic
+    // checks below (parent-escape guard and `copied` membership, which holds
+    // real decoded filenames) while keeping the original encoded text for
+    // the rewritten output so the on-disk link stays valid.
+    let decoded = percent_decode(normalized);
+    if Path::new(&decoded)
         .components()
         .any(|c| matches!(c, Component::ParentDir))
     {
         return None;
     }
-    if !copied.contains(&PathBuf::from(normalized)) {
+    if !copied.contains(&PathBuf::from(&decoded)) {
         return None;
     }
     let prefixed = if path_part.starts_with("./") {
@@ -120,6 +129,33 @@ fn rewritten_dest(dest: &str, name: &str, copied: &HashSet<PathBuf>) -> Option<S
         Some(f) => format!("{prefixed}#{f}"),
         None => prefixed,
     })
+}
+
+/// Best-effort percent-decoding of a link-destination path. Each valid
+/// `%XX` escape becomes its byte; a malformed escape or a decoded byte
+/// sequence that is not UTF-8 is left verbatim. Used only to compare a
+/// destination against `copied` (which stores real, decoded filenames) —
+/// never to build output.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (
+                (bytes[i + 1] as char).to_digit(16),
+                (bytes[i + 2] as char).to_digit(16),
+            )
+        {
+            out.push((hi * 16 + lo) as u8);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| s.to_string())
 }
 
 /// True for `scheme:` URLs (`https:`, `mailto:`, …). A relative file path
@@ -210,6 +246,43 @@ mod tests {
     #[test]
     fn leaves_parent_escape_untouched() {
         let body = "[x](../other/gate.sh)";
+        assert_eq!(run(body, &["other/gate.sh"]), body);
+    }
+
+    #[test]
+    fn rewrites_percent_encoded_link() {
+        // pulldown does not percent-decode `dest_url`, so `my%20notes.md`
+        // must be decoded to match the copied resource `my notes.md`. The
+        // rewritten destination keeps the original encoding.
+        assert_eq!(
+            run("See [n](my%20notes.md).", &["my notes.md"]),
+            "See [n](demo/my%20notes.md)."
+        );
+    }
+
+    #[test]
+    fn rewrites_percent_encoded_link_with_dot_slash() {
+        assert_eq!(
+            run("![d](./a%20b/c.png)", &["a b/c.png"]),
+            "![d](./demo/a%20b/c.png)"
+        );
+    }
+
+    #[test]
+    fn rewrites_percent_encoded_reference_definition() {
+        let body = "Use [n][r].\n\n[r]: my%20notes.md\n";
+        assert_eq!(
+            run(body, &["my notes.md"]),
+            "Use [n][r].\n\n[r]: demo/my%20notes.md\n"
+        );
+    }
+
+    #[test]
+    fn leaves_percent_encoded_parent_escape_untouched() {
+        // `..%2Fgate.sh` decodes to `../gate.sh`: the parent-escape guard
+        // must reject it rather than rewrite a path that climbs out of the
+        // item directory.
+        let body = "[x](..%2Fother%2Fgate.sh)";
         assert_eq!(run(body, &["other/gate.sh"]), body);
     }
 

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -22,6 +22,10 @@ pub enum Client {
 }
 
 impl Client {
+    /// Every client, in declaration order. Single source of truth for code
+    /// that must enumerate clients (e.g. `ALL_CLIENTS`, override detection).
+    pub const ALL: [Client; 3] = [Self::Claude, Self::Copilot, Self::OpenCode];
+
     pub fn name(self) -> &'static str {
         match self {
             Client::Claude => "claude",

--- a/src/pipeline/discovery.rs
+++ b/src/pipeline/discovery.rs
@@ -12,6 +12,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::ItemKind;
+use crate::generate::Client;
 use crate::parse::frontmatter;
 
 /// Effective identity name for an item (§2.1). Skills always take the
@@ -301,20 +302,40 @@ pub(super) fn iter_item_dirs(kind_root: &Path) -> Result<Vec<(String, PathBuf)>>
 /// Recursive; sub-directory structure is preserved in the returned
 /// relative paths. Sorted for deterministic output.
 pub(super) fn iter_item_resources(dir: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    collect_resource_files(dir, dir, &mut out);
+    let mut out: Vec<PathBuf> = walk_files(dir)
+        .into_iter()
+        .filter(|path| {
+            // Entrypoints and override files only ever sit at the top level
+            // of an item directory; a nested file with the same name is
+            // content.
+            let top_level = path.parent() == Some(dir);
+            let fname = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+            !(top_level && is_entrypoint_or_override(fname))
+        })
+        .filter_map(|path| path.strip_prefix(dir).ok().map(Path::to_path_buf))
+        .collect();
     out.sort();
     out
 }
 
-fn collect_resource_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
+/// Every non-symlink regular file under `dir`, recursively. Symlinks (file
+/// and directory) are skipped so a directory-symlink cycle cannot drive
+/// unbounded recursion and a symlinked file cannot smuggle content from
+/// outside `dir`. Order is filesystem-dependent; callers that need
+/// determinism sort the result. Shared by [`iter_item_resources`] and
+/// `hash::hash_item_dir`.
+pub(super) fn walk_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk_files_into(dir, &mut out);
+    out
+}
+
+fn walk_files_into(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
-        // `file_type()` does not follow symlinks. Skip symlinks entirely so a
-        // directory-symlink cycle cannot cause unbounded recursion, and a
-        // symlinked file cannot smuggle a resource from outside the item dir.
+        // `file_type()` does not follow symlinks.
         let Ok(ft) = entry.file_type() else {
             continue;
         };
@@ -323,18 +344,9 @@ fn collect_resource_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
         }
         let path = entry.path();
         if ft.is_dir() {
-            collect_resource_files(root, &path, out);
-            continue;
-        }
-        // Entrypoints and override files only ever sit at the top level of
-        // an item directory; a nested file with the same name is content.
-        let top_level = path.parent() == Some(root);
-        let fname = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
-        if top_level && is_entrypoint_or_override(fname) {
-            continue;
-        }
-        if let Ok(rel) = path.strip_prefix(root) {
-            out.push(rel.to_path_buf());
+            walk_files_into(&path, out);
+        } else {
+            out.push(path);
         }
     }
 }
@@ -343,9 +355,12 @@ fn is_entrypoint_or_override(fname: &str) -> bool {
     matches!(fname, "SKILL.md" | "RULE.md" | "AGENT.md") || is_override_file(fname)
 }
 
-/// `<KIND>.<client>.md` where KIND ∈ {SKILL,RULE,AGENT} and client ∈
-/// {claude,copilot,opencode}. Anchored to entrypoint stems so an
-/// unrelated file like `notes.claude.md` is NOT treated as an override.
+/// `<KIND>.<client>.md` where KIND is an entrypoint stem (`SKILL`, `RULE`,
+/// `AGENT`) and client is a [`Client`] token (`claude`, `copilot`,
+/// `opencode`). Both lists are derived from the [`ItemKind`] and [`Client`]
+/// enums so a new kind or client is recognised without editing this
+/// function. Anchored to entrypoint stems so an unrelated file like
+/// `notes.claude.md` is NOT treated as an override.
 fn is_override_file(fname: &str) -> bool {
     let Some(stem) = fname.strip_suffix(".md") else {
         return false;
@@ -353,8 +368,10 @@ fn is_override_file(fname: &str) -> bool {
     let mut parts = stem.split('.');
     match (parts.next(), parts.next(), parts.next()) {
         (Some(kind), Some(client), None) => {
-            matches!(kind, "SKILL" | "RULE" | "AGENT")
-                && matches!(client, "claude" | "copilot" | "opencode")
+            ItemKind::ALL
+                .iter()
+                .any(|k| k.entrypoint_filename().strip_suffix(".md") == Some(kind))
+                && Client::ALL.iter().any(|c| c.name() == client)
         }
         _ => false,
     }
@@ -572,5 +589,35 @@ mod tests {
             !res.iter().any(|p| p.to_string_lossy().contains("loop")),
             "the symlinked directory must be skipped, not traversed: {res:?}"
         );
+    }
+
+    #[test]
+    fn is_override_file_matches_every_kind_and_client() {
+        // Derived from `ItemKind::ALL` × `Client::ALL`: every combination of
+        // entrypoint stem and client token is an override file.
+        for kind in ItemKind::ALL {
+            let stem = kind.entrypoint_filename().strip_suffix(".md").unwrap();
+            for client in Client::ALL {
+                let fname = format!("{stem}.{}.md", client.name());
+                assert!(is_override_file(&fname), "{fname} should be an override");
+            }
+        }
+    }
+
+    #[test]
+    fn is_override_file_rejects_non_overrides() {
+        for fname in [
+            "notes.claude.md",   // unknown stem
+            "SKILL.cursor.md",   // unknown client
+            "SKILL.md",          // entrypoint, not an override
+            "RULE.claude.txt",   // wrong extension
+            "SKILL.claude",      // missing extension
+            "a.SKILL.claude.md", // too many segments
+        ] {
+            assert!(
+                !is_override_file(fname),
+                "{fname} should not be an override"
+            );
+        }
     }
 }

--- a/src/pipeline/hash.rs
+++ b/src/pipeline/hash.rs
@@ -8,12 +8,12 @@
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 
 use super::ItemKind;
-use super::discovery::{find_registry_root, is_bundle_file, iter_item_dirs};
+use super::discovery::{find_registry_root, is_bundle_file, iter_item_dirs, walk_files};
 
 /// SHA-256 hash of every file under `dir`, with each file's path-relative
 /// name folded into the hash so renames register as drift. Recursive,
@@ -21,8 +21,7 @@ use super::discovery::{find_registry_root, is_bundle_file, iter_item_dirs};
 /// unreadable. Used by the pipeline to populate `LockedItem.hash` and by
 /// `doctor` (Phase B3) to detect SSOT drift.
 pub(crate) fn hash_item_dir(dir: &Path) -> Option<String> {
-    let mut files = Vec::new();
-    collect_files(dir, &mut files);
+    let mut files = walk_files(dir);
     if files.is_empty() {
         return None;
     }
@@ -42,29 +41,6 @@ pub(crate) fn hash_item_dir(dir: &Path) -> Option<String> {
             .map(|b| format!("{b:02x}"))
             .collect(),
     )
-}
-
-fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) {
-    let Ok(entries) = fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        // `file_type()` does not follow symlinks; skip them so a directory
-        // symlink cycle cannot drive unbounded recursion (consistent with
-        // `discovery::collect_resource_files`).
-        let Ok(ft) = entry.file_type() else {
-            continue;
-        };
-        if ft.is_symlink() {
-            continue;
-        }
-        let path = entry.path();
-        if ft.is_dir() {
-            collect_files(&path, files);
-        } else {
-            files.push(path);
-        }
-    }
 }
 
 /// Compute the `(kind, name) -> hash` map a source would install,

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -79,6 +79,10 @@ impl std::str::FromStr for ItemKind {
 }
 
 impl ItemKind {
+    /// Every item kind, in declaration order. Single source of truth for
+    /// code that must enumerate kinds (e.g. override-file detection).
+    pub const ALL: [ItemKind; 3] = [Self::Rule, Self::Skill, Self::Agent];
+
     pub fn entrypoint_filename(self) -> &'static str {
         match self {
             Self::Rule => "RULE.md",
@@ -100,7 +104,7 @@ pub struct AddOptions {
     pub excludes: Vec<String>,
 }
 
-const ALL_CLIENTS: [Client; 3] = [Client::Claude, Client::Copilot, Client::OpenCode];
+const ALL_CLIENTS: [Client; 3] = Client::ALL;
 
 /// Flat list of every item name a single bundle declares (in
 /// rule/skill/agent order). Used by `install_with_lockfile` to populate


### PR DESCRIPTION
Closes #203.

Resolves the remaining lower-severity findings (B–E) from the #199 code review (PR #201). Items A and F were already closed on the issue (A fixed independently, F a misdiagnosis).

## Changes

- **B (fix)** — `rewritten_dest` now percent-decodes a link destination before testing it against the copied-resource set, so `[n](my%20notes.md)` matches a resource named `my notes.md` and is rewritten. pulldown-cmark does not decode `dest_url`, so without this the link was left pointing at a non-existent path. The decoded path also feeds the parent-escape guard, rejecting `..%2F` smuggling. The rewritten output keeps the original encoding so the on-disk link stays valid.
- **C (refactor)** — `rewrite_resource_links` parsed the rendered body twice. pulldown 0.11's `OffsetIter` exposes `reference_definitions()`, so a single parse now serves both the reference-definition pass and the inline link/image pass.
- **D (refactor)** — `discovery::collect_resource_files` and `hash::collect_files` duplicated the symlink-skipping recursive walk. Extracted a shared `discovery::walk_files` helper used by both `iter_item_resources` and `hash_item_dir`.
- **E (refactor)** — `is_override_file` hardcoded the `{SKILL,RULE,AGENT}` / `{claude,copilot,opencode}` lists. It now derives them from new `ItemKind::ALL` and `Client::ALL` consts, so a new kind or client is recognised without editing the function. `ALL_CLIENTS` is now defined as `Client::ALL`.

## Tests

- New: 4 percent-encoded link cases (space-encoded inline link, dot-slash image, reference definition, `..%2F` escape rejection) in `link_rewrite`.
- New: `is_override_file` direct unit tests covering every `ItemKind::ALL × Client::ALL` combination plus negative cases.
- Existing `link_rewrite`, `iter_item_resources`, and hash tests cover the C/D refactors (behavior-preserving).
- `just verify` green: 356 lib tests pass, clippy/fmt/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
