### PR TITLE
refactor(source)!: replace GitLab-specific source with generic git URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ committed). Per-client output paths and ancillary files (`CLAUDE.md`,
 - `owner/repo:path/to/skill` — subfolder
 - `owner/repo@ref:path` — combined
 - `https://github.com/owner/repo[...]` — full URL
-- `https://<host>/<path>[...]` — any https git host (GitLab incl.
+- `https://<host>/<path>[...]` — any other https git host (GitLab including
   self-hosted and subgroups, Bitbucket, Gitea, …)
 - `./path`, `../path`, `/abs/path`, `~/path` — local paths
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,8 @@ committed). Per-client output paths and ancillary files (`CLAUDE.md`,
 - `owner/repo:path/to/skill` — subfolder
 - `owner/repo@ref:path` — combined
 - `https://github.com/owner/repo[...]` — full URL
-- `gitlab:owner/repo[...]` or `https://gitlab.com/...` — GitLab
+- `https://<host>/<path>[...]` — any https git host (GitLab incl.
+  self-hosted and subgroups, Bitbucket, Gitea, …)
 - `./path`, `../path`, `/abs/path`, `~/path` — local paths
 
 ### Authentication

--- a/docs/adr/0009-coupling-tiers-and-dependencies.md
+++ b/docs/adr/0009-coupling-tiers-and-dependencies.md
@@ -78,7 +78,7 @@ requires:
   error).
 - Each `requires.<kind>` entry is a **bare string** (same-source, resolved by
   name) or a `{ name, source }` **map** (cross-source; `source` reuses the
-  `upskill add` source DSL — `owner/repo@ref`, https, `gitlab:`, local).
+  `upskill add` source DSL — `owner/repo@ref`, https URLs, local paths).
 - Resolution is by `(kind, name)`.
 - **`preload-skills`** (agent) is a soft implies of `requires.skills` for skills
   **present in the same source**: those skills are auto-installed alongside the agent AND preloaded

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -41,8 +41,8 @@ upskill add owner/repo:path/to/items                # subfolder
 upskill add owner/repo@v1.2                         # pin to tag
 upskill add owner/repo@main                         # pin to branch
 upskill add owner/repo@abc123                       # pin to commit SHA
-upskill add https://gitlab.com/owner/repo           # any https git host
-upskill add https://git.example.com/owner/repo      # self-hosted (GitLab, Gitea, …)
+upskill add https://gitlab.com/owner/repo           # GitLab.com
+upskill add https://git.example.com/owner/repo      # any https git host (self-hosted, Gitea, …)
 upskill add https://gitlab.com/group/subgroup/repo  # nested groups (any depth)
 upskill add ./path/to/local                         # local directory
 upskill add owner/repo:platform.bundle.yaml         # bundle file (explicit path)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -41,9 +41,9 @@ upskill add owner/repo:path/to/items                # subfolder
 upskill add owner/repo@v1.2                         # pin to tag
 upskill add owner/repo@main                         # pin to branch
 upskill add owner/repo@abc123                       # pin to commit SHA
-upskill add gitlab:owner/repo                       # GitLab.com
-upskill add https://gitlab.example.com/owner/repo   # self-hosted GitLab
-upskill add https://gitlab.example.com/group/subgroup/repo  # GitLab subgroups (any depth)
+upskill add https://gitlab.com/owner/repo           # any https git host
+upskill add https://git.example.com/owner/repo      # self-hosted (GitLab, Gitea, …)
+upskill add https://gitlab.com/group/subgroup/repo  # nested groups (any depth)
 upskill add ./path/to/local                         # local directory
 upskill add owner/repo:platform.bundle.yaml         # bundle file (explicit path)
 upskill add owner/repo platform-baseline            # bundle by name (resolves .bundle.yaml)

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -500,7 +500,7 @@ documentation; the parser ignores it (§2.2).
 
 `requires` entries are maps. Each entry references another bundle by `name`, optionally pinned
 with a semver `version` constraint, and optionally located in another source with `source` (the
-`upskill add` source DSL — `owner/repo@ref`, https, `gitlab:`, local). Absent `source` resolves
+`upskill add` source DSL — `owner/repo@ref`, https URLs, local paths). Absent `source` resolves
 the required bundle in the **same** source registry as the requiring bundle:
 
 ```yaml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ config:
 # ~/.config/upskill/config.yaml
 registries:
   - name: corp
-    source: gitlab:mycompany/ai-skills
+    source: https://gitlab.com/mycompany/ai-skills
   - name: team
     source: myorg/team-skills
 ```

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -31,10 +31,10 @@ git config --global url."git@github.com:".insteadOf "https://github.com/"
 `gh auth setup-git` and `glab auth login` both configure a git credential
 helper, which upskill then picks up transparently.
 
-Self-hosted GitLab is supported via the full URL form
-(`https://gitlab.mycompany.com/team/repo`), including projects nested under
-subgroups to any depth
-(`https://gitlab.mycompany.com/group/subgroup/team/repo`).
+Any https git host works via the full URL form
+(`https://git.mycompany.com/team/repo`), including projects nested under
+groups to any depth
+(`https://git.mycompany.com/group/subgroup/team/repo`).
 
 ## Pin a source to a specific version
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -75,9 +75,9 @@ upskill add <source> [items...] [--global|--project]
 - `owner/repo:path/to/name.bundle.yaml` — bundle file (resolves transitively, see §2.6)
 - `owner/repo@ref:path` — combined
 - `https://github.com/owner/repo[...]` — full HTTPS URL
-- `gitlab:owner/repo[...]` or `https://gitlab.com/[...]` — GitLab
-- `gitlab:group/subgroup[/…]/project[...]` — GitLab subgroups (any nesting
-  depth); the segment before the project is the full namespace path
+- `https://<host>/<path>[...]` — any other https git host: GitLab
+  (including self-hosted instances and subgroups at any nesting depth),
+  Bitbucket, Gitea, or a plain git server
 - `./path`, `../path`, `/abs/path`, `~/path` — local paths
 
 `upskill add <source>` installs everything the source contains. Optional
@@ -267,10 +267,10 @@ credential helpers, `url.<base>.insteadOf` rewrites, and SSH. A private
 repository works whenever a manual `git clone <url>` would; configure git
 the same way. upskill resolves no tokens and reads no token env vars.
 
-Self-hosted GitLab is supported via full URL form
-(`https://gitlab.mycompany.com/team/repo`), including projects nested under
-subgroups to any depth
-(`https://gitlab.mycompany.com/group/subgroup/team/repo`).
+Any https host is treated as a git remote and cloned through git's own
+configuration (`https://git.mycompany.com/team/repo`), including projects
+nested under groups to any depth
+(`https://git.mycompany.com/group/subgroup/team/repo`).
 
 ## 6. CLI compliance
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -267,8 +267,8 @@ credential helpers, `url.<base>.insteadOf` rewrites, and SSH. A private
 repository works whenever a manual `git clone <url>` would; configure git
 the same way. upskill resolves no tokens and reads no token env vars.
 
-Any https host is treated as a git remote and cloned through git's own
-configuration (`https://git.mycompany.com/team/repo`), including projects
+Any https host is treated as an opaque git remote
+(`https://git.mycompany.com/team/repo`), including projects
 nested under groups to any depth
 (`https://git.mycompany.com/group/subgroup/team/repo`).
 

