### PR TITLE
feat(bundle): resolve cross-source bundle requires

### DIFF
--- a/docs/adr/0009-coupling-tiers-and-dependencies.md
+++ b/docs/adr/0009-coupling-tiers-and-dependencies.md
@@ -116,6 +116,47 @@ ignore: ["scripts/**", "fixtures/**"]
   are implemented. A cross-source `source` is fetched once and cached for the
   duration of one resolution; the transitive closure may span sources.
 
+### Bundle-level cross-source `requires`
+
+The item-level `requires` above carries directed dependencies between
+**items**. Bundles carry their own `requires` (bundle → bundle composition,
+[format-spec §3.7](../format-spec.md)), and a meta-bundle frequently composes
+bundles that live in **other** sources (e.g. a methodology bundle that pulls a
+generic-literacy bundle and a working-memory bundle from separate repos).
+
+Bundle `requires` entries therefore gain the **same** optional `source` field:
+
+- A bare `{ name }` entry resolves against the requiring bundle's own source.
+- A `{ name, source }` entry resolves cross-source, `source` reusing the
+  `upskill add` DSL verbatim.
+
+The contract mirrors the item-level one, one layer up:
+
+- **Fetch + cache.** Each distinct `source` is fetched once per resolution; the
+  transitive closure may span sources.
+- **Conflict.** The same bundle `name` reached under two different source
+  labels in one closure is an **error**; an item provided by two different
+  bundles is an **error** (the same-source `union_items` rule, extended across
+  sources).
+- **Cycle detection** is keyed by `(canonical-source-label, bundle-name)`.
+- **Provenance.** Each resolved bundle, and each item it contributes, is
+  recorded in the lockfile under its **own** source and ref.
+- **Reuse.** Bundle resolution emits the same per-source item closure the
+  item-level path produces, so install and item-lockfile recording are shared;
+  only per-bundle source recording is bundle-specific.
+
+**Status.** Implemented. Bundle-level cross-source resolution lands with this
+ADR revision and is exercised by `tests/cli_bundle_cross_source.rs`.
+
+**Known narrow limit.** A bundle reached as a `*.bundle.yaml`-**file** entry
+carries the file-path source label, whereas a cross-source edge references the
+same source by its **directory/repo** label; if that exact bundle is also a
+transitive cross-source dependency of itself, the resolver reports a
+"two different sources" error instead of a "cycle" error. Both are correct
+rejections of an illegal graph; only the message differs. Adding a bundle by
+**name** (the common path) uses the directory label throughout and is
+unaffected.
+
 ### Inherent limit
 
 Co-located rules/agents are invisible to standard-only tooling: the Agent

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -499,16 +499,20 @@ documentation; the parser ignores it (§2.2).
 | `metadata`     | map      | no       | Same as §3.6.                        |
 
 `requires` entries are maps. Each entry references another bundle by `name`, optionally pinned
-with a semver `version` constraint:
+with a semver `version` constraint, and optionally located in another source with `source` (the
+`upskill add` source DSL — `owner/repo@ref`, https, `gitlab:`, local). Absent `source` resolves
+the required bundle in the **same** source registry as the requiring bundle:
 
 ```yaml
 requires:
-  - { name: "platform-baseline", version: "^1.0.0" }
-  - { name: "rust-baseline" } # any version
+  - { name: "platform-baseline", version: "^1.0.0" } # same source
+  - { name: "rust-baseline" } # same source, any version
+  - { name: "markspec-core", source: "driftsys/markspec@v0.8.0" } # cross-source
 ```
 
 The single-form (map-only) shape avoids the polymorphic-string-or-map alternative until that
-flexibility has a documented author need.
+flexibility has a documented author need. `source` mirrors the item-level `requires.<kind>`
+cross-source locator (§3.7, ADR-0009).
 
 Implementations:
 
@@ -518,7 +522,11 @@ Implementations:
   its transitive `requires` closure, then unioning the items contributed by all reached
   bundles. Item-level conflicts (the same item name resolving to different sources or versions)
   MUST be reported as errors.
