### PR TITLE
refactor(skills): rename upskill-using skill to upskill-cli

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ Use the skill tool to load a skill when a task matches its description.
 </skill>
 <skill>
 <name>upskill-prompt-design</name>
-<description>Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, upskill-writing-subagents, or upskill-using.</description>
+<description>Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, upskill-writing-subagents, or upskill-cli.</description>
 <location>skills/upskill-prompt-design/SKILL.md</location>
 </skill>
 <skill>
@@ -208,9 +208,9 @@ Use the skill tool to load a skill when a task matches its description.
 <location>skills/upskill-prompt-distilling/SKILL.md</location>
 </skill>
 <skill>
-<name>upskill-using</name>
+<name>upskill-cli</name>
 <description>Use when working in an upskill-consumer repo and needing to add, modify, vendor, audit, or remove installed content (rules, skills, agents, bundles). Trigger when `upskill lint` or `upskill doctor` reports issues. Trigger when adding a third-party bundle or updating one from upstream. Trigger when generated per-client files (e.g., `.claude/`, `.github/skills/`) look stale or wrong. Do NOT trigger for actual authoring decisions — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, or upskill-writing-subagents. Do NOT trigger for cosmetic typo fixes in skill bodies; raw edits to source registry files plus `upskill lint` are sufficient.</description>
-<location>skills/upskill-using/SKILL.md</location>
+<location>skills/upskill-cli/SKILL.md</location>
 </skill>
 <skill>
 <name>upskill-writing-rules</name>

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,14 +27,14 @@ skills/
 │   └── SKILL.md
 ├── upskill-writing-bundles/        .bundle.yaml authoring + plugin declarations
 │   └── SKILL.md
-└── upskill-using/                  lifecycle operations
+└── upskill-cli/                  lifecycle operations
     └── SKILL.md
 ```
 
 ## Status
 
 All skills are v0.1.0 except `upskill-prompt-distilling` (v0.3.0, renamed from
-`picking-the-layer`) and `upskill-using` (v0.2.0, rewritten against the
+`picking-the-layer`) and `upskill-cli` (v0.2.0, rewritten against the
 real CLI surface). None have yet been through their own
 RED-GREEN-REFACTOR cycle. Each carries an "Honest caveats" section
 flagging this.
@@ -96,7 +96,7 @@ registry directory and pass the item name as a filter:
 upskill add ./skills upskill-prompt-design   # just the umbrella skill
 ```
 
-See `upskill-using/SKILL.md` for the full lifecycle.
+See `upskill-cli/SKILL.md` for the full lifecycle.
 
 ## Recommended adoption sequence
 

--- a/skills/prompt-engineering.bundle.yaml
+++ b/skills/prompt-engineering.bundle.yaml
@@ -16,7 +16,7 @@ items:
     - upskill-writing-rules # authoring: always-loaded invariants
     - upskill-writing-subagents # authoring: bounded sub-task delegation
     - upskill-evaluating-prompts # eval: RED-GREEN-REFACTOR
-    - upskill-using # ops: add / update / audit
+    - upskill-cli # ops: add / update / audit
     - upskill-writing-bundles # authoring: .bundle.yaml manifests + plugins
 
 # Client-native plugins required by this bundle's skills.

--- a/skills/upskill-cli/SKILL.md
+++ b/skills/upskill-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 schema: 1
-name: upskill-using
+name: upskill-cli
 description: Use when working in an upskill-consumer repo and needing to add, modify, vendor, audit, or remove installed content (rules, skills, agents, bundles). Trigger when `upskill lint` or `upskill doctor` reports issues. Trigger when adding a third-party bundle or updating one from upstream. Trigger when generated per-client files (e.g., `.claude/`, `.github/skills/`) look stale or wrong. Do NOT trigger for actual authoring decisions — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, or upskill-writing-subagents. Do NOT trigger for cosmetic typo fixes in skill bodies; raw edits to source registry files plus `upskill lint` are sufficient.
 metadata:
   version: 0.2.0
@@ -41,7 +41,7 @@ SKILLS FOR AUTHORING DECISIONS.
 
 This Iron Law is a routing law, not a discipline law (no "NO X
 WITHOUT Y FIRST" shape like the other meta-skills), because
-`upskill-using` governs which tool to reach for, not whether to
+`upskill-cli` governs which tool to reach for, not whether to
 pressure-test content before shipping it.
 
 The boundary is sharp. upskill handles fetching, frontmatter

--- a/skills/upskill-evaluating-prompts/SKILL.md
+++ b/skills/upskill-evaluating-prompts/SKILL.md
@@ -316,7 +316,7 @@ methodology has.
 This skill has not yet been put through its own RED-GREEN-REFACTOR
 cycle. The most natural way to evaluate it is to use it to evaluate
 the existing meta-skills (`upskill-writing-rules`, `upskill-writing-subagents`,
-`upskill-using`) — if the methodology produces actionable results
+`upskill-cli`) — if the methodology produces actionable results
 when applied to those four, this skill earns its slot. If authors
 end up evaluating prompts the same way regardless of whether this
 skill is present, the skill itself is unjustified.