--- a/docs/wip/2026-06-10-generic-git-url-source-design.md
+++ b/docs/wip/2026-06-10-generic-git-url-source-design.md
@@ -1,0 +1,115 @@
+# Generic git-URL source — design
+
+Date: 2026-06-10
+Status: approved (brainstorm), pending implementation plan
+Branch: `refactor/generic-git-url-source` (based on
+`refactor/clone-auth-git-config-only`)
+
+## Problem
+
+Since the clone-auth refactor (`e7c4120`), upskill clones with the bare
+`https://<host>/...` URL and delegates all authentication to git's own
+configuration. The GitLab-specific source machinery — the `gitlab:` /
+`gitlab+<host>:` shorthands, host classification of full URLs, and the
+typed `GitlabRepo` — no longer buys anything: `gitlab_clone_url()` merely
+reassembles `https://{host}/{path}.git` from pieces the parser split
+apart. Meanwhile, non-GitLab hosts (Bitbucket, Gitea, Codeberg, corporate
+git servers) are excluded for no reason.
+
+## Decision
+
+Replace the GitLab-specific source with a generic git-URL source: any
+`https://` URL is a clonable git remote. "GitLab support" stops being a
+feature — it is just git.
+
+### Decisions taken during brainstorm
+
+1. **Shorthands deleted outright.** `gitlab:owner/repo` and
+   `gitlab+<host>:...` input forms and lockfile labels are removed with no
+   migration (pre-1.0 no-backcompat policy). Old lockfiles holding such
+   labels hard-fail at parse with a clear error.
+2. **GitHub variant kept.** `owner/repo[@ref][:path]` shorthand and
+   `https://github.com/...` URLs continue to classify as
+   `InstallSource::Github` with the compact `owner/repo` lockfile label.
+   Only non-GitHub URLs go through the new generic source.
+3. **`https://` only.** No `ssh://` or scp-style `git@host:path` input,
+   and no `git+https://` scheme prefix. SSH users reach SSH via git's
+   `url.<ssh>.insteadOf` rewrite, consistent with the auth-via-git-config
+   design.
+
+## Design
+
+### Source model (`src/source.rs`)
+
+Delete `GitlabRepo` and `InstallSource::Gitlab`. Add:
+
+```rust
+pub struct GitRepo {
+    pub url: String,            // bare https remote, no trailing .git
+    pub git_ref: Option<String>,
+    pub subfolder: Option<String>,
+}
+```
+
+`InstallSource` becomes `Github(GithubRepo) | Git(GitRepo) | Local(PathBuf)`.
+
+### Parsing (`parse_install_source`)
+
+- Local paths and GitHub shorthand `owner/repo[@ref][:path]` — unchanged.
+- `https://github.com/...` — still classifies as `Github` (unchanged).
+- `https://<any-other-host>/<path>[@<ref>][:<subfolder>]` — parses to
+  `Git`. Host and path are opaque: subgroups at any depth, ports, and any
+  git host work identically. A trailing `.git` on the path is stripped.
+  At least one path segment is required after the host.
+- `gitlab:` and `gitlab+<host>:` prefixes — parse error
+  (`SourceParseError`), with a message pointing at the full-URL form.
+
+### Labels (`Display` + `parse_install_source_label`)
+
+The `Git` label round-trips as `url[@ref][:subfolder]` — i.e. the input
+form is the label. GitHub and local labels are unchanged.
+
+### Clone (`src/pipeline/git.rs`)
+
+`install_from_gitlab` and `gitlab_clone_url` collapse into a generic path
+cloning `{url}.git`. Shallow/sparse clone behavior and the
+auth-via-git-config posture are untouched.
+
+### Docs and tests
+
+- Update the source-format lists in `docs/commands.md`, `AGENTS.md`,
+  `README.md`, and `docs/format-spec.md` / `docs/specification.md` where
+  `gitlab:` is mentioned.
+- Rewrite `parse_gitlab_*` and GitLab label round-trip unit tests as
+  generic git-URL tests, keeping the subgroup, port, and ref+subfolder
+  cases and adding a non-GitLab host case (e.g. Bitbucket/Gitea).
+- Update `pipeline_source` integration tests accordingly; add a test that
+  `gitlab:` now fails with a usage error.
+
+## Alternatives considered
+
+- **Keep `gitlab:` as sugar over the generic source** — rejected: two
+  spellings for one thing, and the shorthand saves almost nothing over
+  pasting the URL.
+- **Collapse GitHub into the generic source too** — rejected for now:
+  the `owner/repo` shorthand and compact lockfile label are worth the
+  second code path.
+- **Accept ssh URLs directly** — rejected: `@ref` / `:subfolder` suffixes
+  clash with `git@host:path` syntax; `insteadOf` rewrites cover SSH.
+- **`git+https://` scheme prefix** — rejected: upskill has exactly one
+  https fetch strategy (git clone), so the prefix would disambiguate
+  against nothing and breaks browser-paste UX.
+
+## Acceptance criteria
+
+1. `upskill add https://gitlab.example.com/group/sub/repo@v1:skills/x`
+   installs exactly as before the refactor.
+2. `upskill add https://bitbucket.org/team/repo` clones and installs
+   (host-agnostic).
+3. `upskill add gitlab:team/repo` exits 2 with a parse error naming the
+   full-URL form.
+4. Lockfile written by the new code round-trips through
+   `list` / `update` / `remove`.
+5. `rg -i gitlab src/` only matches host-agnostic strings (tests/fixtures
+   using gitlab.com as an example host are fine; no GitLab-specific code
+   paths remain).