-- MUST reject circular `requires` chains as errors.
+- MUST resolve a `{ name, source }` entry by fetching that source (each distinct source fetched
+  once per resolution) and locating the named bundle in it; the closure MAY span sources. Each
+  bundle and each item is recorded in the lockfile under its **own** source. The same bundle
+  name resolving to two different sources within one closure MUST be reported as an error.
+- MUST reject circular `requires` chains as errors (cycle detection keyed by source and name).
 
 #### `plugins` map
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -155,10 +155,12 @@ Implementation behaviour:
   resolved against the same source repository and installed. Unresolved
   names error out before any write.
 - **Transitive `requires:`.** When the bundle declares `requires:`, every
-  bundle in the transitive closure is resolved against the same source.
-  Cross-source bundle resolution is not supported; bundles and their
-  dependencies must live in one source repository. Circular `requires:`
-  is rejected.
+  bundle in the transitive closure is installed. A bare `{ name }` entry is
+  resolved against the same source; a `{ name, source }` entry is resolved
+  cross-source (`source` reuses the `upskill add` DSL), and the closure MAY
+  span sources. Each bundle and item is recorded in the lockfile under its own
+  source. Circular `requires:` is rejected; the same bundle name resolving to
+  two different sources within one closure is an error.
 - **Lockfile.** Each installed bundle is recorded as a top-level `bundles[]`
   entry in `.upskill-lock.json` alongside its resolved items. The same item
   may appear in multiple bundle `items[]` lists; it is installed once.

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -190,6 +190,7 @@ mod tests {
                 .map(|n| Requires {
                     name: n.to_string(),
                     version: None,
+                    source: None,
                 })
                 .collect(),
             plugins: Default::default(),

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -83,6 +83,12 @@ pub struct Requires {
     /// the resolver to interpret in C2.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Cross-source locator (the `upskill add` source DSL — `owner/repo@ref`,
+    /// https, `gitlab:`, local). Absent means the required bundle is resolved
+    /// in the same source registry as the requiring bundle. Mirrors the
+    /// item-level `RequireRef::Detailed.source` (ADR-0009).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 /// Per-plugin entry in the `plugins:` map. Contains optional descriptors

--- a/src/parse/bundle.rs
+++ b/src/parse/bundle.rs
@@ -230,6 +230,34 @@ requires:
     }
 
     #[test]
+    fn load_parses_requires_with_cross_source() {
+        // A bundle MAY depend on a bundle living in another source via the
+        // `source` field (the `upskill add` DSL). Bare and same-source entries
+        // keep `source: None`.
+        let content = "schema: 1
+name: meta
+description: Meta-bundle composing bundles across sources
+items:
+  rules: []
+requires:
+  - { name: markspec-core, source: \"driftsys/markspec@v0.8.0\" }
+  - { name: local-baseline }
+";
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_file(tmp.path(), "meta.bundle.yaml", content);
+
+        let bundle = load(&path).expect("load");
+        assert_eq!(bundle.requires.len(), 2);
+        assert_eq!(bundle.requires[0].name, "markspec-core");
+        assert_eq!(
+            bundle.requires[0].source.as_deref(),
+            Some("driftsys/markspec@v0.8.0")
+        );
+        assert_eq!(bundle.requires[1].name, "local-baseline");
+        assert_eq!(bundle.requires[1].source, None);
+    }
+
+    #[test]
     fn load_rejects_string_form_requires() {
         // Per §3.7 (post-PR #76): map-only `requires`. Bare strings must
         // fail to deserialize so a future polymorphic shape stays a

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -438,6 +438,284 @@ pub(super) fn resolve_requires_closure(
 }
 
 // ---------------------------------------------------------------------------
+// Bundle-level `requires` transitive closure (cross-source) — ADR-0009
+// ---------------------------------------------------------------------------
+
+/// One resolved bundle tagged with the source it was reached from. Drives the
+/// per-bundle lockfile `bundles[]` recording and plugin/MCP installation.
+#[derive(Debug, Clone)]
+pub(super) struct ResolvedBundle {
+    pub bundle: crate::model::Bundle,
+    pub source_label: String,
+    pub git_ref: Option<String>,
+}
+
+/// A fetched-and-discovered source, cached by canonical label during the
+/// bundle DFS.
+struct FetchedBundleSource {
+    root: PathBuf,
+    git_ref: Option<String>,
+    bundles: BTreeMap<String, crate::model::Bundle>,
+}
+
+/// The `(kind, name)` items a single bundle directly declares.
+fn bundle_item_identities(bundle: &crate::model::Bundle) -> Vec<(ItemKind, String)> {
+    let mut out = Vec::new();
+    out.extend(
+        bundle
+            .items
+            .rules
+            .iter()
+            .map(|n| (ItemKind::Rule, n.clone())),
+    );
+    out.extend(
+        bundle
+            .items
+            .skills
+            .iter()
+            .map(|n| (ItemKind::Skill, n.clone())),
+    );
+    out.extend(
+        bundle
+            .items
+            .agents
+            .iter()
+            .map(|n| (ItemKind::Agent, n.clone())),
+    );
+    out
+}
+
+/// Discover every bundle in `root`, keyed by name. A later bundle with a
+/// duplicate name wins (malformed registry; not expected in practice).
+fn discover_bundles(root: &Path) -> Result<BTreeMap<String, crate::model::Bundle>> {
+    Ok(crate::parse::bundle::discover(root)?
+        .into_iter()
+        .map(|(_, b)| (b.name.clone(), b))
+        .collect())
+}
+
+/// DFS state for the bundle closure. Mirrors [`Resolver`] (item-level) but
+/// walks bundle `requires` edges and accumulates per-source item sets.
+struct BundleResolver {
+    sources: BTreeMap<String, FetchedBundleSource>,
+    guards: Vec<tempfile::TempDir>,
+    /// Bundles fully resolved (dedup), keyed `(label, bundle-name)`.
+    resolved: BTreeSet<(String, String)>,
+    /// The label each bundle name resolved under; a second visit under a
+    /// different label is a cross-source bundle conflict.
+    bundle_label: BTreeMap<String, String>,
+    /// On-path set keyed `(label, bundle-name)` for cycle detection.
+    on_path: BTreeSet<(String, String)>,
+    /// Post-order accumulation (dependencies before dependents).
+    order: Vec<ResolvedBundle>,
+    /// Per source: union of items across reached bundles, in dependency order.
+    items_by_source: BTreeMap<String, crate::bundle::ResolvedItems>,
+    /// Owning `(label, bundle)` of each item identity — a second owner is an
+    /// item conflict (the same-source `union_items` rule, extended across
+    /// sources).
+    item_owner: BTreeMap<(ItemKind, String), (String, String)>,
+    /// Canonical source label each resolved item identity came from.
+    item_source: BTreeMap<(ItemKind, String), String>,
+}
+
+impl BundleResolver {
+    /// Ensure `src_dsl` is fetched and its bundles discovered; return its label.
+    fn ensure_source(&mut self, src_dsl: &str) -> Result<String> {
+        let install_source = parse_install_source(src_dsl)
+            .map_err(|e| anyhow::anyhow!("parse requires source `{src_dsl}`: {e}"))?;
+        let label = install_source.to_string();
+        if !self.sources.contains_key(&label) {
+            let (root, guard) = super::git::fetch_ssot(&install_source)
+                .with_context(|| format!("fetch requires source `{label}`"))?;
+            if let Some(g) = guard {
+                self.guards.push(g);
+            }
+            let bundles = discover_bundles(&root)?;
+            self.sources.insert(
+                label.clone(),
+                FetchedBundleSource {
+                    root,
+                    git_ref: source_git_ref(&install_source),
+                    bundles,
+                },
+            );
+        }
+        Ok(label)
+    }
+
+    fn visit(&mut self, label: &str, name: &str) -> Result<()> {
+        // Cross-source bundle conflict: same bundle name from two sources.
+        if let Some(prev) = self.bundle_label.get(name)
+            && prev != label
+        {
+            anyhow::bail!(
+                "bundle `{name}` is required from two different sources: `{prev}` and `{label}`"
+            );
+        }
+
+        let bundle = self
+            .sources
+            .get(label)
+            .expect("source fetched before visit")
+            .bundles
+            .get(name)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow::anyhow!("bundle `{name}` is required but not found in source `{label}`")
+            })?;
+
+        let path_key = (label.to_string(), name.to_string());
+        if self.resolved.contains(&path_key) {
+            return Ok(());
+        }
+        if self.on_path.contains(&path_key) {
+            anyhow::bail!("bundle dependency cycle detected including `{name}`");
+        }
+        self.on_path.insert(path_key.clone());
+        self.bundle_label
+            .insert(name.to_string(), label.to_string());
+
+        // Accumulate this bundle's items into its source, detecting conflicts.
+        for (kind, item_name) in bundle_item_identities(&bundle) {
+            let id = (kind, item_name.clone());
+            match self.item_owner.get(&id) {
+                Some((ol, ob)) if (ol.as_str(), ob.as_str()) != (label, name) => {
+                    anyhow::bail!(
+                        "item conflict: {kind} `{item_name}` is provided by bundles `{ob}` (`{ol}`) and `{name}` (`{label}`)"
+                    );
+                }
+                Some(_) => {}
+                None => {
+                    self.item_owner
+                        .insert(id.clone(), (label.to_string(), name.to_string()));
+                    self.item_source.insert(id.clone(), label.to_string());
+                    let items = self.items_by_source.entry(label.to_string()).or_default();
+                    match kind {
+                        ItemKind::Rule => items.rules.push(item_name),
+                        ItemKind::Skill => items.skills.push(item_name),
+                        ItemKind::Agent => items.agents.push(item_name),
+                    }
+                }
+            }
+        }
+
+        // Walk requires: bare → same source; `{ name, source }` → cross-source.
+        for req in &bundle.requires {
+            match &req.source {
+                None => self.visit(label, &req.name)?,
+                Some(src_dsl) => {
+                    let dep_label = self.ensure_source(src_dsl)?;
+                    self.visit(&dep_label, &req.name)?;
+                }
+            }
+        }
+
+        self.on_path.remove(&path_key);
+        self.resolved.insert(path_key);
+        let git_ref = self.sources.get(label).and_then(|s| s.git_ref.clone());
+        self.order.push(ResolvedBundle {
+            bundle,
+            source_label: label.to_string(),
+            git_ref,
+        });
+        Ok(())
+    }
+}
+
+/// Resolve the cross-source bundle closure for `entry_bundles` (names present
+/// in the already-fetched entry source). Returns the item-level
+/// [`DependencyClosure`] — so the existing per-source install and item lockfile
+/// machinery is reused verbatim — plus the ordered resolved bundles for
+/// plugin/MCP install and per-bundle lockfile recording.
+pub(super) fn resolve_bundle_closure(
+    entry_label: &str,
+    entry_root: &Path,
+    entry_git_ref: Option<&str>,
+    entry_bundles: &[String],
+) -> Result<(DependencyClosure, Vec<ResolvedBundle>)> {
+    let mut resolver = BundleResolver {
+        sources: BTreeMap::new(),
+        guards: Vec::new(),
+        resolved: BTreeSet::new(),
+        bundle_label: BTreeMap::new(),
+        on_path: BTreeSet::new(),
+        order: Vec::new(),
+        items_by_source: BTreeMap::new(),
+        item_owner: BTreeMap::new(),
+        item_source: BTreeMap::new(),
+    };
+    resolver.sources.insert(
+        entry_label.to_string(),
+        FetchedBundleSource {
+            root: entry_root.to_path_buf(),
+            git_ref: entry_git_ref.map(str::to_string),
+            bundles: discover_bundles(entry_root)?,
+        },
+    );
+
+    for name in entry_bundles {
+        resolver.visit(entry_label, name)?;
+    }
+
+    let mut by_source: BTreeMap<String, SourceInstall> = BTreeMap::new();
+    for (lbl, items) in &resolver.items_by_source {
+        let fs = resolver.sources.get(lbl).expect("source present");
+        by_source.insert(
+            lbl.clone(),
+            SourceInstall {
+                root: fs.root.clone(),
+                git_ref: fs.git_ref.clone(),
+                items: items.clone(),
+            },
+        );
+    }
+    let closure = DependencyClosure {
+        by_source,
+        item_source: resolver.item_source,
+        // Bundle items carry no item-level `required_by`; each bundle's own
+        // lockfile entry records which items it provides.
+        required_by: BTreeMap::new(),
+        guards: resolver.guards,
+    };
+    Ok((closure, resolver.order))
+}
+
+/// Detect a bundle-shaped `add` — a `*.bundle.yaml` source, or positional
+/// `names` that all resolve to bundles — and resolve its cross-source closure.
+/// Returns `None` when the request is not bundle-shaped (the caller keeps the
+/// item-closure / direct-install path), including ambiguous names that match
+/// both an item and a bundle (left to the name-resolution path to report).
+pub(super) fn resolve_bundle_request(
+    label: &str,
+    local_source: &Path,
+    git_ref: Option<&str>,
+    names: &[String],
+) -> Result<Option<(DependencyClosure, Vec<ResolvedBundle>)>> {
+    if is_bundle_file(local_source) {
+        let registry_root = find_registry_root(local_source)?;
+        let entry = crate::parse::bundle::load(local_source)?;
+        return resolve_bundle_closure(
+            label,
+            &registry_root,
+            git_ref,
+            std::slice::from_ref(&entry.name),
+        )
+        .map(Some);
+    }
+    if names.is_empty() {
+        return Ok(None);
+    }
+    let all_bundles = names
+        .iter()
+        .all(|n| find_bundle_by_name(local_source, n).is_some());
+    let any_item = names.iter().any(|n| has_matching_items(local_source, n));
+    if !all_bundles || any_item {
+        return Ok(None);
+    }
+    resolve_bundle_closure(label, local_source, git_ref, names).map(Some)
+}
+
+// ---------------------------------------------------------------------------
 // Plugin installation orchestration (ADR-0008)
 // ---------------------------------------------------------------------------
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -42,8 +42,8 @@ pub use git::{fetch_ssot, install_from_git_url, install_from_source};
 pub(crate) use hash::hash_item_dir;
 pub use install::install_from_local_path;
 use install::{
-    install_mcps_from_bundles, install_plugins_from_bundles,
-    install_with_name_resolution_from_local, resolve_requires_closure,
+    ResolvedBundle, install_mcps_from_bundles, install_plugins_from_bundles,
+    install_with_name_resolution_from_local, resolve_bundle_request, resolve_requires_closure,
 };
 pub use lifecycle::{doctor, list, remove, update};
 pub use report::*;
@@ -267,16 +267,29 @@ pub fn install_with_lockfile(
         InstallSource::Gitlab(r) => r.git_ref.as_deref(),
         InstallSource::LocalPath(_) => None,
     };
-    let closure = if discovery::is_bundle_file(&local_source) || defer_to_name_resolution {
-        None
-    } else {
-        Some(resolve_requires_closure(
-            &label,
-            &local_source,
-            git_ref,
-            &requested,
-        )?)
-    };
+    // A bundle-shaped request (`*.bundle.yaml` source or positional names that
+    // all resolve to bundles) resolves its own — possibly cross-source — bundle
+    // closure (ADR-0009). It produces the same `DependencyClosure` the
+    // item-level path uses, so the install + item-lockfile machinery is shared;
+    // `resolved_bundles` carries each bundle's own source for the bundle
+    // lockfile recording and plugin/MCP install.
+    let bundle_resolution = resolve_bundle_request(&label, &local_source, git_ref, items)?;
+    let (closure, resolved_bundles): (Option<install::DependencyClosure>, Vec<ResolvedBundle>) =
+        if let Some((c, bundles)) = bundle_resolution {
+            (Some(c), bundles)
+        } else if discovery::is_bundle_file(&local_source) || defer_to_name_resolution {
+            (None, Vec::new())
+        } else {
+            (
+                Some(resolve_requires_closure(
+                    &label,
+                    &local_source,
+                    git_ref,
+                    &requested,
+                )?),
+                Vec::new(),
+            )
+        };
 
     // -- Conflict detection (before any files are written) --
     let mut lock = crate::lockfile::Lockfile::load(target)?;
@@ -352,6 +365,16 @@ pub fn install_with_lockfile(
     } else {
         install_with_name_resolution_from_local(&local_source, target, items)?
     };
+
+    // A bundle-shaped install resolves its items per source above (no bundles
+    // in the per-source reports); attach the resolved bundles so plugin/MCP
+    // install and the lockfile see them with their own sources.
+    if !resolved_bundles.is_empty() {
+        report.bundles = resolved_bundles
+            .iter()
+            .map(|rb| rb.bundle.clone())
+            .collect();
+    }
 
     // -- Plugin installation (ADR-0008) --
     let plugin_results = install_plugins_from_bundles(&report.bundles, plugin_scope, target);
@@ -468,13 +491,27 @@ pub fn install_with_lockfile(
         }
         lock.upsert(item);
     }
