### PR TITLE
feat(source): support GitLab subgroup paths in install sources

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,6 +43,7 @@ upskill add owner/repo@main                         # pin to branch
 upskill add owner/repo@abc123                       # pin to commit SHA
 upskill add gitlab:owner/repo                       # GitLab.com
 upskill add https://gitlab.example.com/owner/repo   # self-hosted GitLab
+upskill add https://gitlab.example.com/group/subgroup/repo  # GitLab subgroups (any depth)
 upskill add ./path/to/local                         # local directory
 upskill add owner/repo:platform.bundle.yaml         # bundle file (explicit path)
 upskill add owner/repo platform-baseline            # bundle by name (resolves .bundle.yaml)

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -33,7 +33,9 @@ Resolution order:
 | GitLab | `GITLAB_TOKEN` → `GL_TOKEN` → `glab auth token` → unauthenticated |
 
 Self-hosted GitLab is supported via the full URL form
-(`https://gitlab.mycompany.com/team/repo`).
+(`https://gitlab.mycompany.com/team/repo`), including projects nested under
+subgroups to any depth
+(`https://gitlab.mycompany.com/group/subgroup/team/repo`).
 
 ## Pin a source to a specific version
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -76,6 +76,8 @@ upskill add <source> [items...] [--global|--project]
 - `owner/repo@ref:path` — combined
 - `https://github.com/owner/repo[...]` — full HTTPS URL
 - `gitlab:owner/repo[...]` or `https://gitlab.com/[...]` — GitLab
+- `gitlab:group/subgroup[/…]/project[...]` — GitLab subgroups (any nesting
+  depth); the segment before the project is the full namespace path
 - `./path`, `../path`, `/abs/path`, `~/path` — local paths
 
 `upskill add <source>` installs everything the source contains. Optional
@@ -265,7 +267,9 @@ Token resolution order:
 | GitLab | `GITLAB_TOKEN` → `GL_TOKEN` → `glab auth token` → unauthenticated |
 
 Self-hosted GitLab is supported via full URL form
-(`https://gitlab.mycompany.com/team/repo`).
+(`https://gitlab.mycompany.com/team/repo`), including projects nested under
+subgroups to any depth
+(`https://gitlab.mycompany.com/group/subgroup/team/repo`).
 
 ## 6. CLI compliance
 

--- a/src/pipeline/git.rs
+++ b/src/pipeline/git.rs
@@ -259,6 +259,23 @@ mod tests {
     }
 
     #[test]