--- a/docs/wip/2026-06-10-generic-git-url-source-plan.md
+++ b/docs/wip/2026-06-10-generic-git-url-source-plan.md
@@ -1,0 +1,679 @@
+# Generic git-URL Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the GitLab-specific source machinery with a generic https git-URL source so any git host works, per the approved spec at `docs/wip/2026-06-10-generic-git-url-source-design.md`.
+
+**Architecture:** `InstallSource::Gitlab(GitlabRepo)` becomes `InstallSource::Git(GitRepo)` where `GitRepo` stores the bare https remote URL plus optional ref/subfolder. The `gitlab:` / `gitlab+<host>:` shorthands are deleted with a dedicated parse error pointing at the full-URL form. GitHub keeps its typed variant. Clone behavior (`shallow_clone`, auth via git config) is untouched — only URL construction changes.
+
+**Tech Stack:** Rust edition 2024, `thiserror` (source.rs typed errors), `assert_cmd` + `predicates` + `tempfile` (integration tests). Worktree: `.claude/worktrees/refactor-generic-git-url-source`. All paths below are relative to the worktree root.
+
+**Verification baseline:** `just test` green before starting (branch tip `813173b`).
+
+---
+
+## Task 1: Core source-model swap (`GitRepo` replaces `GitlabRepo`)
+
+This is one atomic refactor — the enum change breaks every consumer, so the crate only compiles again at the end of this task. Tests are written first (ATDD integration test + rewritten unit tests = RED as compile errors and failures), then the implementation and consumer arms.
+
+**Files:**
+
+- Modify: `tests/cli_exit_codes.rs` (ATDD test)
+- Modify: `src/source.rs` (model, parsing, labels, unit tests)
+- Modify: `src/pipeline/git.rs` (clone dispatch + unit tests)
+- Modify: `src/index.rs:352-364` (`clone_url_for`)
+- Modify: `src/main.rs:246-263` (`print_install_progress`)
+- Modify: `src/pipeline/install.rs:363-369` (`source_git_ref`)
+- Modify: `src/pipeline/mod.rs:206,265-269` (doc comment + `git_ref` match)
+
+- [ ] **Step 1: Write the ATDD integration test (acceptance criterion 3)**
+
+Append to `tests/cli_exit_codes.rs` (file already has `mod common;`; add `use predicates::prelude::*;` below the existing `use` lines):
+
+```rust
+#[test]
+fn removed_gitlab_shorthand_exits_two_with_url_hint() {
+    // The `gitlab:` shorthand was deleted in favor of full https URLs.
+    // The error must name the replacement so users can self-serve.
+    let cwd = tempdir().expect("must create temp dir");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let mut cmd = common::upskill_cmd(&home);
+
+    cmd.current_dir(cwd.path())
+        .args(["add", "gitlab:team/skills", "--claude"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("https://gitlab.com"));
+}
+```
+
+- [ ] **Step 2: Run the ATDD test to verify it fails**
+
+Run: `cargo test --test cli_exit_codes removed_gitlab_shorthand -- --nocapture`
+Expected: FAIL — exit code is currently 1 (the shorthand still parses, then the clone of `https://gitlab.com/team/skills.git` fails), and stderr does not contain the hint. If the sandbox has no network, the clone fails faster — the test still fails on the missing stderr hint.
+
+- [ ] **Step 3: Rewrite the GitLab unit tests in `src/source.rs`**
+
+Delete the test functions `parse_gitlab_prefix`, `parse_gitlab_prefix_with_ref`, `parse_gitlab_prefix_with_subfolder`, `parse_gitlab_url`, `parse_selfhosted_gitlab_url`, `parse_selfhosted_gitlab_with_port`, `parse_selfhosted_gitlab_subgroup`, `parse_selfhosted_gitlab_subgroup_with_ref_and_subfolder`, `parse_gitlab_prefix_subgroup`, `reject_gitlab_bare_project_without_namespace`, `label_roundtrip_gitlab_dot_com`, `label_roundtrip_gitlab_self_hosted`, `label_roundtrip_gitlab_self_hosted_subgroup`, `label_rejects_gitlab_plus_without_host` (currently `src/source.rs:504-633` and `674-717`). Keep `parse_github_url` and everything else. In their place add:
+
+```rust
+    // Generic git-URL source tests — any https host that is not github.com
+    // is an opaque git remote (GitLab, Bitbucket, Gitea, corporate git).
+
+    #[test]
+    fn parse_git_url_gitlab_com() {
+        let source = parse_install_source("https://gitlab.com/team/skills").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://gitlab.com/team/skills");
+        assert_eq!(repo.git_ref, None);
+        assert_eq!(repo.subfolder, None);
+    }
+
+    #[test]
+    fn parse_git_url_bitbucket() {
+        let source = parse_install_source("https://bitbucket.org/team/repo").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://bitbucket.org/team/repo");
+    }
+
+    #[test]
+    fn parse_git_url_self_hosted_with_port() {
+        let source =
+            parse_install_source("https://git.company.com:8443/team/skills").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://git.company.com:8443/team/skills");
+    }
+
+    #[test]
+    fn parse_git_url_subgroups_any_depth() {
+        let source = parse_install_source(
+            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed",
+        )
+        .expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(
+            repo.url,
+            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed"
+        );
+    }
+
+    #[test]
+    fn parse_git_url_with_ref_and_subfolder() {
+        let source = parse_install_source(
+            "https://gitlabee.dt.renault.com/partners/seed@v0.2.0:skills/seed.bundle.yaml",
+        )
+        .expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://gitlabee.dt.renault.com/partners/seed");
+        assert_eq!(repo.git_ref.as_deref(), Some("v0.2.0"));
+        assert_eq!(repo.subfolder.as_deref(), Some("skills/seed.bundle.yaml"));
+    }
+
+    #[test]
+    fn parse_git_url_single_path_segment() {
+        // Plain git servers can host a repo directly under the root —
+        // unlike GitLab there is no namespace requirement.
+        let source = parse_install_source("https://git.example.com/repo").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://git.example.com/repo");
+    }
+
+    #[test]
+    fn parse_git_url_strips_trailing_dot_git() {
+        let source =
+            parse_install_source("https://gitlab.com/team/skills.git").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://gitlab.com/team/skills");
+    }
+
+    #[test]
+    fn parse_git_url_strips_trailing_slash() {
+        let source = parse_install_source("https://gitlab.com/team/skills/").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://gitlab.com/team/skills");
+    }
+
+    #[test]
+    fn reject_git_url_without_path() {
+        let err = parse_install_source("https://gitlab.com").expect_err("must fail");
+        assert_eq!(err, SourceParseError::InvalidFormat);
+    }
+
+    #[test]
+    fn reject_git_url_with_empty_path() {
+        let err = parse_install_source("https://gitlab.com/").expect_err("must fail");
+        assert_eq!(err, SourceParseError::EmptySegment);
+    }
+
+    #[test]
+    fn reject_removed_gitlab_shorthand() {
+        let err = parse_install_source("gitlab:team/skills").expect_err("must fail");
+        assert_eq!(err, SourceParseError::GitlabShorthandRemoved);
+    }
+
+    #[test]
+    fn reject_removed_gitlab_plus_shorthand() {
+        let err =
+            parse_install_source("gitlab+git.company.com:team/skills").expect_err("must fail");
+        assert_eq!(err, SourceParseError::GitlabShorthandRemoved);
+    }
+```
+
+And in the label round-trip section (after `label_roundtrip_github_full`):
+
+```rust
+    #[test]
+    fn label_roundtrip_git_minimal() {
+        assert_label_roundtrip(&InstallSource::Git(GitRepo {
+            url: "https://gitlab.com/team/skills".into(),
+            git_ref: None,
+            subfolder: None,
+        }));
+    }
+
+    #[test]
+    fn label_roundtrip_git_full() {
+        assert_label_roundtrip(&InstallSource::Git(GitRepo {
+            url: "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed".into(),
+            git_ref: Some("v0.2.0".into()),
+            subfolder: Some("skills/seed.bundle.yaml".into()),
+        }));
+    }
+
+    #[test]
+    fn label_rejects_removed_gitlab_shorthand() {
+        // Old lockfiles may still carry `gitlab:` labels — they hard-fail
+        // with the same self-serve error as the CLI input form (pre-1.0,
+        // no migration).
+        let err = parse_install_source_label("gitlab:team/x@main").expect_err("must reject");
+        assert_eq!(err, SourceParseError::GitlabShorthandRemoved);
+        let err = parse_install_source_label("gitlab+h.com:team/x").expect_err("must reject");
+        assert_eq!(err, SourceParseError::GitlabShorthandRemoved);
+    }
+```
+
+- [ ] **Step 4: Implement the model and parsing in `src/source.rs`**
+
+Replace `GitlabRepo` (lines 14-21) with:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitRepo {
+    /// Bare https remote without a trailing `.git`, e.g.
+    /// `https://gitlab.example.com/group/sub/repo`. The host and path are
+    /// opaque — any git host works; auth is git's job (config/helpers).
+    pub url: String,
+    pub git_ref: Option<String>,
+    pub subfolder: Option<String>,
+}
+```
+
+Change the enum variant (line 26): `Gitlab(GitlabRepo)` → `Git(GitRepo)`.
+
+Replace the `Display` doc comment lines 33-36 and the `Gitlab` arm (lines 49-62):
+
+```rust
+/// - `github:<owner>/<name>[@<ref>][:<subfolder>]`
+/// - `<url>[@<ref>][:<subfolder>]` — generic git source; the bare https
+///   URL is its own label
+/// - `local:<path>` (absolute when known, otherwise as-given)
+```
+
+```rust
+InstallSource::Git(r) => {
+    write!(f, "{}", r.url)?;
+    if let Some(g) = &r.git_ref {
+        write!(f, "@{}", g)?;
+    }
+    if let Some(s) = &r.subfolder {
+        write!(f, ":{}", s)?;
+    }
+    Ok(())
+}
+```
+
+Add a `SourceParseError` variant:
+
+```rust
+#[error(
+    "the `gitlab:` shorthand was removed; use the full https URL instead, \
+     e.g. https://gitlab.com/owner/repo"
+)]
+GitlabShorthandRemoved,
+```
+
+In `parse_install_source`, replace the `gitlab:` branch (lines 119-122):
+
+```rust
+// The `gitlab:` / `gitlab+<host>:` shorthands were removed in favor of
+// full https URLs. Catch them explicitly so the error names the
+// replacement instead of falling through to a confusing
+// owner/repo parse error.
+if source.starts_with("gitlab:") || source.starts_with("gitlab+") {
+    return Err(SourceParseError::GitlabShorthandRemoved);
+}
+```
+
+In `parse_install_source_label`, replace the two gitlab branches (lines 169-180) and update the doc comment list (lines 157-161) to match the new Display forms:
+
+```rust
+if let Some(rest) = label.strip_prefix("https://") {
+    return parse_url_source(rest);
+}
+if label.starts_with("gitlab:") || label.starts_with("gitlab+") {
+    return Err(SourceParseError::GitlabShorthandRemoved);
+}
+```
+
+Replace `parse_url_source`'s last line (line 198) and delete `parse_gitlab_source` (lines 201-244), adding in its place:
+
+```rust
+    // Any other https host is an opaque git remote.
+    parse_git_url(host_part, path_part).map(InstallSource::Git)
+}
+
+/// Parse the path portion of a generic git URL:
+/// `<path>[@<ref>][:<subfolder>]`. The host is opaque (and may carry a
+/// port); the path may nest arbitrarily deep (GitLab subgroups). A
+/// trailing `/` or `.git` on the repo path is stripped so browser-pasted
+/// and clone URLs normalise to one canonical label.
+fn parse_git_url(host: &str, path: &str) -> Result<GitRepo, SourceParseError> {
+    // Split off :subfolder first. The port is on the host part, already
+    // split away, so a ':' here is always a subfolder separator.
+    let (before_subfolder, subfolder) = if let Some((before, sub)) = path.split_once(':') {
+        if sub.trim().is_empty() {
+            return Err(SourceParseError::EmptySubfolder);
+        }
+        (before, Some(sub.to_string()))
+    } else {
+        (path, None)
+    };
+
+    // Split off @ref
+    let (repo_path, git_ref) = if let Some((before, r)) = before_subfolder.split_once('@') {
+        if r.trim().is_empty() {
+            return Err(SourceParseError::EmptyRef);
+        }
+        (before, Some(r.to_string()))
+    } else {
+        (before_subfolder, None)
+    };
+
+    let repo_path = repo_path.trim_end_matches('/');
+    let repo_path = repo_path.strip_suffix(".git").unwrap_or(repo_path);
+    if repo_path.trim().is_empty() {
+        return Err(SourceParseError::EmptySegment);
+    }
+
+    Ok(GitRepo {
+        url: format!("https://{host}/{repo_path}"),
+        git_ref,
+        subfolder,
+    })
+}
+```
+
+- [ ] **Step 5: Verify RED — crate fails to compile only at the known consumer sites**
+
+Run: `cargo test --lib 2>&1 | grep -E "^error" | head -20`
+Expected: compile errors mentioning `Gitlab` in `src/pipeline/git.rs`, `src/index.rs`, `src/main.rs` (binary compiles separately — lib errors first), `src/pipeline/install.rs`, `src/pipeline/mod.rs`. No errors in other files.
+
+- [ ] **Step 6: Update `src/pipeline/git.rs`**
+
+Replace the import (line 16): `use crate::source::{GitRepo, GithubRepo, InstallSource};`
+
+Update the `install_from_source` doc comment (lines 25-27):
+
+```rust
+/// - `Github` — `https://github.com/<owner>/<repo>.git`.
+/// - `Git` — `<url>.git`; the URL is stored verbatim on [`GitRepo`], so
+///   any https git host (GitLab incl. self-hosted/subgroups, Bitbucket,
+///   Gitea, …) works identically.
+```
+
+Replace the `Gitlab` dispatch arm (line 40), `install_from_gitlab` (lines 60-74), and `gitlab_clone_url` (lines 80-82):
+
+```rust
+InstallSource::Git(repo) => install_from_git(repo, target, filter),
+```
+
+```rust
+fn install_from_git(
+    repo: &GitRepo,
+    target: &Path,
+    filter: Option<&crate::bundle::ResolvedItems>,
+) -> Result<InstallReport> {
+    let (owner, name) = repo_display_parts(&repo.url);
+    install_from_git_url(
+        &git_clone_url(repo),
+        repo.git_ref.as_deref(),
+        repo.subfolder.as_deref(),
+        owner,
+        name,
+        target,
+        filter,
+    )
+}
+```
+
+```rust
+fn git_clone_url(repo: &GitRepo) -> String {
+    format!("{}.git", repo.url)
+}
+
+/// Split a bare remote URL into (prefix, last segment) for the
+/// human-facing error messages in `fetch::resolve_subfolder`, which
+/// formats them back as `{owner}/{name}` — reproducing the full URL.
+fn repo_display_parts(url: &str) -> (&str, &str) {
+    url.rsplit_once('/').unwrap_or(("", url))
+}
+```
+
+Replace the `fetch_ssot` `Gitlab` arm (lines 106-113):
+
+```rust
+InstallSource::Git(repo) => {
+    let (owner, name) = repo_display_parts(&repo.url);
+    clone_to_tempdir(
+        &git_clone_url(repo),
+        repo.git_ref.as_deref(),
+        repo.subfolder.as_deref(),
+        owner,
+        name,
+    )
+}
+```
+
+Replace the two GitLab tests (`gitlab_clone_url_uses_repo_host`, `gitlab_clone_url_with_subgroups`, lines 174-218):
+
+```rust
+    #[test]
+    fn git_clone_url_appends_dot_git() {
+        let repo = GitRepo {
+            url: "https://gitlab.example.com/team/rules".into(),
+            git_ref: None,
+            subfolder: None,
+        };
+        assert_eq!(
+            git_clone_url(&repo),
+            "https://gitlab.example.com/team/rules.git"
+        );
+    }
+
+    #[test]
+    fn git_clone_url_preserves_deep_paths_and_ports() {
+        let repo = GitRepo {
+            url: "https://git.company.com:8443/partners/devex/process/seed".into(),
+            git_ref: None,
+            subfolder: None,
+        };
+        assert_eq!(
+            git_clone_url(&repo),
+            "https://git.company.com:8443/partners/devex/process/seed.git"
+        );
+    }
+
+    #[test]
+    fn repo_display_parts_splits_last_segment() {
+        assert_eq!(
+            repo_display_parts("https://gitlab.com/team/skills"),
+            ("https://gitlab.com/team", "skills")
+        );
+    }
+```
+
+- [ ] **Step 7: Update the remaining consumer match arms**
+
+`src/index.rs:358-361` — replace the `Gitlab` arm of `clone_url_for`:
+
+```rust
+InstallSource::Git(repo) => Ok(format!("{}.git", repo.url)),
+```
+
+`src/main.rs:255-262` — replace the `Gitlab` arm of `print_install_progress`:
+
+```rust
+InstallSource::Git(repo) => {
+    eprintln!("{} {}", style::dim("Cloning"), style::name(&repo.url));
+}
+```
+
+`src/pipeline/install.rs:366` — replace the `Gitlab` arm of `source_git_ref`:
+
+```rust
+InstallSource::Git(r) => r.git_ref.clone(),
+```
+
+`src/pipeline/mod.rs:267` — replace the `Gitlab` arm in the `git_ref` match:
+
+```rust
+InstallSource::Git(r) => r.git_ref.as_deref(),
+```
+
+`src/pipeline/mod.rs:206` — in the doc comment, change "Github/Gitlab" to "Github/Git" so it reads: is pinned (Github/Git `git_ref`); local-path sources record `None`.
+
+- [ ] **Step 8: Run the full test suite to verify GREEN**
+
+Run: `just test`
+Expected: PASS — all unit tests including the new `parse_git_url_*` / `label_roundtrip_git_*` tests, and the Step 1 ATDD test `removed_gitlab_shorthand_exits_two_with_url_hint` now passes (parse fails fast with exit 2 and the URL hint, no clone attempted).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/source.rs src/pipeline/git.rs src/index.rs src/main.rs src/pipeline/install.rs src/pipeline/mod.rs tests/cli_exit_codes.rs
+git commit -m "refactor(source)!: replace GitLab-specific source with generic git URL
+
+Any https git host now works (GitLab incl. self-hosted/subgroups,
+Bitbucket, Gitea, corporate git). The gitlab:/gitlab+host: shorthands
+are removed; the parse error names the full-URL replacement. Pre-1.0:
+old gitlab: lockfile labels hard-fail, no migration.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Documentation sweep
+
+No code. Update every user-facing mention of the `gitlab:` shorthand and GitLab-specific URL support to the generic git-URL story. Keep ADRs untouched (historical record).
+
+**Files:**
+
+- Modify: `AGENTS.md` (Source format section)
+- Modify: `docs/commands.md:44-46`
+- Modify: `docs/specification.md:78-79,271-273`
+- Modify: `docs/recipes.md:35-37`
+- Modify: `docs/format-spec.md:503`
+- Modify: `docs/getting-started.md:77`
+- Modify: `tests/pipeline_source.rs:71-74,230-232` (comments only)
+
+- [ ] **Step 1: Update `AGENTS.md` "Source format" list**
+
+Replace the line:
+
+```markdown
+- `gitlab:owner/repo[...]` or `https://gitlab.com/...` — GitLab
+```
+
+with:
+
+```markdown
+- `https://<host>/<path>[...]` — any https git host (GitLab incl.
+  self-hosted and subgroups, Bitbucket, Gitea, …)
+```
+
+- [ ] **Step 2: Update `docs/commands.md` add examples (lines 44-46)**
+
+Replace:
+
+```bash
+upskill add gitlab:owner/repo                       # GitLab.com
+upskill add https://gitlab.example.com/owner/repo   # self-hosted GitLab
+upskill add https://gitlab.example.com/group/subgroup/repo  # GitLab subgroups (any depth)
+```
+
+with:
+
+```bash
+upskill add https://gitlab.com/owner/repo           # any https git host
+upskill add https://git.example.com/owner/repo      # self-hosted (GitLab, Gitea, …)
+upskill add https://gitlab.com/group/subgroup/repo  # nested groups (any depth)
+```
+
+- [ ] **Step 3: Update `docs/specification.md`**
+
+Lines 78-79, replace:
+
+```markdown
+- `gitlab:owner/repo[...]` or `https://gitlab.com/[...]` — GitLab
+- `gitlab:group/subgroup[/…]/project[...]` — GitLab subgroups (any nesting
+```
+
+with:
+
+```markdown
+- `https://<host>/<path>[...]` — any other https git host: GitLab
+  (including self-hosted instances and subgroups at any nesting depth),
+  Bitbucket, Gitea, or a plain git server
+```
+
+Lines 270-273, replace:
+
+```markdown
+Self-hosted GitLab is supported via full URL form
+(`https://gitlab.mycompany.com/team/repo`), including projects nested under
+subgroups to any depth
+(`https://gitlab.mycompany.com/group/subgroup/team/repo`).
+```
+
+with:
+
+```markdown
+Any https host is treated as a git remote and cloned through git's own
+configuration (`https://git.mycompany.com/team/repo`), including projects
+nested under groups to any depth
+(`https://git.mycompany.com/group/subgroup/team/repo`).
+```
+
+- [ ] **Step 4: Update `docs/recipes.md:34-37`**
+
+Replace:
+
+```markdown
+Self-hosted GitLab is supported via the full URL form
+(`https://gitlab.mycompany.com/team/repo`), including projects nested under
+subgroups to any depth
+(`https://gitlab.mycompany.com/group/subgroup/team/repo`).
+```
+
+with:
+
+```markdown
+Any https git host works via the full URL form
+(`https://git.mycompany.com/team/repo`), including projects nested under
+groups to any depth
+(`https://git.mycompany.com/group/subgroup/team/repo`).
+```
+
+- [ ] **Step 5: Update `docs/format-spec.md:503`**
+
+In the `requires` source-DSL parenthetical, replace:
+
+```markdown
+`upskill add` source DSL — `owner/repo@ref`, https, `gitlab:`, local). Absent `source` resolves
+```
+
+with:
+
+```markdown
+`upskill add` source DSL — `owner/repo@ref`, https URLs, local paths). Absent `source` resolves
+```
+
+- [ ] **Step 6: Update `docs/getting-started.md:77`**
+
+Replace the registry config example source:
+
+```yaml
+source: gitlab:mycompany/ai-skills
+```
+
+with:
+
+```yaml
+source: https://gitlab.com/mycompany/ai-skills
+```
+
+- [ ] **Step 7: Update stale comments in `tests/pipeline_source.rs`**
+
+Lines 71-74: replace the comment naming `gitlab_clone_url_uses_repo_host` with the new test name (`git_clone_url_appends_dot_git`) and reword "GitLab dispatch" to "generic git-URL dispatch".
+
+Lines 230-232: replace `` `github:` / `gitlab:` / `gitlab+host:` / `local:` prefixes `` with `` `github:` / `local:` prefixes and bare https URLs `` (the file:// caveat still holds — `file://` is not an accepted source form).
+
+- [ ] **Step 8: Verify docs build and grep for leftovers**
+
+Run: `rg -in "gitlab" src/ tests/ AGENTS.md docs/commands.md docs/specification.md docs/recipes.md docs/format-spec.md docs/getting-started.md`
+Expected: matches only in (a) test/doc example hostnames like `gitlab.com`/`gitlabee.dt.renault.com` used as opaque hosts, (b) the `GitlabShorthandRemoved` error variant, its message, and its tests. No remaining `gitlab:` shorthand documentation.
+
+Run: `just book`
+Expected: mdBook builds with no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add AGENTS.md docs/ tests/pipeline_source.rs
+git commit -m "docs: describe generic git-url sources, drop gitlab shorthand
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Final verification against the spec
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format and full verify**
+
+Run: `just fmt && just verify`
+Expected: both exit 0, zero warnings (CI enforces `-D warnings`).
+
+- [ ] **Step 2: Check the spec's acceptance criteria**
+
+From `docs/wip/2026-06-10-generic-git-url-source-design.md`:
+
+1. Deep-URL install — covered by `parse_git_url_with_ref_and_subfolder` + the unchanged `install_from_git_url` file:// integration tests in `tests/pipeline_source.rs`.
+2. Host-agnostic — covered by `parse_git_url_bitbucket` + `git_clone_url_appends_dot_git`.
+3. `gitlab:` exits 2 with hint — covered by `removed_gitlab_shorthand_exits_two_with_url_hint`.
+4. Lockfile round-trip — covered by `label_roundtrip_git_minimal` / `label_roundtrip_git_full`.
+5. No GitLab-specific code paths — covered by the Task 2 Step 8 grep.
+
+Confirm each maps to a passing test or check; if any gap, add the missing test before proceeding.
+
+- [ ] **Step 3: Commit any formatting fallout**
+
+```bash
+git status --short
+# if dirty:
+git add -A && git commit -m "chore: formatting
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+After this task, the branch is ready for the finishing flow (sdd-gardening of `docs/wip/`, then PR per `superpowers:finishing-a-development-branch`).

--- a/skills/upskill-cli/SKILL.md
+++ b/skills/upskill-cli/SKILL.md
@@ -87,7 +87,7 @@ on content you authored and understand, and always lint after.
 ### Adding installable content to a consumer project
 
 1. Identify the source: either an org repo (e.g. `driftsys/skills`), a
-   GitLab path (`gitlab:team/repo`), a full https URL, or a local path
+   full https URL (any git host), or a local path
    (`./local-source`).
 2. From the consumer project root, run `upskill add <source>` to install
    every item in the source, or `upskill add <source> item-a item-b` to

--- a/skills/upskill-cli/SKILL.md
+++ b/skills/upskill-cli/SKILL.md
@@ -86,9 +86,8 @@ on content you authored and understand, and always lint after.
 
 ### Adding installable content to a consumer project
 
-1. Identify the source: either an org repo (e.g. `driftsys/skills`), a
-   full https URL (any git host), or a local path
-   (`./local-source`).
+1. Identify the source: either an org repo (e.g. `driftsys/skills`), a full
+   https URL (any git host), or a local path (`./local-source`).
 2. From the consumer project root, run `upskill add <source>` to install
    every item in the source, or `upskill add <source> item-a item-b` to
    install a named subset.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Install rules, skills, or agents from a GitHub/GitLab repo or local path.
+    /// Install rules, skills, or agents from a git repo or local path.
     ///
     /// Parses each item from the source, renders per-client output, and
     /// records the install in `.upskill-lock.json`. Default scope is the
@@ -51,7 +51,7 @@ pub enum Commands {
             upskill add owner/repo@v1.2\n  \
             upskill add owner/repo:skills/code-review\n  \
             upskill add owner/repo code-review secret-scanner\n  \
-            upskill add gitlab:team/repo\n  \
+            upskill add https://gitlab.com/team/repo\n  \
             upskill add ./local-source\n  \
             upskill add owner/repo --global"
     )]

--- a/src/index.rs
+++ b/src/index.rs
@@ -355,10 +355,7 @@ fn clone_url_for(source: &InstallSource) -> Result<String> {
             "https://github.com/{}/{}.git",
             repo.owner, repo.name
         )),
-        InstallSource::Gitlab(repo) => Ok(format!(
-            "https://{}/{}/{}.git",
-            repo.host, repo.owner, repo.name
-        )),
+        InstallSource::Git(repo) => Ok(format!("{}.git", repo.url)),
         InstallSource::LocalPath(_) => bail!("local paths do not have clone URLs"),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,12 +252,8 @@ fn print_install_progress(source: &InstallSource) {
                 style::name(&format!("github:{}/{}", repo.owner, repo.name))
             );
         }
-        InstallSource::Gitlab(repo) => {
-            eprintln!(
-                "{} {}",
-                style::dim("Cloning"),
-                style::name(&format!("{}:{}/{}", repo.host, repo.owner, repo.name))
-            );
+        InstallSource::Git(repo) => {
+            eprintln!("{} {}", style::dim("Cloning"), style::name(&repo.url));
         }
     }
 }

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -84,7 +84,7 @@ pub struct Requires {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     /// Cross-source locator (the `upskill add` source DSL — `owner/repo@ref`,
-    /// https, `gitlab:`, local). Absent means the required bundle is resolved
+    /// https URLs, local paths). Absent means the required bundle is resolved
     /// in the same source registry as the requiring bundle. Mirrors the
     /// item-level `RequireRef::Detailed.source` (ADR-0009).
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/pipeline/git.rs
+++ b/src/pipeline/git.rs
@@ -145,7 +145,7 @@ fn clone_to_tempdir(
 /// removed on return regardless of outcome (RAII via `tempfile::TempDir`).
 ///
 /// Public so callers can install from arbitrary git URLs (mirrors, local
-/// `file://` clones, future GitLab self-hosted) without going through
+/// `file://` clones) without going through
 /// [`InstallSource`]. The high-level [`install_from_source`] is preferred
 /// when an `InstallSource` already exists.
 pub fn install_from_git_url(

--- a/src/pipeline/git.rs
+++ b/src/pipeline/git.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 
 use super::{InstallReport, install_from_local_path};
 use crate::fetch;
-use crate::source::{GithubRepo, GitlabRepo, InstallSource};
+use crate::source::{GitRepo, GithubRepo, InstallSource};
 
 /// Install items from any supported source into `target`.
 ///
@@ -23,8 +23,9 @@ use crate::source::{GithubRepo, GitlabRepo, InstallSource};
 ///
 /// - `LocalPath` — installs directly from the path on disk.
 /// - `Github` — `https://github.com/<owner>/<repo>.git`.
-/// - `Gitlab` — `https://<host>/<owner>/<repo>.git`. Self-hosted GitLab
-///   works through the `host` field on `GitlabRepo`.
+/// - `Git` — `<url>.git`; the URL is stored verbatim on [`GitRepo`], so
+///   any https git host (GitLab incl. self-hosted/subgroups, Bitbucket,
+///   Gitea, …) works identically.
 ///
 /// Authentication: clones use the bare URL and rely on git's own
 /// configuration (credential helpers, `insteadOf` rewrites, SSH).
@@ -37,7 +38,7 @@ pub fn install_from_source(
     match source {
         InstallSource::LocalPath(path) => install_from_local_path(path, target, filter),
         InstallSource::Github(repo) => install_from_github(repo, target, filter),
-        InstallSource::Gitlab(repo) => install_from_gitlab(repo, target, filter),
+        InstallSource::Git(repo) => install_from_git(repo, target, filter),
     }
 }
 
@@ -57,17 +58,18 @@ fn install_from_github(
     )
 }
 
