### PR TITLE
fix(plugin): use marketplace name for claude/copilot install ref (#227)

### DIFF
--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -472,6 +472,7 @@ plugins:
   superpowers:
     claude:
       source: anthropics/claude-plugins
+      marketplace: claude-plugins
       plugin: superpowers
 
 metadata:
@@ -534,10 +535,12 @@ plugins:
   superpowers:
     claude:
       source: anthropics/claude-plugins
+      marketplace: claude-plugins
       plugin: superpowers
       install_url: https://github.com/obra/superpowers#install
     copilot:
       source: obra/superpowers-marketplace
+      marketplace: superpowers-marketplace
       plugin: superpowers
       install_url: https://github.com/obra/superpowers#install
     vscode:
@@ -550,18 +553,29 @@ plugins:
 
 **Per-client descriptor fields:**
 
-| Client     | Field         | Type   | Required | Description                                                      |
-| ---------- | ------------- | ------ | -------- | ---------------------------------------------------------------- |
-| `claude`   | `source`      | string | YES      | Marketplace source (passed to `claude plugin marketplace add`).  |
-| `claude`   | `plugin`      | string | YES      | Plugin identifier (passed to `claude plugin install`).           |
-| `claude`   | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.               |
-| `copilot`  | `source`      | string | YES      | Marketplace source (passed to `copilot plugin marketplace add`). |
-| `copilot`  | `plugin`      | string | YES      | Plugin identifier (passed to `copilot plugin install`).          |
-| `copilot`  | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.               |
-| `vscode`   | `extension`   | string | YES      | Extension ID (passed to `code --install-extension`).             |
-| `vscode`   | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.               |
-| `opencode` | `module`      | string | YES      | Module name (passed to `opencode plugin`).                       |
-| `opencode` | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.               |
+| Client     | Field         | Type   | Required | Description                                                                                            |
+| ---------- | ------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------ |
+| `claude`   | `source`      | string | YES      | Marketplace source (passed to `claude plugin marketplace add`): `owner/repo`, URL, or path.            |
+| `claude`   | `marketplace` | string | YES      | Marketplace **name** for the install ref `<plugin>@<marketplace>`. Distinct from `source` (see below). |
+| `claude`   | `plugin`      | string | YES      | Plugin identifier (passed to `claude plugin install`).                                                 |
+| `claude`   | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.                                                     |
+| `copilot`  | `source`      | string | YES      | Marketplace source (passed to `copilot plugin marketplace add`).                                       |
+| `copilot`  | `marketplace` | string | YES      | Marketplace **name** for the install ref `<plugin>@<marketplace>`. Distinct from `source`.             |
+| `copilot`  | `plugin`      | string | YES      | Plugin identifier (passed to `copilot plugin install`).                                                |
+| `copilot`  | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.                                                     |
+| `vscode`   | `extension`   | string | YES      | Extension ID (passed to `code --install-extension`).                                                   |
+| `vscode`   | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.                                                     |
+| `opencode` | `module`      | string | YES      | Module name (passed to `opencode plugin`).                                                             |
+| `opencode` | `install_url` | string | no       | URL shown in warn-skip message when CLI not found.                                                     |
+
+`source` and `marketplace` are **distinct** and both required for the `claude`/`copilot`
+auto-install form. `source` is what `marketplace add` consumes (`owner/repo`, a URL, or a
+path); `marketplace` is the registered marketplace **name** the CLI requires in the install
+ref `<plugin>@<marketplace>`. The CLI derives the name from the marketplace's manifest, so it
+generally differs from `source` — e.g. source `anthropics/claude-plugins` registers a
+marketplace named `claude-plugins`, and the plugin installs as `superpowers@claude-plugins`.
+Installing with `<plugin>@<source>` fails (`Plugin not found in marketplace <source>`), so the
+name MUST be supplied explicitly rather than inferred from `source`.
 
 A plugin entry MAY declare any subset of client blocks. A plugin that only exists for Claude
 Code carries only a `claude:` block; clients without a matching block skip installation
@@ -572,11 +586,11 @@ silently.
 A client block MAY use one of these alternative forms instead of the standard
 auto-install form. The mode is determined by which required field is present:
 
-| Mode              | Discriminating fields                      | Available for | Behavior                               |
-| ----------------- | ------------------------------------------ | ------------- | -------------------------------------- |
-| Auto-install      | `source`+`plugin` / `extension` / `module` | all clients   | Shell out to client CLI                |
-| Instructions-only | `instructions_url`                         | all clients   | Print info notice; no automated action |
-| Config-write      | `plugin_uri`                               | opencode only | Write URI to project `opencode.json`   |
+| Mode              | Discriminating fields                                    | Available for | Behavior                               |
+| ----------------- | -------------------------------------------------------- | ------------- | -------------------------------------- |
+| Auto-install      | `source`+`marketplace`+`plugin` / `extension` / `module` | all clients   | Shell out to client CLI                |
+| Instructions-only | `instructions_url`                                       | all clients   | Print info notice; no automated action |
+| Config-write      | `plugin_uri`                                             | opencode only | Write URI to project `opencode.json`   |
 
 **Instructions-only form:**
 
@@ -617,12 +631,12 @@ descriptors.
 
 **Install behavior:**
 
-| Client   | CLI commands                                                                                             |
-| -------- | -------------------------------------------------------------------------------------------------------- |
-| claude   | `claude plugin marketplace add <source>`, then `claude plugin install <plugin>@<source> --scope <scope>` |
-| copilot  | `copilot plugin marketplace add <source>`, then `copilot plugin install <plugin>@<source>`               |
-| vscode   | `code --install-extension <extension>`                                                                   |
-| opencode | `opencode plugin <module>`                                                                               |
+| Client   | CLI commands                                                                                                  |
+| -------- | ------------------------------------------------------------------------------------------------------------- |
+| claude   | `claude plugin marketplace add <source>`, then `claude plugin install <plugin>@<marketplace> --scope <scope>` |
+| copilot  | `copilot plugin marketplace add <source>`, then `copilot plugin install <plugin>@<marketplace>`               |
+| vscode   | `code --install-extension <extension>`                                                                        |
+| opencode | `opencode plugin <module>`                                                                                    |
 
 Claude's `--scope` derives from upskill's project/global context:
 

--- a/skills/prompt-engineering.bundle.yaml
+++ b/skills/prompt-engineering.bundle.yaml
@@ -23,7 +23,8 @@ items:
 plugins:
   superpowers:
     claude:
-      source: superpowers-dev
+      source: anthropics/claude-plugins-official
+      marketplace: claude-plugins-official
       plugin: superpowers
       install_url: https://github.com/obra/superpowers#install
     opencode:

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -893,7 +893,8 @@ mod tests {
             "plugins:\n",
             "  superpowers:\n",
             "    claude:\n",
-            "      source: marketplace\n",
+            "      source: anthropics/claude-plugins\n",
+            "      marketplace: claude-plugins\n",
             "      plugin: superpowers\n",
         );
         let out = canonicalise(raw, Path::new("test.bundle.yaml")).unwrap();

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -113,8 +113,14 @@ pub struct PluginEntry {
 pub enum ClaudePluginDescriptor {
     /// Install via `claude plugin marketplace add` + `claude plugin install`.
     Install {
-        /// Marketplace source (passed to `claude plugin marketplace add`).
+        /// Marketplace source (passed to `claude plugin marketplace add`):
+        /// `owner/repo`, a URL, or a path.
         source: String,
+        /// Marketplace name used in the install ref `<plugin>@<marketplace>`.
+        /// `claude` derives this name from the marketplace manifest, so it is
+        /// distinct from `source` (e.g. source `anthropics/claude-plugins`,
+        /// marketplace `claude-plugins`).
+        marketplace: String,
         /// Plugin identifier (passed to `claude plugin install`).
         plugin: String,
         /// URL shown in warn-skip message when CLI not found.
@@ -137,8 +143,13 @@ pub enum ClaudePluginDescriptor {
 pub enum CopilotPluginDescriptor {
     /// Install via `copilot plugin marketplace add` + `copilot plugin install`.
     Install {
-        /// Marketplace source (passed to `copilot plugin marketplace add`).
+        /// Marketplace source (passed to `copilot plugin marketplace add`):
+        /// `owner/repo`, a URL, or a path.
         source: String,
+        /// Marketplace name used in the install ref `<plugin>@<marketplace>`,
+        /// distinct from `source` (the CLI derives the name from the
+        /// marketplace manifest).
+        marketplace: String,
         /// Plugin identifier (passed to `copilot plugin install`).
         plugin: String,
         /// URL shown in warn-skip message when CLI not found.

--- a/src/parse/bundle.rs
+++ b/src/parse/bundle.rs
@@ -411,10 +411,12 @@ plugins:
   superpowers:
     claude:
       source: anthropics/claude-plugins
+      marketplace: claude-plugins
       plugin: superpowers
       install_url: https://github.com/obra/superpowers#install
     copilot:
       source: obra/superpowers-marketplace
+      marketplace: superpowers-marketplace
       plugin: superpowers
       install_url: https://github.com/obra/superpowers#install
     vscode:
@@ -435,10 +437,12 @@ plugins:
         match claude {
             ClaudePluginDescriptor::Install {
                 source,
+                marketplace,
                 plugin,
                 install_url,
             } => {
                 assert_eq!(source, "anthropics/claude-plugins");
+                assert_eq!(marketplace, "claude-plugins");
                 assert_eq!(plugin, "superpowers");
                 assert_eq!(
                     install_url.as_deref(),
@@ -452,10 +456,12 @@ plugins:
         match copilot {
             CopilotPluginDescriptor::Install {
                 source,
+                marketplace,
                 plugin,
                 install_url,
             } => {
                 assert_eq!(source, "obra/superpowers-marketplace");
+                assert_eq!(marketplace, "superpowers-marketplace");
                 assert_eq!(plugin, "superpowers");
                 assert_eq!(
                     install_url.as_deref(),
@@ -510,6 +516,7 @@ plugins:
   my-plugin:
     claude:
       source: my-org/marketplace
+      marketplace: marketplace
       plugin: my-plugin
 ";
         let tmp = tempfile::tempdir().unwrap();
@@ -522,6 +529,31 @@ plugins:
         assert!(plugin.claude.is_some());
         assert!(plugin.vscode.is_none());
         assert!(plugin.opencode.is_none());
+    }
+
+    #[test]
+    fn load_rejects_claude_plugin_without_marketplace() {
+        // A claude auto-install descriptor with `source`+`plugin` but no
+        // `marketplace` is invalid: the CLI's install ref needs the
+        // marketplace NAME, which is distinct from the source (#227).
+        let content = "schema: 1
+name: missing-marketplace
+description: Claude plugin missing the marketplace name
+items:
+  rules: []
+plugins:
+  superpowers:
+    claude:
+      source: anthropics/claude-plugins
+      plugin: superpowers
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "missing-marketplace.bundle.yaml", content);
+
+        assert!(
+            load(&path).is_err(),
+            "claude Install descriptor without `marketplace` must be rejected"
+        );
     }
 
     #[test]

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -464,11 +464,17 @@ pub(super) fn install_plugins_from_bundles(
                 match claude {
                     ClaudePluginDescriptor::Install {
                         source,
+                        marketplace,
                         plugin,
                         install_url,
                     } => {
-                        let outcome = crate::plugin::install_claude_plugin(source, plugin, scope);
-                        let identifier = format!("{plugin}@{source}");
+                        let outcome = crate::plugin::install_claude_plugin(
+                            source,
+                            marketplace,
+                            plugin,
+                            scope,
+                        );
+                        let identifier = format!("{plugin}@{marketplace}");
                         results.push(PluginResult {
                             name: plugin_name.clone(),
                             client: "claude".into(),
@@ -594,11 +600,13 @@ pub(super) fn install_plugins_from_bundles(
                 match copilot {
                     CopilotPluginDescriptor::Install {
                         source,
+                        marketplace,
                         plugin,
                         install_url,
                     } => {
-                        let outcome = crate::plugin::install_copilot_plugin(source, plugin);
-                        let identifier = format!("{plugin}@{source}");
+                        let outcome =
+                            crate::plugin::install_copilot_plugin(source, marketplace, plugin);
+                        let identifier = format!("{plugin}@{marketplace}");
                         results.push(PluginResult {
                             name: plugin_name.clone(),
                             client: "copilot".into(),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -72,7 +72,17 @@ impl PluginOutcome {
 
 /// Install a Claude Code plugin via `claude plugin marketplace add` followed
 /// by `claude plugin install`. The marketplace-add step is idempotent.
-pub fn install_claude_plugin(source: &str, plugin: &str, scope: PluginScope) -> PluginOutcome {
+///
+/// `source` is the `owner/repo`/URL/path passed to `marketplace add`;
+/// `marketplace` is the marketplace **name** the CLI requires in the install
+/// ref `<plugin>@<marketplace>` (the CLI derives the name from the marketplace
+/// manifest, so it differs from `source`).
+pub fn install_claude_plugin(
+    source: &str,
+    marketplace: &str,
+    plugin: &str,
+    scope: PluginScope,
+) -> PluginOutcome {
     // Step 1: Add marketplace source (idempotent).
     let result = run_command("claude", &["plugin", "marketplace", "add", source]);
     match result {
@@ -82,8 +92,9 @@ pub fn install_claude_plugin(source: &str, plugin: &str, scope: PluginScope) -> 
         PluginOutcome::ManualInstructions => unreachable!(),
     }
 
-    // Step 2: Install plugin with scope.
-    let install_ref = format!("{plugin}@{source}");
+    // Step 2: Install plugin with scope. The install ref uses the marketplace
+    // NAME, not the source — `claude plugin install` resolves `<plugin>@<name>`.
+    let install_ref = format!("{plugin}@{marketplace}");
     run_command(
         "claude",
         &[
@@ -109,7 +120,7 @@ pub fn install_opencode_plugin(module: &str) -> PluginOutcome {
 /// Install a GitHub Copilot CLI plugin via `copilot plugin marketplace add`
 /// followed by `copilot plugin install`. The marketplace-add step is
 /// idempotent. Unlike Claude, Copilot CLI does not support a `--scope` flag.
-pub fn install_copilot_plugin(source: &str, plugin: &str) -> PluginOutcome {
+pub fn install_copilot_plugin(source: &str, marketplace: &str, plugin: &str) -> PluginOutcome {
     // Step 1: Add marketplace source (idempotent).
     let result = run_command("copilot", &["plugin", "marketplace", "add", source]);
     match result {
@@ -119,8 +130,9 @@ pub fn install_copilot_plugin(source: &str, plugin: &str) -> PluginOutcome {
         PluginOutcome::ManualInstructions => unreachable!(),
     }
 
-    // Step 2: Install plugin from marketplace.
-    let install_ref = format!("{plugin}@{source}");
+    // Step 2: Install plugin from marketplace. The install ref uses the
+    // marketplace NAME, not the source.
+    let install_ref = format!("{plugin}@{marketplace}");
     run_command("copilot", &["plugin", "install", &install_ref])
 }
 
@@ -128,9 +140,14 @@ pub fn install_copilot_plugin(source: &str, plugin: &str) -> PluginOutcome {
 // Uninstall functions
 // ---------------------------------------------------------------------------
 
-/// Uninstall a Claude Code plugin.
-pub fn uninstall_claude_plugin(plugin: &str, source: &str, scope: PluginScope) -> PluginOutcome {
-    let install_ref = format!("{plugin}@{source}");
+/// Uninstall a Claude Code plugin. `marketplace` is the marketplace name used
+/// in the install ref `<plugin>@<marketplace>` (see [`install_claude_plugin`]).
+pub fn uninstall_claude_plugin(
+    plugin: &str,
+    marketplace: &str,
+    scope: PluginScope,
+) -> PluginOutcome {
+    let install_ref = format!("{plugin}@{marketplace}");
     run_command(
         "claude",
         &[
@@ -153,9 +170,10 @@ pub fn uninstall_opencode_plugin(module: &str) -> PluginOutcome {
     run_command("opencode", &["plugin", "remove", module])
 }
 
-/// Uninstall a GitHub Copilot CLI plugin.
-pub fn uninstall_copilot_plugin(plugin: &str, source: &str) -> PluginOutcome {
-    let install_ref = format!("{plugin}@{source}");
+/// Uninstall a GitHub Copilot CLI plugin. `marketplace` is the marketplace
+/// name used in the install ref `<plugin>@<marketplace>`.
+pub fn uninstall_copilot_plugin(plugin: &str, marketplace: &str) -> PluginOutcome {
+    let install_ref = format!("{plugin}@{marketplace}");
     run_command("copilot", &["plugin", "uninstall", &install_ref])
 }
 

--- a/tests/fixtures/bundles/with-plugins.bundle.yaml
+++ b/tests/fixtures/bundles/with-plugins.bundle.yaml
@@ -11,10 +11,12 @@ plugins:
   superpowers:
     claude:
       source: anthropics/claude-plugins
+      marketplace: claude-plugins
       plugin: superpowers
       install_url: https://github.com/obra/superpowers#install
     copilot:
       source: obra/superpowers-marketplace
+      marketplace: superpowers-marketplace
       plugin: superpowers
       install_url: https://github.com/obra/superpowers#install
     vscode:

--- a/tests/parse_bundles.rs
+++ b/tests/parse_bundles.rs
@@ -69,10 +69,12 @@ fn with_plugins_declares_client_native_plugins() {
     match claude {
         ClaudePluginDescriptor::Install {
             source,
+            marketplace,
             plugin,
             install_url,
         } => {
             assert_eq!(source, "anthropics/claude-plugins");
+            assert_eq!(marketplace, "claude-plugins");
             assert_eq!(plugin, "superpowers");
             assert_eq!(
                 install_url.as_deref(),

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -435,10 +435,10 @@ fn plugin_results_carry_correct_metadata() {
         .find(|r| r.client == "claude")
         .expect("claude result");
     assert_eq!(claude_result.name, "superpowers");
-    assert_eq!(
-        claude_result.identifier,
-        "superpowers@anthropics/claude-plugins"
-    );
+    // Identifier uses the marketplace NAME (`claude-plugins`), not the source
+    // (`anthropics/claude-plugins`) — `claude plugin install` requires
+    // `<plugin>@<marketplace>` (#227).
+    assert_eq!(claude_result.identifier, "superpowers@claude-plugins");
     assert_eq!(claude_result.bundle, "with-plugins");
     assert_eq!(
         claude_result.install_url.as_deref(),
@@ -460,9 +460,10 @@ fn plugin_results_carry_correct_metadata() {
         .find(|r| r.client == "copilot")
         .expect("copilot result");
     assert_eq!(copilot_result.name, "superpowers");
+    // Marketplace name (`superpowers-marketplace`), not source.
     assert_eq!(
         copilot_result.identifier,
-        "superpowers@obra/superpowers-marketplace"
+        "superpowers@superpowers-marketplace"
     );
     assert_eq!(copilot_result.bundle, "with-plugins");
     assert_eq!(


### PR DESCRIPTION
Fixes #227.

## Problem

`upskill add` failed to install Claude/Copilot plugins declared by a bundle. The installer ran `<cli> plugin marketplace add <source>` then `<cli> plugin install <plugin>@<source>` — reusing the marketplace **source** (`owner/repo`) as the install ref. But the CLI requires the marketplace **name** there, which it derives from the marketplace manifest and is distinct from the source:

```
claude plugin install superpowers@claude-plugins            → ok
claude plugin install superpowers@anthropics/claude-plugins → "Plugin not found in marketplace anthropics/claude-plugins"
```

A single `source` field can't satisfy both `marketplace add` (wants `owner/repo`) and `install` (wants the name). The shipped `prompt-engineering` bundle compounded this with an outright-invalid `source: superpowers-dev`.

## Fix (Option B — explicit field)

- **Schema** ([`src/model/bundle.rs`](https://github.com/driftsys/upskill/blob/main/src/model/bundle.rs)): `ClaudePluginDescriptor::Install` and `CopilotPluginDescriptor::Install` gain a **required** `marketplace: String`.
- **Installer** ([`src/plugin.rs`](https://github.com/driftsys/upskill/blob/main/src/plugin.rs)): `marketplace add` still uses `source`; the install/uninstall ref is now `<plugin>@<marketplace>`.
- **Pipeline** ([`src/pipeline/install.rs`](https://github.com/driftsys/upskill/blob/main/src/pipeline/install.rs)): the lockfile `identifier` becomes `<plugin>@<marketplace>`.
- **Spec** (`format-spec.md §3.7`): documents the new field and the source-vs-name distinction.
- **Manifest** (`skills/prompt-engineering.bundle.yaml`): `source: anthropics/claude-plugins-official` + `marketplace: claude-plugins-official` (verified: `superpowers@claude-plugins-official` installs).

## Tests

- Parser: asserts `marketplace` is parsed, and a **claude `Install` without `marketplace` is rejected** (new negative test).
- Pipeline: asserts the lockfile identifier uses the marketplace name (`superpowers@claude-plugins`), not the source.
- Fixture + inline test YAML updated.

`just verify` green (clippy, fmt, dprint, markdownlint, shellcheck, full test suite).

## Note

Required-field change is breaking for any existing bundle that declared a claude/copilot plugin with only `source`+`plugin` (pre-1.0, no back-compat shim — such a bundle was already non-functional). The only in-repo bundle is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