-    for bundle in &report.bundles {
-        lock.upsert_bundle(crate::lockfile::LockedBundle {
-            name: bundle.name.clone(),
-            source: label.clone(),
-            git_ref: git_ref.map(str::to_string),
-            items: bundle_item_names(bundle),
-        });
+    if resolved_bundles.is_empty() {
+        // Same-source bundle install (no cross-source provenance): every bundle
+        // came from the entry source.
+        for bundle in &report.bundles {
+            lock.upsert_bundle(crate::lockfile::LockedBundle {
+                name: bundle.name.clone(),
+                source: label.clone(),
+                git_ref: git_ref.map(str::to_string),
+                items: bundle_item_names(bundle),
+            });
+        }
+    } else {
+        // Bundle closure: record each bundle under its OWN source and ref.
+        for rb in &resolved_bundles {
+            lock.upsert_bundle(crate::lockfile::LockedBundle {
+                name: rb.bundle.name.clone(),
+                source: rb.source_label.clone(),
+                git_ref: rb.git_ref.clone(),
+                items: bundle_item_names(&rb.bundle),
+            });
+        }
     }
     // Record installed and warn-skipped plugins in the lockfile so that
     // `doctor` can surface skipped ones and verify installed ones.

--- a/tests/cli_bundle_cross_source.rs
+++ b/tests/cli_bundle_cross_source.rs
@@ -1,0 +1,303 @@
+//! ATDD tests for cross-source bundle `requires` (ADR-0009).
+//!
+//! A bundle MAY depend on a bundle living in another source via a
+//! `{ name, source }` entry in `requires`. Installing the entry bundle pulls
+//! in the required bundle's items from that other source; the lockfile records
+//! each bundle and each item under its OWN source.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+/// Write a rule item at `<root>/<name>/RULE.md`.
+fn write_rule(root: &Path, name: &str) {
+    let dir = root.join(name);
+    fs::create_dir_all(&dir).unwrap();
+    let body =
+        format!("---\nschema: 1\nname: {name}\ndescription: test rule {name}\n---\n# {name}\n");
+    fs::write(dir.join("RULE.md"), body).unwrap();
+}
+
+/// Write a bundle manifest at `<root>/bundles/<name>.bundle.yaml`.
+fn write_bundle(root: &Path, name: &str, body: &str) {
+    let dir = root.join("bundles");
+    fs::create_dir_all(&dir).unwrap();
+    let content = format!("schema: 1\nname: {name}\ndescription: test bundle {name}\n{body}");
+    fs::write(dir.join(format!("{name}.bundle.yaml")), content).unwrap();
+}
+
+#[test]
+fn add_bundle_pulls_cross_source_required_bundle() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // Source DEP: holds the leaf bundle `dep` and its item.
+    let reg_dep = tmp.path().join("reg-dep");
+    write_rule(&reg_dep, "dep-rule");
+    write_bundle(&reg_dep, "dep", "items:\n  rules:\n  - dep-rule\n");
+
+    // Source META: bundle `meta` requires `dep` from the DEP source by path.
+    let reg_meta = tmp.path().join("reg-meta");
+    write_rule(&reg_meta, "meta-rule");
+    write_bundle(
+        &reg_meta,
+        "meta",
+        &format!(
+            "items:\n  rules:\n  - meta-rule\nrequires:\n  - {{ name: dep, source: {} }}\n",
+            reg_dep.display()
+        ),
+    );
+
+    let bundle = reg_meta.join("bundles/meta.bundle.yaml");
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", bundle.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
+            .unwrap();
+
+    // The entry source label for a bundle-file `add` is the file path itself;
+    // the cross-source dependency records its OWN (registry) source.
+    let entry_src = format!("local:{}", bundle.display());
+    let dep_src = format!("local:{}", reg_dep.display());
+
+    let items = lock["items"].as_array().unwrap();
+    let find = |name: &str| {
+        items
+            .iter()
+            .find(|i| i["kind"] == "rule" && i["name"] == name)
+            .unwrap_or_else(|| panic!("rule {name} must be installed: {lock}"))
+    };
+    assert_eq!(find("meta-rule")["source"], entry_src);
+    assert_eq!(find("dep-rule")["source"], dep_src);
+
+    // Both bundles recorded, each under its OWN source.
+    let bundles = lock["bundles"].as_array().unwrap();
+    let bundle_src = |name: &str| {
+        bundles
+            .iter()
+            .find(|b| b["name"] == name)
+            .unwrap_or_else(|| panic!("bundle {name} must be recorded: {lock}"))["source"]
+            .clone()
+    };
+    assert_eq!(bundle_src("meta"), entry_src);
+    assert_eq!(bundle_src("dep"), dep_src);
+}
+
+#[test]
+fn add_bundle_by_name_pulls_cross_source_required_bundle() {
+    // Same as above, but via name resolution (`add <source> meta`) rather
+    // than a bundle-file path — the seed scenario.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    let reg_dep = tmp.path().join("reg-dep");
+    write_rule(&reg_dep, "dep-rule");
+    write_bundle(&reg_dep, "dep", "items:\n  rules:\n  - dep-rule\n");
+
+    let reg_meta = tmp.path().join("reg-meta");
+    write_rule(&reg_meta, "meta-rule");
+    write_bundle(
+        &reg_meta,
+        "meta",
+        &format!(
+            "items:\n  rules:\n  - meta-rule\nrequires:\n  - {{ name: dep, source: {} }}\n",
+            reg_dep.display()
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", reg_meta.to_str().unwrap(), "meta"])
+        .assert()
+        .success();
+
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
+            .unwrap();
+    let items = lock["items"].as_array().unwrap();
+    let has = |name: &str| {
+        items
+            .iter()
+            .any(|i| i["kind"] == "rule" && i["name"] == name)
+    };
+    assert!(has("meta-rule"), "entry bundle item installed: {lock}");
+    assert!(
+        has("dep-rule"),
+        "cross-source required bundle item installed: {lock}"
+    );
+}
+
+#[test]
+fn add_bundle_cross_source_dep_with_same_source_subdeps() {
+    // The seed/metapowers shape: a cross-source required bundle whose OWN
+    // requires are bare (same-source) names within its own source.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // DEP source: bundle `dep` bare-requires sibling `leaf` (same source).
+    let reg_dep = tmp.path().join("reg-dep");
+    write_rule(&reg_dep, "dep-rule");
+    write_rule(&reg_dep, "leaf-rule");
+    write_bundle(&reg_dep, "leaf", "items:\n  rules:\n  - leaf-rule\n");
+    write_bundle(
+        &reg_dep,
+        "dep",
+        "items:\n  rules:\n  - dep-rule\nrequires:\n  - { name: leaf }\n",
+    );
+
+    let reg_meta = tmp.path().join("reg-meta");
+    write_rule(&reg_meta, "meta-rule");
+    write_bundle(
+        &reg_meta,
+        "meta",
+        &format!(
+            "items:\n  rules:\n  - meta-rule\nrequires:\n  - {{ name: dep, source: {} }}\n",
+            reg_dep.display()
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", reg_meta.to_str().unwrap(), "meta"])
+        .assert()
+        .success();
+
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(target.join(".upskill-lock.json")).unwrap())
+            .unwrap();
+    let items = lock["items"].as_array().unwrap();
+    let has = |name: &str| {
+        items
+            .iter()
+            .any(|i| i["kind"] == "rule" && i["name"] == name)
+    };
+    assert!(has("meta-rule"), "entry item: {lock}");
+    assert!(has("dep-rule"), "cross-source dep item: {lock}");
+    assert!(
+        has("leaf-rule"),
+        "same-source sub-dependency of the cross-source bundle: {lock}"
+    );
+}
+
+#[test]
+fn add_bundle_cross_source_cycle_errors() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    let reg_a = tmp.path().join("reg-a");
+    let reg_b = tmp.path().join("reg-b");
+    write_rule(&reg_a, "a-rule");
+    write_rule(&reg_b, "b-rule");
+    write_bundle(
+        &reg_a,
+        "a",
+        &format!(
+            "items:\n  rules:\n  - a-rule\nrequires:\n  - {{ name: b, source: {} }}\n",
+            reg_b.display()
+        ),
+    );
+    write_bundle(
+        &reg_b,
+        "b",
+        &format!(
+            "items:\n  rules:\n  - b-rule\nrequires:\n  - {{ name: a, source: {} }}\n",
+            reg_a.display()
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", reg_a.to_str().unwrap(), "a"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("cycle"));
+}
+
+#[test]
+fn add_bundle_cross_source_item_conflict_errors() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // Both bundles provide a rule named `shared` from different sources.
+    let reg_dep = tmp.path().join("reg-dep");
+    write_rule(&reg_dep, "shared");
+    write_bundle(&reg_dep, "dep", "items:\n  rules:\n  - shared\n");
+
+    let reg_meta = tmp.path().join("reg-meta");
+    write_rule(&reg_meta, "shared");
+    write_bundle(
+        &reg_meta,
+        "meta",
+        &format!(
+            "items:\n  rules:\n  - shared\nrequires:\n  - {{ name: dep, source: {} }}\n",
+            reg_dep.display()
+        ),
+    );
+
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args([
+            "add",
+            reg_meta.join("bundles/meta.bundle.yaml").to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("conflict"));
+}
+
+#[test]
+fn add_bundle_missing_cross_source_bundle_errors() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(target.join(".git")).unwrap();
+
+    // DEP source exists but does NOT contain a bundle named `dep`.
+    let reg_dep = tmp.path().join("reg-dep");
+    write_rule(&reg_dep, "unrelated");
+
+    let reg_meta = tmp.path().join("reg-meta");
+    write_rule(&reg_meta, "meta-rule");
+    write_bundle(
+        &reg_meta,
+        "meta",
+        &format!(
+            "items:\n  rules:\n  - meta-rule\nrequires:\n  - {{ name: dep, source: {} }}\n",
+            reg_dep.display()
+        ),
+    );
+
+    let bundle = reg_meta.join("bundles/meta.bundle.yaml");
+    common::upskill_cmd(&home)
+        .current_dir(&target)
+        .args(["add", bundle.to_str().unwrap()])
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
## Why

Bundle-level `requires` only resolved within the same source registry — `Requires { name, version }` had no `source` field. A meta-bundle that composes bundles living in **other** repos (e.g. a methodology bundle pulling a generic-literacy bundle and a working-memory bundle from separate repos) could not resolve its dependencies.

## What

- Bundle `Requires` gains an optional `source` field (the `upskill add` DSL), mirroring item-level cross-source requires (ADR-0009).
- A new bundle resolver walks bundle→bundle edges, fetching each distinct `{ name, source }` source once and discovering its bundles, recursing through bare (same-source) and cross-source edges alike.
- It emits the **same `DependencyClosure`** the item-level path produces, so per-source install and item-lockfile recording are reused verbatim; only per-bundle source recording is bundle-specific. Each bundle and item is recorded in the lockfile under its **own** source and ref.
- Cycles keyed by `(source-label, bundle-name)`; the same bundle name from two sources, or an item provided by two bundles, is a conflict error.

## Tests

`tests/cli_bundle_cross_source.rs` — 6 ATDD cases: cross-source pull, name-resolution form, cross-source dep with same-source sub-deps, cycle, item conflict, missing-bundle. **All 577 existing tests still pass** (bundle installs now route through the new path). `just verify` green.

## Docs

`format-spec §3.7` and `specification §2.6` updated; **ADR-0009 extended** with a bundle-level cross-source section (including the documented narrow file-vs-dir label limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)