### PR TITLE
feat(pipeline): support --as aliasing for items with supporting resources (#200)

### DIFF
--- a/src/generate/link_rewrite.rs
+++ b/src/generate/link_rewrite.rs
@@ -27,7 +27,39 @@ pub fn rewrite_resource_links(
     if copied.is_empty() {
         return Ok(rendered.to_string());
     }
+    Ok(apply_dest_edits(rendered, |dest| {
+        rewritten_dest(dest, name, copied)
+    }))
+}
 
+/// Re-prefix already-namespaced resource links from `<old_name>/` to
+/// `<new_name>/`. Used when an item that ships supporting resources is
+/// relocated by `--as`: its resource directory moves from `<old_name>/` to
+/// `<new_name>/`, so the entrypoint links — which a prior
+/// [`rewrite_resource_links`] pass pointed at `<old_name>/` — must follow.
+/// `copied` holds the resource paths relative to the (relocated) resource
+/// directory; only destinations whose remainder resolves to one of them are
+/// rewritten, so a coincidental `<old_name>/…` link that is not a resource is
+/// left intact.
+pub fn reprefix_resource_links(
+    rendered: &str,
+    old_name: &str,
+    new_name: &str,
+    copied: &HashSet<PathBuf>,
+) -> Result<String> {
+    if copied.is_empty() || old_name == new_name {
+        return Ok(rendered.to_string());
+    }
+    Ok(apply_dest_edits(rendered, |dest| {
+        reprefixed_dest(dest, old_name, new_name, copied)
+    }))
+}
+
+/// Scan `rendered` for link, image, and reference-definition destinations,
+/// ask `remap` for each one's replacement, and splice the accepted
+/// replacements in. Inline-code and fenced-code spans are reported by
+/// pulldown-cmark as non-link events, so they never reach `remap`.
+fn apply_dest_edits(rendered: &str, remap: impl Fn(&str) -> Option<String>) -> String {
     // (absolute byte range of the destination token, replacement string).
     let mut edits: Vec<(Range<usize>, String)> = Vec::new();
 
@@ -40,7 +72,7 @@ pub fn rewrite_resource_links(
     // initial scan and are not emitted as link events, so collect them
     // separately. `RefDef.span` covers the whole definition line.
     for (_label, def) in parser.reference_definitions().iter() {
-        if let Some(new_dest) = rewritten_dest(&def.dest, name, copied)
+        if let Some(new_dest) = remap(&def.dest)
             && let Some(off) = locate_dest(&rendered[def.span.clone()], &def.dest, true)
         {
             let abs = def.span.start + off;
@@ -55,7 +87,7 @@ pub fn rewrite_resource_links(
             | Event::Start(Tag::Image { dest_url, .. }) => dest_url.to_string(),
             _ => continue,
         };
-        if let Some(new_dest) = rewritten_dest(&dest, name, copied)
+        if let Some(new_dest) = remap(&dest)
             && let Some(off) = locate_dest(&rendered[range.clone()], &dest, false)
         {
             let abs = range.start + off;
@@ -69,7 +101,7 @@ pub fn rewrite_resource_links(
     for (range, replacement) in edits {
         out.replace_range(range, &replacement);
     }
-    Ok(out)
+    out
 }
 
 /// Byte offset of the destination within a link or reference-definition
@@ -156,6 +188,54 @@ fn percent_decode(s: &str) -> String {
         }
     }
     String::from_utf8(out).unwrap_or_else(|_| s.to_string())
+}
+
+/// Returns `Some(new_dest)` when `dest` is a relative path (optionally with a
+/// `#fragment`) already namespaced under `old_name/` whose remainder is a
+/// copied resource, with the leading `old_name/` segment swapped for
+/// `new_name/`; else `None`. The `/` after `old_name` is required, so a
+/// sibling prefix like `old_name-2/…` is not mistaken for a match.
+fn reprefixed_dest(
+    dest: &str,
+    old_name: &str,
+    new_name: &str,
+    copied: &HashSet<PathBuf>,
+) -> Option<String> {
+    let (path_part, frag) = match dest.split_once('#') {
+        Some((p, f)) => (p, Some(f)),
+        None => (dest, None),
+    };
+    if path_part.is_empty() || has_scheme(path_part) || path_part.starts_with('/') {
+        return None;
+    }
+    let had_dot_slash = path_part.starts_with("./");
+    let normalized = path_part.strip_prefix("./").unwrap_or(path_part);
+    // Strip the existing `<old_name>/` namespace segment, keeping the encoded
+    // remainder for output. Decode it only for the path-semantic checks below
+    // (parent-escape guard and `copied` membership, which holds real decoded
+    // filenames), mirroring `rewritten_dest`.
+    let rest = normalized
+        .strip_prefix(old_name)
+        .and_then(|r| r.strip_prefix('/'))?;
+    let decoded = percent_decode(rest);
+    if Path::new(&decoded)
+        .components()
+        .any(|c| matches!(c, Component::ParentDir))
+    {
+        return None;
+    }
+    if !copied.contains(&PathBuf::from(&decoded)) {
+        return None;
+    }
+    let prefixed = if had_dot_slash {
+        format!("./{new_name}/{rest}")
+    } else {
+        format!("{new_name}/{rest}")
+    };
+    Some(match frag {
+        Some(f) => format!("{prefixed}#{f}"),
+        None => prefixed,
+    })
 }
 
 /// True for `scheme:` URLs (`https:`, `mailto:`, …). A relative file path
@@ -352,6 +432,69 @@ mod tests {
                 &["scripts/gate.sh"]
             ),
             "[g]: demo/scripts/gate.sh \"scripts/gate.sh\"\n"
+        );
+    }
+
+    fn reprefix(body: &str, paths: &[&str]) -> String {
+        reprefix_resource_links(body, "demo", "renamed", &copied(paths)).unwrap()
+    }
+
+    #[test]
+    fn reprefix_swaps_namespaced_segment() {
+        assert_eq!(
+            reprefix("See [g](./demo/scripts/gate.sh).", &["scripts/gate.sh"]),
+            "See [g](./renamed/scripts/gate.sh)."
+        );
+    }
+
+    #[test]
+    fn reprefix_without_dot_slash() {
+        assert_eq!(
+            reprefix("[g](demo/scripts/gate.sh)", &["scripts/gate.sh"]),
+            "[g](renamed/scripts/gate.sh)"
+        );
+    }
+
+    #[test]
+    fn reprefix_preserves_fragment() {
+        assert_eq!(
+            reprefix("[p](./demo/refs/p.md#sec)", &["refs/p.md"]),
+            "[p](./renamed/refs/p.md#sec)"
+        );
+    }
+
+    #[test]
+    fn reprefix_percent_encoded_remainder() {
+        // The namespaced remainder is percent-decoded to match the copied
+        // resource `my notes.md`; the rewritten destination keeps the encoding.
+        assert_eq!(
+            reprefix("[n](./demo/my%20notes.md)", &["my notes.md"]),
+            "[n](./renamed/my%20notes.md)"
+        );
+    }
+
+    #[test]
+    fn reprefix_leaves_non_resource_coincidence_untouched() {
+        // `demo/other.md` is namespaced under `demo/` but is not a copied
+        // resource, so re-prefixing must not touch it.
+        let body = "[x](./demo/other.md)";
+        assert_eq!(reprefix(body, &["scripts/gate.sh"]), body);
+    }
+
+    #[test]
+    fn reprefix_leaves_sibling_prefix_untouched() {
+        // `demo-2/` shares a textual prefix with `demo` but is a different
+        // namespace segment; the required `/` boundary protects it.
+        let body = "[x](./demo-2/scripts/gate.sh)";
+        assert_eq!(reprefix(body, &["scripts/gate.sh"]), body);
+    }
+
+    #[test]
+    fn reprefix_identity_when_names_equal() {
+        let body = "[g](./demo/scripts/gate.sh)";
+        assert_eq!(
+            reprefix_resource_links(body, "demo", "demo", &copied(&["scripts/gate.sh"])).unwrap(),
+            body
         );
     }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -120,18 +120,79 @@ fn bundle_item_names(bundle: &crate::model::Bundle) -> Vec<String> {
     out
 }
 
-/// Replace the item name component in an output path.
-/// E.g., `.claude/skills/foo/SKILL.md` → `.claude/skills/bar/SKILL.md`
-fn rename_output_path(path: &Path, old_name: &str, new_name: &str) -> PathBuf {
-    path.iter()
-        .map(|component| {
-            if component == old_name {
-                std::ffi::OsStr::new(new_name)
-            } else {
-                component
-            }
-        })
-        .collect()
+/// Move a file or directory from `from` to `to`, creating `to`'s parent
+/// directory first and replacing any stale destination. A no-op when `from`
+/// does not exist, or when `from` and `to` are the same path.
+///
+/// Replacing the destination matters on `update` / re-add: the fresh install
+/// writes under the item's original name and then relocates to the alias, so
+/// a prior aliased install can still be sitting at `to`. A plain `fs::rename`
+/// of a directory onto a non-empty directory fails ("Directory not empty"),
+/// so the stale destination is removed first.
+fn relocate(from: &Path, to: &Path) -> Result<()> {
+    if !from.exists() || from == to {
+        return Ok(());
+    }
+    if let Some(parent) = to.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
+    }
+    if to.is_dir() {
+        let _ = fs::remove_dir_all(to);
+    } else if to.exists() {
+        let _ = fs::remove_file(to);
+    }
+    fs::rename(from, to).with_context(|| format!("rename {} to {}", from.display(), to.display()))
+}
+
+/// Relocate one already-installed per-client output from its original name to
+/// `alias`, including any supporting resources (format-spec §2.4).
+///
+/// - **Directory-backed** kinds (all skills, opencode rules) keep the
+///   entrypoint and resources together in `resource_base_path`, so the whole
+///   directory is moved. Their links are not namespaced — no rewrite.
+/// - **Flat** kinds (Claude/Copilot rules, all agents) keep the entrypoint
+///   file beside a sibling `<name>/` resource namespace dir. The entrypoint
+///   file and the namespace dir are moved, then the entrypoint's namespaced
+///   links are re-prefixed from `<orig>/` to `<alias>/`.
+///
+/// Returns the new output path (relative to `target`) for the entrypoint.
+fn relocate_aliased_output(
+    target: &Path,
+    item: &report::InstalledItem,
+    alias: &str,
+) -> Result<PathBuf> {
+    let (kind, client, orig) = (item.kind, item.client, item.name.as_str());
+    let new_output = output::output_path(kind, client, alias);
+
+    if output::is_dir_backed(kind, client) {
+        // Entrypoint + resources share one directory; move it wholesale.
+        let old_base = target.join(output::resource_base_path(kind, client, orig));
+        let new_base = target.join(output::resource_base_path(kind, client, alias));
+        relocate(&old_base, &new_base)?;
+        return Ok(new_output);
+    }
+
+    // Flat kind: move the entrypoint file, then its resource namespace dir.
+    relocate(&target.join(&item.output_path), &target.join(&new_output))?;
+    let old_base = target.join(output::resource_base_path(kind, client, orig));
+    if old_base.is_dir() {
+        let new_base = target.join(output::resource_base_path(kind, client, alias));
+        relocate(&old_base, &new_base)?;
+        // Re-prefix the entrypoint's namespaced links to the moved dir.
+        let copied: std::collections::HashSet<PathBuf> = discovery::iter_item_resources(&new_base)
+            .into_iter()
+            .collect();
+        let entry = target.join(&new_output);
+        let body =
+            fs::read_to_string(&entry).with_context(|| format!("read {}", entry.display()))?;
+        let rewritten =
+            crate::generate::link_rewrite::reprefix_resource_links(&body, orig, alias, &copied)
+                .with_context(|| format!("re-prefix resource links for {alias} ({client:?})"))?;
+        if rewritten != body {
+            fs::write(&entry, rewritten).with_context(|| format!("write {}", entry.display()))?;
+        }
+    }
+    Ok(new_output)
 }
 
 /// Install + write lockfile. Consumer-facing entry point.
@@ -170,29 +231,6 @@ pub fn install_with_lockfile(
                  Use --as <original>=<alias> syntax to alias specific items.",
                 unique_names.len()
             );
-        }
-    }
-
-    // -- Guard: aliasing an item that ships supporting resources is not yet
-    // supported (the resource namespace dir and rewritten `<name>/` link
-    // prefix would not be relocated to the alias). Tracked as debt; abort
-    // before writing rather than emit broken output.
-    // Skip for bundle-file sources: `local_source` is then a file, not a
-    // directory, so `iter_item_dirs` would error. Bundle-sourced aliasing of
-    // resource-bearing items is covered by the same debt follow-up (#200).
-    if !options.aliases.is_empty() && !discovery::is_bundle_file(&local_source) {
-        for (name, dir) in discovery::iter_item_dirs(&local_source)? {
-            let aliased = options
-                .aliases
-                .iter()
-                .any(|(from, _)| from.is_empty() || *from == name);
-            if aliased && !discovery::iter_item_resources(&dir).is_empty() {
-                anyhow::bail!(
-                    "aliasing items with supporting resources is not yet supported \
-                     ('{name}' ships resource files). Install it without --as. \
-                     (See format-spec §2.4; tracked in #200.)"
-                );
-            }
         }
     }
 