-fn install_from_gitlab(
-    repo: &GitlabRepo,
+fn install_from_git(
+    repo: &GitRepo,
     target: &Path,
     filter: Option<&crate::bundle::ResolvedItems>,
 ) -> Result<InstallReport> {
+    let (owner, name) = repo_display_parts(&repo.url);
     install_from_git_url(
-        &gitlab_clone_url(repo),
+        &git_clone_url(repo),
         repo.git_ref.as_deref(),
         repo.subfolder.as_deref(),
-        &repo.owner,
-        &repo.name,
+        owner,
+        name,
         target,
         filter,
     )
@@ -77,8 +79,15 @@ fn github_clone_url(repo: &GithubRepo) -> String {
     format!("https://github.com/{}/{}.git", repo.owner, repo.name)
 }
 
-fn gitlab_clone_url(repo: &GitlabRepo) -> String {
-    format!("https://{}/{}/{}.git", repo.host, repo.owner, repo.name)
+fn git_clone_url(repo: &GitRepo) -> String {
+    format!("{}.git", repo.url)
+}
+
+/// Split a bare remote URL into (prefix, last segment) for the
+/// human-facing error messages in `fetch::resolve_subfolder`, which
+/// formats them back as `{owner}/{name}` — reproducing the full URL.
+fn repo_display_parts(url: &str) -> (&str, &str) {
+    url.rsplit_once('/').unwrap_or(("", url))
 }
 
 /// Resolve the SSOT root for a source, fetching when remote.
@@ -103,13 +112,16 @@ pub fn fetch_ssot(source: &InstallSource) -> Result<(PathBuf, Option<tempfile::T
             &repo.owner,
             &repo.name,
         ),
-        InstallSource::Gitlab(repo) => clone_to_tempdir(
-            &gitlab_clone_url(repo),
-            repo.git_ref.as_deref(),
-            repo.subfolder.as_deref(),
-            &repo.owner,
-            &repo.name,
-        ),
+        InstallSource::Git(repo) => {
+            let (owner, name) = repo_display_parts(&repo.url);
+            clone_to_tempdir(
+                &git_clone_url(repo),
+                repo.git_ref.as_deref(),
+                repo.subfolder.as_deref(),
+                owner,
+                name,
+            )
+        }
     }
 }
 
@@ -172,48 +184,36 @@ mod tests {
     }
 
     #[test]
-    fn gitlab_clone_url_uses_repo_host() {
-        // gitlab.com
-        let repo = GitlabRepo {
-            host: "gitlab.com".into(),
-            owner: "driftsys".into(),
-            name: "skills".into(),
+    fn git_clone_url_appends_dot_git() {
+        let repo = GitRepo {
+            url: "https://gitlab.example.com/team/rules".into(),
             git_ref: None,
             subfolder: None,
         };
         assert_eq!(
-            gitlab_clone_url(&repo),
-            "https://gitlab.com/driftsys/skills.git"
-        );
-
-        // self-hosted GitLab
-        let self_hosted = GitlabRepo {
-            host: "gitlab.example.com".into(),
-            owner: "team".into(),
-            name: "rules".into(),
-            git_ref: None,
-            subfolder: None,
-        };
-        assert_eq!(
-            gitlab_clone_url(&self_hosted),
+            git_clone_url(&repo),
             "https://gitlab.example.com/team/rules.git"
         );
     }
 
     #[test]
-    fn gitlab_clone_url_with_subgroups() {
-        // Subgroup namespaces carry slashes in `owner`; the clone URL is the
-        // full path joined to the project name (GitLab clones the whole path).
-        let repo = GitlabRepo {
-            host: "gitlabee.dt.renault.com".into(),
-            owner: "partners/alliance-car/devex/process".into(),
-            name: "seed".into(),
+    fn git_clone_url_preserves_deep_paths_and_ports() {
+        let repo = GitRepo {
+            url: "https://git.company.com:8443/partners/devex/process/seed".into(),
             git_ref: None,
             subfolder: None,
         };
         assert_eq!(
-            gitlab_clone_url(&repo),
-            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed.git"
+            git_clone_url(&repo),
+            "https://git.company.com:8443/partners/devex/process/seed.git"
+        );
+    }
+
+    #[test]
+    fn repo_display_parts_splits_last_segment() {
+        assert_eq!(
+            repo_display_parts("https://gitlab.com/team/skills"),
+            ("https://gitlab.com/team", "skills")
         );
     }
 }

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -363,7 +363,7 @@ impl Resolver {
 fn source_git_ref(s: &InstallSource) -> Option<String> {
     match s {
         InstallSource::Github(r) => r.git_ref.clone(),
-        InstallSource::Gitlab(r) => r.git_ref.clone(),
+        InstallSource::Git(r) => r.git_ref.clone(),
         InstallSource::LocalPath(_) => None,
     }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -203,7 +203,7 @@ fn relocate_aliased_output(
 /// installed from a different source are left in place.
 ///
 /// `git_ref` recorded per item is taken from the source variant when one
-/// is pinned (Github/Gitlab `git_ref`); local-path sources record `None`.
+/// is pinned (Github/Git `git_ref`); local-path sources record `None`.
 /// `source` label is the [`InstallSource`] `Display` form.
 pub fn install_with_lockfile(
     source: &InstallSource,
@@ -264,7 +264,7 @@ pub fn install_with_lockfile(
                 .any(|n| discovery::find_bundle_by_name(&local_source, n).is_some()));
     let git_ref = match source {
         InstallSource::Github(r) => r.git_ref.as_deref(),
-        InstallSource::Gitlab(r) => r.git_ref.as_deref(),
+        InstallSource::Git(r) => r.git_ref.as_deref(),
         InstallSource::LocalPath(_) => None,
     };
     // A bundle-shaped request (`*.bundle.yaml` source or positional names that

--- a/src/source.rs
+++ b/src/source.rs
@@ -12,10 +12,11 @@ pub struct GithubRepo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GitlabRepo {
-    pub host: String,
-    pub owner: String,
-    pub name: String,
+pub struct GitRepo {
+    /// Bare https remote without a trailing `.git`, e.g.
+    /// `https://gitlab.example.com/group/sub/repo`. The host and path are
+    /// opaque — any git host works; auth is git's job (config/helpers).
+    pub url: String,
     pub git_ref: Option<String>,
     pub subfolder: Option<String>,
 }
@@ -23,7 +24,7 @@ pub struct GitlabRepo {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstallSource {
     Github(GithubRepo),
-    Gitlab(GitlabRepo),
+    Git(GitRepo),
     LocalPath(PathBuf),
 }
 
@@ -31,8 +32,8 @@ pub enum InstallSource {
 /// and CLI output. Format mirrors what `parse_install_source` accepts:
 ///
 /// - `github:<owner>/<name>[@<ref>][:<subfolder>]`
-/// - `gitlab:<owner>/<name>[@<ref>][:<subfolder>]` (host omitted when
-///   `gitlab.com`; otherwise `gitlab+<host>:...`)
+/// - `<url>[@<ref>][:<subfolder>]` — generic git source; the bare https
+///   URL is its own label
 /// - `local:<path>` (absolute when known, otherwise as-given)
 impl fmt::Display for InstallSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -46,12 +47,8 @@ impl fmt::Display for InstallSource {
                     Some(s) => write!(f, ":{}", s),
                     None => Ok(()),
                 }),
-            InstallSource::Gitlab(r) => {
-                if r.host == "gitlab.com" {
-                    write!(f, "gitlab:{}/{}", r.owner, r.name)?;
-                } else {
-                    write!(f, "gitlab+{}:{}/{}", r.host, r.owner, r.name)?;
-                }
+            InstallSource::Git(r) => {
+                write!(f, "{}", r.url)?;
                 if let Some(g) = &r.git_ref {
                     write!(f, "@{}", g)?;
                 }
@@ -75,6 +72,11 @@ pub enum SourceParseError {
     EmptySubfolder,
     #[error("ref must be non-empty")]
     EmptyRef,
+    #[error(
+        "the `gitlab:` shorthand was removed; use the full https URL instead, \
+         e.g. https://gitlab.com/owner/repo"
+    )]
+    GitlabShorthandRemoved,
 }
 
 /// Resolve the running user's home directory.
@@ -116,9 +118,12 @@ pub fn parse_install_source(source: &str) -> Result<InstallSource, SourceParseEr
         return Ok(InstallSource::LocalPath(PathBuf::from(source)));
     }
 
-    // gitlab: prefix
-    if let Some(rest) = source.strip_prefix("gitlab:") {
-        return parse_gitlab_source(rest, "gitlab.com").map(InstallSource::Gitlab);
+    // The `gitlab:` / `gitlab+<host>:` shorthands were removed in favor of
+    // full https URLs. Catch them explicitly so the error names the
+    // replacement instead of falling through to a confusing
+    // owner/repo parse error.
+    if source.starts_with("gitlab:") || source.starts_with("gitlab+") {
+        return Err(SourceParseError::GitlabShorthandRemoved);
     }
 
     // HTTPS URLs
@@ -156,8 +161,7 @@ fn is_windows_absolute(s: &str) -> bool {
 ///
 /// Recognised labels:
 /// - `github:<owner>/<name>[@<ref>][:<subfolder>]`
-/// - `gitlab:<owner>/<name>[@<ref>][:<subfolder>]` — host is `gitlab.com`
-/// - `gitlab+<host>:<owner>/<name>[@<ref>][:<subfolder>]` — self-hosted
+/// - `https://<host>/<path>[@<ref>][:<subfolder>]` — generic git source
 /// - `local:<path>` — absolute on round-trip; passed through verbatim
 pub fn parse_install_source_label(label: &str) -> Result<InstallSource, SourceParseError> {
     if let Some(rest) = label.strip_prefix("local:") {
@@ -166,17 +170,11 @@ pub fn parse_install_source_label(label: &str) -> Result<InstallSource, SourcePa
     if let Some(rest) = label.strip_prefix("github:") {
         return parse_github_source(rest).map(InstallSource::Github);
     }
-    if let Some(rest) = label.strip_prefix("gitlab+") {
-        let (host, after) = rest
-            .split_once(':')
-            .ok_or(SourceParseError::InvalidFormat)?;
-        if host.is_empty() {
-            return Err(SourceParseError::EmptySegment);
-        }
-        return parse_gitlab_source(after, host).map(InstallSource::Gitlab);
+    if let Some(rest) = label.strip_prefix("https://") {
+        return parse_url_source(rest);
     }
-    if let Some(rest) = label.strip_prefix("gitlab:") {
-        return parse_gitlab_source(rest, "gitlab.com").map(InstallSource::Gitlab);
+    if label.starts_with("gitlab:") || label.starts_with("gitlab+") {
+        return Err(SourceParseError::GitlabShorthandRemoved);
     }
     Err(SourceParseError::InvalidFormat)
 }
@@ -194,24 +192,29 @@ fn parse_url_source(url_without_scheme: &str) -> Result<InstallSource, SourcePar
         return parse_github_source(path_part).map(InstallSource::Github);
     }
 
-    // Everything else (gitlab.com, self-hosted) treated as GitLab-compatible
-    parse_gitlab_source(path_part, host_part).map(InstallSource::Gitlab)
+    // Any other https host is an opaque git remote.
+    parse_git_url(host_part, path_part).map(InstallSource::Git)
 }
 
-fn parse_gitlab_source(source: &str, host: &str) -> Result<GitlabRepo, SourceParseError> {
-    // Split off :subfolder first
-    let (before_subfolder, subfolder) = if let Some((before, sub)) = source.split_once(':') {
-        // Avoid confusing port numbers with subfolders — port is on the host, not here
+/// Parse the path portion of a generic git URL:
+/// `<path>[@<ref>][:<subfolder>]`. The host is opaque (and may carry a
+/// port); the path may nest arbitrarily deep (GitLab subgroups). A
+/// trailing `/` or `.git` on the repo path is stripped so browser-pasted
+/// and clone URLs normalise to one canonical label.
+fn parse_git_url(host: &str, path: &str) -> Result<GitRepo, SourceParseError> {
+    // Split off :subfolder first. The port is on the host part, already
+    // split away, so a ':' here is always a subfolder separator.
+    let (before_subfolder, subfolder) = if let Some((before, sub)) = path.split_once(':') {
         if sub.trim().is_empty() {
             return Err(SourceParseError::EmptySubfolder);
         }
         (before, Some(sub.to_string()))
     } else {
-        (source, None)
+        (path, None)
     };
 
     // Split off @ref
-    let (repo_source, git_ref) = if let Some((before, r)) = before_subfolder.split_once('@') {
+    let (repo_path, git_ref) = if let Some((before, r)) = before_subfolder.split_once('@') {
         if r.trim().is_empty() {
             return Err(SourceParseError::EmptyRef);
         }
@@ -220,24 +223,14 @@ fn parse_gitlab_source(source: &str, host: &str) -> Result<GitlabRepo, SourcePar
         (before_subfolder, None)
     };
 
-    // GitLab nests projects under arbitrarily deep subgroups. Everything
-    // before the last segment is the namespace (`owner`), the last segment is
-    // the project (`name`); cloning joins them back into the full path, so the
-    // split point only matters for the canonical label. At least one namespace
-    // segment is required — a bare project (`project`) has no `/` and is
-    // rejected.
-    let (owner, name) = repo_source
-        .rsplit_once('/')
-        .ok_or(SourceParseError::InvalidFormat)?;
-
-    if owner.trim().is_empty() || name.trim().is_empty() {
+    let repo_path = repo_path.trim_end_matches('/');
+    let repo_path = repo_path.strip_suffix(".git").unwrap_or(repo_path);
+    if repo_path.trim().is_empty() {
         return Err(SourceParseError::EmptySegment);
     }
 
-    Ok(GitlabRepo {
-        host: host.to_string(),
-        owner: owner.to_string(),
-        name: name.to_string(),
+    Ok(GitRepo {
+        url: format!("https://{host}/{repo_path}"),
         git_ref,
         subfolder,
     })
@@ -501,50 +494,6 @@ mod tests {
         assert_eq!(err, SourceParseError::EmptyRef);
     }
 
-    // GitLab source tests
-
-    #[test]
-    fn parse_gitlab_prefix() {
-        let source = parse_install_source("gitlab:team/skills").expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
-        };
-        assert_eq!(repo.host, "gitlab.com");
-        assert_eq!(repo.owner, "team");
-        assert_eq!(repo.name, "skills");
-    }
-
-    #[test]
-    fn parse_gitlab_prefix_with_ref() {
-        let source = parse_install_source("gitlab:team/skills@v2.0").expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
-        };
-        assert_eq!(repo.git_ref.as_deref(), Some("v2.0"));
-    }
-
-    #[test]
-    fn parse_gitlab_prefix_with_subfolder() {
-        let source =
-            parse_install_source("gitlab:team/skills@v1.0:tools/lint").expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
-        };
-        assert_eq!(repo.git_ref.as_deref(), Some("v1.0"));
-        assert_eq!(repo.subfolder.as_deref(), Some("tools/lint"));
-    }
-
-    #[test]
-    fn parse_gitlab_url() {
-        let source = parse_install_source("https://gitlab.com/team/skills").expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
-        };
-        assert_eq!(repo.host, "gitlab.com");
-        assert_eq!(repo.owner, "team");
-        assert_eq!(repo.name, "skills");
-    }
-
     #[test]
     fn parse_github_url() {
         let source =
@@ -556,80 +505,121 @@ mod tests {
         assert_eq!(repo.name, "skills");
     }
 
-    #[test]
-    fn parse_selfhosted_gitlab_url() {
-        let source =
-            parse_install_source("https://git.company.com/team/skills").expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
-        };
-        assert_eq!(repo.host, "git.company.com");
-        assert_eq!(repo.owner, "team");
-        assert_eq!(repo.name, "skills");
-    }
+    // Generic git-URL source tests — any https host that is not github.com
+    // is an opaque git remote (GitLab, Bitbucket, Gitea, corporate git).
 
     #[test]
-    fn parse_selfhosted_gitlab_with_port() {
-        let source =
-            parse_install_source("https://git.company.com:8443/team/skills").expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
+    fn parse_git_url_gitlab_com() {
+        let source = parse_install_source("https://gitlab.com/team/skills").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
         };
-        assert_eq!(repo.host, "git.company.com:8443");
-        assert_eq!(repo.owner, "team");
-        assert_eq!(repo.name, "skills");
-    }
-
-    #[test]
-    fn parse_selfhosted_gitlab_subgroup() {
-        // Self-hosted GitLab nests projects under arbitrarily deep
-        // subgroups; the full path before the project is the namespace.
-        let source = parse_install_source(
-            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed",
-        )
-        .expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
-        };
-        assert_eq!(repo.host, "gitlabee.dt.renault.com");
-        assert_eq!(repo.owner, "partners/alliance-car/devex/process");
-        assert_eq!(repo.name, "seed");
+        assert_eq!(repo.url, "https://gitlab.com/team/skills");
         assert_eq!(repo.git_ref, None);
         assert_eq!(repo.subfolder, None);
     }
 
     #[test]
-    fn parse_selfhosted_gitlab_subgroup_with_ref_and_subfolder() {
+    fn parse_git_url_bitbucket() {
+        let source = parse_install_source("https://bitbucket.org/team/repo").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://bitbucket.org/team/repo");
+    }
+
+    #[test]
+    fn parse_git_url_self_hosted_with_port() {
+        let source =
+            parse_install_source("https://git.company.com:8443/team/skills").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://git.company.com:8443/team/skills");
+    }
+
+    #[test]
+    fn parse_git_url_subgroups_any_depth() {
         let source = parse_install_source(
-            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed@v0.2.0:skills/seed.bundle.yaml",
+            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed",
         )
         .expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
         };
-        assert_eq!(repo.owner, "partners/alliance-car/devex/process");
-        assert_eq!(repo.name, "seed");
+        assert_eq!(
+            repo.url,
+            "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed"
+        );
+    }
+
+    #[test]
+    fn parse_git_url_with_ref_and_subfolder() {
+        let source = parse_install_source(
+            "https://gitlabee.dt.renault.com/partners/seed@v0.2.0:skills/seed.bundle.yaml",
+        )
+        .expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://gitlabee.dt.renault.com/partners/seed");
         assert_eq!(repo.git_ref.as_deref(), Some("v0.2.0"));
         assert_eq!(repo.subfolder.as_deref(), Some("skills/seed.bundle.yaml"));
     }
 
     #[test]
-    fn parse_gitlab_prefix_subgroup() {
-        let source = parse_install_source("gitlab:group/sub/project").expect("must parse");
-        let InstallSource::Gitlab(repo) = source else {
-            panic!("expected Gitlab");
+    fn parse_git_url_single_path_segment() {
+        // Plain git servers can host a repo directly under the root —
+        // unlike GitLab there is no namespace requirement.
+        let source = parse_install_source("https://git.example.com/repo").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
         };
-        assert_eq!(repo.host, "gitlab.com");
-        assert_eq!(repo.owner, "group/sub");
-        assert_eq!(repo.name, "project");
+        assert_eq!(repo.url, "https://git.example.com/repo");
     }
 
     #[test]
-    fn reject_gitlab_bare_project_without_namespace() {
-        // A GitLab source still needs at least one namespace segment before
-        // the project — `project` alone has nowhere to live.
-        let err = parse_install_source("gitlab:project").expect_err("must fail");
+    fn parse_git_url_strips_trailing_dot_git() {
+        let source =
+            parse_install_source("https://gitlab.com/team/skills.git").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://gitlab.com/team/skills");
+    }
+
+    #[test]
+    fn parse_git_url_strips_trailing_slash() {
+        let source = parse_install_source("https://gitlab.com/team/skills/").expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://gitlab.com/team/skills");
+    }
+
+    #[test]
+    fn reject_git_url_without_path() {
+        let err = parse_install_source("https://gitlab.com").expect_err("must fail");
         assert_eq!(err, SourceParseError::InvalidFormat);
+    }
+
+    #[test]
+    fn reject_git_url_with_empty_path() {
+        let err = parse_install_source("https://gitlab.com/").expect_err("must fail");
+        assert_eq!(err, SourceParseError::EmptySegment);
+    }
+
+    #[test]
+    fn reject_removed_gitlab_shorthand() {
+        let err = parse_install_source("gitlab:team/skills").expect_err("must fail");
+        assert_eq!(err, SourceParseError::GitlabShorthandRemoved);
+    }
+
+    #[test]
+    fn reject_removed_gitlab_plus_shorthand() {
+        let err =
+            parse_install_source("gitlab+git.company.com:team/skills").expect_err("must fail");
+        assert_eq!(err, SourceParseError::GitlabShorthandRemoved);
     }
 
     // Lockfile source label round-trip — every shape Display can produce
@@ -672,48 +662,38 @@ mod tests {
     }
 
     #[test]
-    fn label_roundtrip_gitlab_dot_com() {
-        assert_label_roundtrip(&InstallSource::Gitlab(GitlabRepo {
-            host: "gitlab.com".into(),
-            owner: "team".into(),
-            name: "skills".into(),
-            git_ref: Some("main".into()),
+    fn label_roundtrip_git_minimal() {
+        assert_label_roundtrip(&InstallSource::Git(GitRepo {
+            url: "https://gitlab.com/team/skills".into(),
+            git_ref: None,
             subfolder: None,
         }));
     }
 
     #[test]
-    fn label_roundtrip_gitlab_self_hosted() {
-        assert_label_roundtrip(&InstallSource::Gitlab(GitlabRepo {
-            host: "gitlab.example.com".into(),
-            owner: "team".into(),
-            name: "rules".into(),
-            git_ref: None,
-            subfolder: Some("a/b".into()),
-        }));
-    }
-
-    #[test]
-    fn label_roundtrip_gitlab_self_hosted_subgroup() {
-        assert_label_roundtrip(&InstallSource::Gitlab(GitlabRepo {
-            host: "gitlabee.dt.renault.com".into(),
-            owner: "partners/alliance-car/devex/process".into(),
-            name: "seed".into(),
+    fn label_roundtrip_git_full() {
+        assert_label_roundtrip(&InstallSource::Git(GitRepo {
+            url: "https://gitlabee.dt.renault.com/partners/alliance-car/devex/process/seed".into(),
             git_ref: Some("v0.2.0".into()),
             subfolder: Some("skills/seed.bundle.yaml".into()),
         }));
     }
 
     #[test]
-    fn label_rejects_bare_string() {
-        let err = parse_install_source_label("driftsys/skills").expect_err("must reject");
-        assert_eq!(err, SourceParseError::InvalidFormat);
+    fn label_rejects_removed_gitlab_shorthand() {
+        // Old lockfiles may still carry `gitlab:` labels — they hard-fail
+        // with the same self-serve error as the CLI input form (pre-1.0,
+        // no migration).
+        let err = parse_install_source_label("gitlab:team/x@main").expect_err("must reject");
+        assert_eq!(err, SourceParseError::GitlabShorthandRemoved);
+        let err = parse_install_source_label("gitlab+h.com:team/x").expect_err("must reject");
+        assert_eq!(err, SourceParseError::GitlabShorthandRemoved);
     }
 
     #[test]
-    fn label_rejects_gitlab_plus_without_host() {
-        let err = parse_install_source_label("gitlab+:team/x").expect_err("must reject");
-        assert_eq!(err, SourceParseError::EmptySegment);
+    fn label_rejects_bare_string() {
+        let err = parse_install_source_label("driftsys/skills").expect_err("must reject");
+        assert_eq!(err, SourceParseError::InvalidFormat);
     }
 
     #[test]

--- a/src/source.rs
+++ b/src/source.rs
@@ -598,6 +598,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_git_url_strips_dot_git_before_ref_and_subfolder() {
+        let source = parse_install_source("https://gitlab.com/team/skills.git@v1.0:tools/lint")
+            .expect("must parse");
+        let InstallSource::Git(repo) = source else {
+            panic!("expected Git");
+        };
+        assert_eq!(repo.url, "https://gitlab.com/team/skills");
+        assert_eq!(repo.git_ref.as_deref(), Some("v1.0"));
+        assert_eq!(repo.subfolder.as_deref(), Some("tools/lint"));
+    }
+
+    #[test]
+    fn reject_git_url_empty_ref() {
+        let err = parse_install_source("https://gitlab.com/team/skills@").expect_err("must fail");
+        assert_eq!(err, SourceParseError::EmptyRef);
+    }
+
+    #[test]
+    fn reject_git_url_empty_subfolder() {
+        let err = parse_install_source("https://gitlab.com/team/skills:").expect_err("must fail");
+        assert_eq!(err, SourceParseError::EmptySubfolder);
+    }
+
+    #[test]
     fn reject_git_url_without_path() {
         let err = parse_install_source("https://gitlab.com").expect_err("must fail");
         assert_eq!(err, SourceParseError::InvalidFormat);
@@ -677,6 +701,28 @@ mod tests {
             git_ref: Some("v0.2.0".into()),
             subfolder: Some("skills/seed.bundle.yaml".into()),
         }));
+    }
+
+    #[test]
+    fn label_roundtrip_git_with_port() {
+        assert_label_roundtrip(&InstallSource::Git(GitRepo {
+            url: "https://git.company.com:8443/team/skills".into(),
+            git_ref: Some("main".into()),
+            subfolder: None,
+        }));
+    }
+
+    #[test]
+    fn git_label_exact_form() {
+        let source = InstallSource::Git(GitRepo {
+            url: "https://git.company.com:8443/team/skills".into(),
+            git_ref: Some("v1.0".into()),
+            subfolder: Some("tools/lint".into()),
+        });
+        assert_eq!(
+            source.to_string(),
+            "https://git.company.com:8443/team/skills@v1.0:tools/lint"
+        );
     }
 
     #[test]

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -4,7 +4,7 @@
 //! `InstallSource`, runs `pipeline::install_with_lockfile`, and writes
 //! per-client output for rules / skills / agents (format-spec §7).
 //!
-//! Local-path source only — no network. GitHub/GitLab-source coverage is
+//! Local-path source only — no network. Git-source coverage is
 //! in `tests/pipeline_source.rs` at the library level.
 
 mod common;

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -8,6 +8,8 @@ use std::fs;
 
 use tempfile::tempdir;
 
+use predicates::prelude::*;
+
 #[test]
 fn version_long_flag_prints_to_stdout_and_exits_zero() {
     let cwd = tempdir().expect("must create temp dir");
@@ -81,4 +83,20 @@ fn general_errors_exit_one() {
         .assert()
         .code(1)
         .stderr("error: HOME (or USERPROFILE on Windows) is not set\n");
+}
+
+#[test]
+fn removed_gitlab_shorthand_exits_two_with_url_hint() {
+    // The `gitlab:` shorthand was deleted in favor of full https URLs.
+    // The error must name the replacement so users can self-serve.
+    let cwd = tempdir().expect("must create temp dir");
+    let home = cwd.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let mut cmd = common::upskill_cmd(&home);
+
+    cmd.current_dir(cwd.path())
+        .args(["add", "gitlab:team/skills"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("https://gitlab.com"));
 }

--- a/tests/pipeline_source.rs
+++ b/tests/pipeline_source.rs
@@ -7,7 +7,8 @@
 //!   the crate-internal `install_from_git_url` helper, which is the same
 //!   code path the GitHub branch uses (the only difference is URL
 //!   construction).
-//! - `Gitlab` — currently returns an error (out of scope for this slice).
+//! - `Git` — generic git-URL clone; exercised through the same
+//!   `install_from_git_url` code path.
 //!
 //! Network is not used.
 
@@ -68,10 +69,10 @@ fn install_from_source_local_path() {
     );
 }
 
-// GitLab dispatch is covered by unit tests in src/pipeline.rs
-// (gitlab_clone_url_uses_repo_host) plus the existing file:// tests against
+// Generic git-URL dispatch is covered by unit tests in src/pipeline/git.rs
+// (git_clone_url_appends_dot_git) plus the existing file:// tests against
 // install_from_git_url, which is the shared code path. An end-to-end network
-// test would depend on a live GitLab instance and is intentionally omitted.
+// test would depend on a live git host and is intentionally omitted.
 
 /// Build a local bare repo containing the fixture SSOT corpus, return its
 /// path. The pipeline can then clone it via a `file://` URL — exercises the
@@ -228,7 +229,7 @@ fn re_install_after_upstream_push_picks_up_new_content() {
     // install and update.
     //
     // CLI `update` reads source labels from the lockfile and only knows
-    // `github:` / `gitlab:` / `gitlab+host:` / `local:` prefixes — none of
+    // `github:` / `local:` prefixes and bare https URLs — none of
     // which round-trip a `file://` clone URL. So this test exercises the
     // underlying mechanism at the library layer: clone-install,
     // upstream-push, clone-install again. The clone+install path is


### PR DESCRIPTION
## Summary

- Replaces `InstallSource::Gitlab(GitlabRepo)` with a generic `InstallSource::Git(GitRepo { url, git_ref, subfolder })`: any https git host now works as a source (GitLab including self-hosted/subgroups, Bitbucket, Gitea, corporate git) — host and path are opaque, clones go through git's own configuration.
- **Breaking (pre-1.0, no migration):** the `gitlab:owner/repo` and `gitlab+<host>:` shorthands are removed. They now exit 2 with an error naming the full-URL replacement; old `gitlab:` lockfile labels hard-fail the same way. The GitHub `owner/repo` shorthand and full GitHub URLs are unchanged.
- New URL parsing normalizes browser-pasted forms (trailing `/` and `.git` stripped, ports preserved, any path depth) and the bare URL is its own lockfile label (`url[@ref][:subfolder]`, round-trip tested).
- Full docs sweep: commands/specification/recipes/format-spec/getting-started, AGENTS.md, CLI help text, bundle doc comments, and the `upskill-cli` skill no longer teach the removed shorthand.

Spec and plan are tracked under `docs/wip/` (to be gardened before the stack tip targets `main`).

## Test Plan

- [x] `just verify` green (zero-warning policy, clippy `-D warnings`, fmt, full suite)
- [x] New unit tests: generic URL parsing (Bitbucket, ports, subgroups any depth, single segment, `.git`/slash strip, empty ref/subfolder/path rejects) and Git label round-trips (minimal/full/port, exact Display form)
- [x] ATDD: `upskill add gitlab:team/repo` exits 2 with the full-URL hint (`tests/cli_exit_codes.rs`)
- [x] Verified live: built binary rejects the shorthand with the hint; clone-URL construction byte-identical to the old GitLab path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