+    fn gitlab_clone_url_with_subgroups() {
+        // Subgroup namespaces carry slashes in `owner`; the clone URL is the
+        // full path joined to the project name (GitLab clones the whole path).
+        let repo = GitlabRepo {
+            host: "gitlabee.dt.renault.com".into(),
+            owner: "partners/alliance-car/devex/process".into(),
+            name: "seed".into(),
+            git_ref: None,
+            subfolder: None,
+        };
+        assert_eq!(
+            gitlab_clone_url(&repo),
+            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed.git"
+        );
+    }
+
+    #[test]
     fn inject_basic_auth_github_oauth_user() {
         // Mirrors the call install_from_github makes when GITHUB_TOKEN is set.
         let url = inject_basic_auth(

--- a/src/source.rs
+++ b/src/source.rs
@@ -220,16 +220,18 @@ fn parse_gitlab_source(source: &str, host: &str) -> Result<GitlabRepo, SourcePar
         (before_subfolder, None)
     };
 
+    // GitLab nests projects under arbitrarily deep subgroups. Everything
+    // before the last segment is the namespace (`owner`), the last segment is
+    // the project (`name`); cloning joins them back into the full path, so the
+    // split point only matters for the canonical label. At least one namespace
+    // segment is required — a bare project (`project`) has no `/` and is
+    // rejected.
     let (owner, name) = repo_source
-        .split_once('/')
+        .rsplit_once('/')
         .ok_or(SourceParseError::InvalidFormat)?;
 
     if owner.trim().is_empty() || name.trim().is_empty() {
         return Err(SourceParseError::EmptySegment);
-    }
-
-    if repo_source.matches('/').count() != 1 {
-        return Err(SourceParseError::InvalidFormat);
     }
 
     Ok(GitlabRepo {
@@ -578,6 +580,58 @@ mod tests {
         assert_eq!(repo.name, "skills");
     }
 
+    #[test]
+    fn parse_selfhosted_gitlab_subgroup() {
+        // Self-hosted GitLab nests projects under arbitrarily deep
+        // subgroups; the full path before the project is the namespace.
+        let source = parse_install_source(
+            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed",
+        )
+        .expect("must parse");
+        let InstallSource::Gitlab(repo) = source else {
+            panic!("expected Gitlab");
+        };
+        assert_eq!(repo.host, "gitlabee.dt.renault.com");
+        assert_eq!(repo.owner, "partners/alliance-car/devex/process");
+        assert_eq!(repo.name, "seed");
+        assert_eq!(repo.git_ref, None);
+        assert_eq!(repo.subfolder, None);
+    }
+
+    #[test]
+    fn parse_selfhosted_gitlab_subgroup_with_ref_and_subfolder() {
+        let source = parse_install_source(
+            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed@v0.2.0:skills/seed.bundle.yaml",
+        )
+        .expect("must parse");
+        let InstallSource::Gitlab(repo) = source else {
+            panic!("expected Gitlab");
+        };
+        assert_eq!(repo.owner, "partners/alliance-car/devex/process");
+        assert_eq!(repo.name, "seed");
+        assert_eq!(repo.git_ref.as_deref(), Some("v0.2.0"));
+        assert_eq!(repo.subfolder.as_deref(), Some("skills/seed.bundle.yaml"));
+    }
+
+    #[test]
+    fn parse_gitlab_prefix_subgroup() {
+        let source = parse_install_source("gitlab:group/sub/project").expect("must parse");
+        let InstallSource::Gitlab(repo) = source else {
+            panic!("expected Gitlab");
+        };
+        assert_eq!(repo.host, "gitlab.com");
+        assert_eq!(repo.owner, "group/sub");
+        assert_eq!(repo.name, "project");
+    }
+
+    #[test]
+    fn reject_gitlab_bare_project_without_namespace() {
+        // A GitLab source still needs at least one namespace segment before
+        // the project — `project` alone has nowhere to live.
+        let err = parse_install_source("gitlab:project").expect_err("must fail");
+        assert_eq!(err, SourceParseError::InvalidFormat);
+    }
+
     // Lockfile source label round-trip — every shape Display can produce
     // must round-trip through parse_install_source_label so `update` can
     // reconstruct the source from a lockfile entry.
@@ -636,6 +690,17 @@ mod tests {
             name: "rules".into(),
             git_ref: None,
             subfolder: Some("a/b".into()),
+        }));
+    }
+
+    #[test]
+    fn label_roundtrip_gitlab_self_hosted_subgroup() {
+        assert_label_roundtrip(&InstallSource::Gitlab(GitlabRepo {
+            host: "gitlabee.dt.renault.com".into(),
+            owner: "partners/alliance-car/devex/process".into(),
+            name: "seed".into(),
+            git_ref: Some("v0.2.0".into()),
+            subfolder: Some("skills/seed.bundle.yaml".into()),
         }));
     }
 


### PR DESCRIPTION
## Why

GitLab nests projects under arbitrarily deep subgroups, but the source parser required exactly one slash (`owner/repo`). A project like `partners/alliance-car/devex/process/seed` could not be named at all — `upskill add https://gitlab.example.com/group/subgroup/project` errored before any clone.

## What

- `parse_gitlab_source` splits the GitLab namespace from the project on the **last** slash: everything before it is `owner` (the full subgroup path), the last segment is `name`. Cloning rejoins them into the full path, so the split only affects the canonical lockfile label.
- A bare project with no namespace is still rejected. **GitHub remains strictly `owner/repo`.**

## Tests

5 new unit tests (subgroup URL, ref+subfolder, `gitlab:` prefix, label round-trip, clone-URL); full source + git module suites still green. Docs updated (specification, recipes, commands).

## Notes

Unblocks installing from self-hosted GitLab subgroup repos. Pairs with #231 for the cross-org meta-bundle scenario, but is independently useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)