@@ -334,7 +372,8 @@ pub fn install_with_lockfile(
     let mut aliased_names: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
     if !options.aliases.is_empty() {
-        // Rename output files on disk and update report items.
+        // Relocate output files (and any supporting resources) on disk and
+        // update report items.
         for item in &mut report.items {
             // Only entry-source items are aliasable; dependency-pulled
             // (cross-source) items are never renamed. When there is no
@@ -353,23 +392,7 @@ pub fn install_with_lockfile(
                 None
             };
             if let Some((_, alias_name)) = alias {
-                let old_path = target.join(&item.output_path);
-                let new_output = rename_output_path(&item.output_path, &item.name, alias_name);
-                let new_path = target.join(&new_output);
-
-                if old_path.exists() {
-                    if let Some(parent) = new_path.parent() {
-                        fs::create_dir_all(parent)?;
-                    }
-                    fs::rename(&old_path, &new_path).with_context(|| {
-                        format!("rename {} to {}", old_path.display(), new_path.display())
-                    })?;
-                    // Clean up empty parent directory
-                    if let Some(parent) = old_path.parent() {
-                        let _ = fs::remove_dir(parent);
-                    }
-                }
-
+                let new_output = relocate_aliased_output(target, item, alias_name)?;
                 aliased_names
                     .entry(alias_name.clone())
                     .or_insert_with(|| item.name.clone());

--- a/tests/cli_resources.rs
+++ b/tests/cli_resources.rs
@@ -1,6 +1,7 @@
 //! Integration coverage for format-spec §2.4 supporting-resource copying
 //! (#199): resources travel with each rendered entrypoint; flat-kind
-//! bodies are link-rewritten; remove/update reconcile; `--as` is guarded.
+//! bodies are link-rewritten; remove/update reconcile; `--as` relocates the
+//! resource directory and re-prefixes namespaced links (#200).
 
 mod common;
 
@@ -288,26 +289,186 @@ fn update_removes_stale_resource_after_source_deletes_it() {
 }
 
 #[test]
-fn alias_on_resource_item_is_rejected() {
+fn alias_relocates_dir_backed_skill_resources() {
+    // Dir-backed kinds (all skills, opencode rules): the resource directory
+    // IS the entrypoint's own `<name>/` dir, so `--as` must move the whole
+    // directory to `<alias>/`. Links are not namespaced, so they are intact.
     let e = env();
     write_item(
         &e.src,
         "demo-skill",
         "SKILL.md",
-        "## X\n\n[g](./scripts/gate.sh)\n",
+        "## X\n\nRun [gate](./scripts/gate.sh). See [notes](./references/notes.md).\n",
     );
 
     e.cmd()
         .args(["add", e.src.to_str().unwrap(), "--as", "renamed"])
         .assert()
-        .failure()
-        .stderr(predicates::str::contains(
-            "aliasing items with supporting resources is not yet supported",
-        ));
+        .success();
 
-    // Nothing written.
-    assert!(!e.proj.join(".claude/skills/renamed").exists());
-    assert!(!e.proj.join(".claude/skills/demo-skill").exists());
+    for base in [".claude/skills", ".github/skills", ".agents/skills"] {
+        let aliased = e.proj.join(base).join("renamed");
+        assert!(
+            aliased.join("SKILL.md").is_file(),
+            "{base}: entrypoint moved"
+        );
+        assert!(
+            aliased.join("scripts/gate.sh").is_file(),
+            "{base}: script relocated"
+        );
+        assert!(
+            aliased.join("references/notes.md").is_file(),
+            "{base}: ref relocated"
+        );
+        assert!(
+            read(&aliased.join("SKILL.md")).contains("(./scripts/gate.sh)"),
+            "{base}: dir-backed link must NOT be rewritten"
+        );
+        assert!(
+            !e.proj.join(base).join("demo-skill").exists(),
+            "{base}: original directory must be gone"
+        );
+    }
+}
+
+#[test]
+fn alias_relocates_and_reprefixes_flat_rule_resources() {
+    // Flat kinds (Claude/Copilot rules) keep resources in a sibling
+    // `<name>/` namespace dir and namespace their links into it. `--as` must
+    // move the entrypoint file, move the namespace dir, and re-prefix the
+    // links from `<orig>/` to `<alias>/`. opencode rules are dir-backed.
+    let e = env();
+    write_item(
+        &e.src,
+        "demo-rule",
+        "RULE.md",
+        "## Gate\n\nRun [the gate](./scripts/gate.sh) in CI.\n",
+    );
+
+    e.cmd()
+        .args(["add", e.src.to_str().unwrap(), "--as", "renamed"])
+        .assert()
+        .success();
+
+    // Claude: flat entrypoint moved, namespace dir moved, link re-prefixed.
+    let claude_md = e.proj.join(".claude/rules/renamed.md");
+    assert!(claude_md.is_file(), "claude entrypoint renamed");
+    assert!(
+        e.proj
+            .join(".claude/rules/renamed/scripts/gate.sh")
+            .is_file(),
+        "claude resource relocated to aliased namespace dir"
+    );
+    assert!(
+        read(&claude_md).contains("(./renamed/scripts/gate.sh)"),
+        "claude rule link must be re-prefixed to the aliased namespace dir"
+    );
+    assert!(!e.proj.join(".claude/rules/demo-rule.md").exists());
+    assert!(!e.proj.join(".claude/rules/demo-rule").exists());
+
+    // Copilot: same flat shape under .github/instructions/.
+    let copilot_md = e.proj.join(".github/instructions/renamed.instructions.md");
+    assert!(copilot_md.is_file());
+    assert!(
+        e.proj
+            .join(".github/instructions/renamed/scripts/gate.sh")
+            .is_file()
+    );
+    assert!(read(&copilot_md).contains("(./renamed/scripts/gate.sh)"));
+    assert!(
+        !e.proj
+            .join(".github/instructions/demo-rule.instructions.md")
+            .exists()
+    );
+
+    // opencode: directory-backed — whole dir moved, link unchanged.
+    let oc = e.proj.join(".agents/rules/renamed");
+    assert!(oc.join("scripts/gate.sh").is_file());
+    assert!(read(&oc.join("RULE.md")).contains("(./scripts/gate.sh)"));
+    assert!(!e.proj.join(".agents/rules/demo-rule").exists());
+}
+
+#[test]
+fn alias_relocates_and_reprefixes_flat_agent_resources() {
+    // Agents are flat on every client.
+    let e = env();
+    write_item(
+        &e.src,
+        "demo-agent",
+        "AGENT.md",
+        "## Agent\n\nUses [gate](./scripts/gate.sh).\n",
+    );
+
+    e.cmd()
+        .args(["add", e.src.to_str().unwrap(), "--as", "renamed"])
+        .assert()
+        .success();
+
+    for (entry, dir, orig_entry) in [
+        (
+            ".claude/agents/renamed.md",
+            ".claude/agents/renamed",
+            ".claude/agents/demo-agent.md",
+        ),
+        (
+            ".github/agents/renamed.agent.md",
+            ".github/agents/renamed",
+            ".github/agents/demo-agent.agent.md",
+        ),
+        (
+            ".opencode/agents/renamed.md",
+            ".opencode/agents/renamed",
+            ".opencode/agents/demo-agent.md",
+        ),
+    ] {
+        assert!(
+            e.proj.join(dir).join("scripts/gate.sh").is_file(),
+            "{dir}: resource relocated"
+        );
+        assert!(
+            read(&e.proj.join(entry)).contains("(./renamed/scripts/gate.sh)"),
+            "{entry}: agent link re-prefixed"
+        );
+        assert!(!e.proj.join(orig_entry).exists(), "{orig_entry}: gone");
+    }
+}
+
+#[test]
+fn update_relocates_aliased_resource_item() {
+    // Regression for the `update` deadlock noted on #200: `update` rebuilds
+    // the alias from the lockfile and re-runs the install. A resource-bearing
+    // aliased item must update cleanly, staying at its alias.
+    let e = env();
+    write_item(
+        &e.src,
+        "demo-rule",
+        "RULE.md",
+        "## Gate\n\nRun [the gate](./scripts/gate.sh) in CI.\n",
+    );
+
+    e.cmd()
+        .args(["add", e.src.to_str().unwrap(), "--as", "renamed"])
+        .assert()
+        .success();
+
+    e.cmd().args(["update"]).assert().success();
+
+    let claude_md = e.proj.join(".claude/rules/renamed.md");
+    assert!(
+        claude_md.is_file(),
+        "still installed at the alias after update"
+    );
+    assert!(
+        e.proj
+            .join(".claude/rules/renamed/scripts/gate.sh")
+            .is_file(),
+        "resource still relocated after update"
+    );
+    assert!(
+        read(&claude_md).contains("(./renamed/scripts/gate.sh)"),
+        "link still re-prefixed after update"
+    );
+    assert!(!e.proj.join(".claude/rules/demo-rule.md").exists());
 }
 
 #[test]


### PR DESCRIPTION
Closes #200.

## What

`upskill add --as <alias>` previously aborted with a pre-flight guard whenever the target item shipped supporting resources (format-spec §2.4). This implements proper relocation and drops the guard.

While fixing it, a second, broader bug surfaced: the old post-hoc alias step (`rename_output_path`) renamed a path *component* matching the bare item name. That only ever matched dir-backed kinds (skill dir, opencode rule). For flat kinds the entrypoint filename is `<name>.md` / `<name>.instructions.md` — never a bare `<name>` component — so **flat-kind entrypoint aliasing was already silently broken**: the file stayed at the original name while the lockfile recorded the alias.

## How

- Replace `rename_output_path` with `relocate_aliased_output`, deriving both endpoints from the typed `output_path` / `resource_base_path` functions:
  - **Directory-backed** kinds (all skills, opencode rules): move the whole directory, carrying entrypoint + resources together. Links are not namespaced — no rewrite.
  - **Flat** kinds (Claude/Copilot rules, all agents): move the entrypoint file and its sibling `<name>/` resource namespace dir, then re-prefix the entrypoint's namespaced links from `<orig>/` to `<alias>/`.
- Add `link_rewrite::reprefix_resource_links` (the namespaced-link counterpart to `rewrite_resource_links`, sharing a new `apply_dest_edits` helper). Only links whose remainder resolves to an actual relocated resource are touched, so a coincidental `<orig>/…` literal is left intact.
- `relocate` replaces any stale destination, which also fixes the **`update` deadlock** noted on the issue: `update` rebuilds the alias from the lockfile and re-installs under the original name before relocating, so a prior aliased install can still sit at the destination (a plain dir rename onto a non-empty dir fails).
- Drop the pre-flight guard in `install_with_lockfile`.

## Tests

- `tests/cli_resources.rs`: replaced the rejection test with relocation coverage for dir-backed skills, flat rules (with re-prefix), flat agents, and an `update` regression test.
- `src/generate/link_rewrite.rs`: unit tests for `reprefix_resource_links` (swap, fragment preservation, non-resource coincidence left intact, sibling-prefix boundary, identity).
- Manual end-to-end: add `--as` → `doctor: clean` → `remove` leaves no orphan files.

`just verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