--- a/skills/upskill-prompt-design/SKILL.md
+++ b/skills/upskill-prompt-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 schema: 1
 name: upskill-prompt-design
-description: Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, upskill-writing-subagents, or upskill-using.
+description: Use as the entry point to the upskill framework's prompt-engineering discipline. Trigger when someone is new to the framework, when an author is not sure which meta-skill to activate, when reviewing how a team is using rules/skills/subagents, or when cross-cutting concerns (portability across clients, classification, token economics, composition patterns) come up. Do NOT trigger for general one-shot prompt-writing guidance — that is an onboarding concern outside the framework. Do NOT trigger for specific authoring tasks — hand off to upskill-prompt-distilling, upskill-writing-rules, writing-skills, upskill-writing-subagents, or upskill-cli.
 metadata:
   version: 0.1.0
   author: driftsys
@@ -40,7 +40,7 @@ processes.
 | "I know it's a rule, how do I write it well"                               | `upskill-writing-rules`                                  |
 | "I know it's a skill, how do I write it well"                              | `superpowers:writing-skills`                             |
 | "I know it's a subagent, how do I write it well"                           | `upskill-writing-subagents`                              |
-| "I need to run upskill commands / vendor a bundle / audit content"         | `upskill-using`                                          |
+| "I need to run upskill commands / vendor a bundle / audit content"         | `upskill-cli`                                            |
 | "I need to set up the RED-GREEN-REFACTOR cycle for something I authored"   | `upskill-evaluating-prompts`                             |
 | "I want to write an MCP server"                                            | `mcp-builder` (vendored) — out of upskill's direct scope |
 | "I want to write good one-shot prompts to send to Claude Code"             | Not this framework — see onboarding doc                  |
@@ -126,7 +126,7 @@ per-client files in the consumer project at install time.
 registries; `upskill doctor` verifies installed state against
 `.upskill-lock.json`. Generated per-client files are never hand-edited
 — drift is silent. Vendored bundles (like `superpowers`) carry NOTICE
-files and attribution. `upskill-using` covers the workflows.
+files and attribution. `upskill-cli` covers the workflows.
 
 ## Symptoms that suggest framework-level problems
 
@@ -143,7 +143,7 @@ diagnosis:
 - "The subagent's output is bigger than what the parent would have
   done inline" → return-contract failure. Activate `upskill-writing-subagents`.
 - "We added a rule and now every interaction feels slower" → token
-  budget exceeded. Activate `upskill-using` (`doctor`) and
+  budget exceeded. Activate `upskill-cli` (`doctor`) and
   `upskill-prompt-distilling` (the content may not deserve to be a rule).
 - "Different teams handle the same situation differently" →
   cross-cutting convention without a home. Route via

--- a/skills/upskill-writing-bundles/SKILL.md
+++ b/skills/upskill-writing-bundles/SKILL.md
@@ -25,7 +25,7 @@ dependencies.
 - Authoring individual skill content → `writing-skills`
 - Authoring rules → `upskill-writing-rules`
 - Authoring subagents → `upskill-writing-subagents`
-- Lifecycle operations (add/update/remove) → `upskill-using`
+- Lifecycle operations (add/update/remove) → `upskill-cli`
 
 ## Bundle YAML Schema
 


### PR DESCRIPTION
## What

Renames the `upskill-using` meta-skill to **`upskill-cli`**.

`upskill-using` was just the mechanical re-prefix of the old `using-upskill` name (#220) and reads awkwardly — "using" carries no meaning once the `upskill-` namespace prefix is applied. This skill is the lifecycle / CLI-operations skill (`add`/`update`/`remove`/`list`/`doctor`/`lint`/`fmt`/`new`), so `upskill-cli` names it for what it does and pairs cleanly against the authoring skills (`upskill-writing-*`).

## Changes

- Move `skills/upskill-using/` → `skills/upskill-cli/` and update the `name:` field (skills require `name:` == directory name).
- Update every reference:
  - `skills/prompt-engineering.bundle.yaml` (bundle item list)
  - sibling skills' cross-references: `upskill-writing-bundles`, `upskill-prompt-design`, `upskill-evaluating-prompts`
  - `skills/README.md`
  - `AGENTS.md` available-skills list

## Docs

No published mdBook (`docs/`) page referenced the skill by name, so no `docs/` changes are needed. The doc-like surfaces that did reference it (README, AGENTS.md, cross-refs) are all updated.

## Verification

- `upskill lint skills` → 8 files checked, **0 findings**.
- `upskill fmt skills` clean; diff is purely the rename (15 insertions / 15 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
