### PR TITLE
feat(mcp): configure MCP servers for Copilot, VS Code, and opencode (#237)

### DIFF
--- a/docs/adr/0010-mcp-config-write.md
+++ b/docs/adr/0010-mcp-config-write.md
@@ -110,25 +110,45 @@ upskill never owns a secret value. The rule:
 This is the same posture upskill already takes for git auth (tokens come
 from env / `gh` / `glab`, never persisted).
 
-### Per-client install contract — CLI-first, config-write fallback
+### Per-target install contract — CLI-first, config-write fallback
 
-v1 targets **Claude Code only**. opencode, VS Code, and GitHub Copilot are
-deferred to future releases (see Deferred section). An MCP entry in a
-bundle that arrives on a machine where only non-Claude clients are targeted
-produces a warn-skip — not an error.
+> **Amended 2026-07-01 (issue #237):** the contract below now covers **all
+> four MCP targets** — Claude Code, GitHub Copilot, VS Code, and opencode.
+> The original v1 shipped Claude-only; the _Deferred → Non-Claude clients_
+> note is now delivered. VS Code is an MCP **target** but not a generation
+> `Client`: it shares `.github/**` output with Copilot and forks only on MCP,
+> so the MCP target set (`claude`, `copilot`, `vscode`, `opencode`) is modelled
+> separately from `Client` (the `McpTarget` enum in `src/mcp.rs`).
 
-For Claude Code, the preference order is:
+Each bundle `mcps:` entry is configured for every target, CLI-first with a
+config-write fallback per target. A target whose CLI is absent **and** has no
+applicable config-write target produces a warn-skip — not an error.
 
-1. **CLI-first**: shell out to `claude mcp add`. The specific form depends
-   on transport:
-   - Local (stdio):
-     `claude mcp add <name> --scope <scope> [-e KEY=${VAR} …] -- <command> [args…]`
-   - Remote (http/sse):
-     `claude mcp add --transport <http|sse> <name> <url> --scope <scope> [-H "Header: ${VAR}" …]`
-2. **Config-write fallback**: when `claude` is not on PATH
-   (`ErrorKind::NotFound`), fall back to writing `.mcp.json` in the project
-   root (for project scope) or the user config location (for global scope).
-   The `.mcp.json` shape is `{ "mcpServers": { "<name>": { … } } }`.
+| Target         | CLI-first                                                 | Config-write fallback file                | Root key     |
+| -------------- | --------------------------------------------------------- | ----------------------------------------- | ------------ |
+| Claude Code    | `claude mcp add …` (`--scope`, `-e`, `--transport`, `-H`) | `.mcp.json`                               | `mcpServers` |
+| GitHub Copilot | `copilot mcp add …` (no `--scope`)                        | `~/.copilot/mcp-config.json` (user scope) | `mcpServers` |
+| VS Code        | `code --add-mcp '<json>'`                                 | `.vscode/mcp.json`                        | `servers`    |
+| opencode       | — (no `mcp add` verb)                                     | `opencode.json`                           | `mcp`        |
+
+The Claude forms are unchanged:
+
+- Local (stdio):
+  `claude mcp add <name> --scope <scope> [-e KEY=${VAR} …] -- <command> [args…]`
+- Remote (http/sse):
+  `claude mcp add --transport <http|sse> <name> <url> --scope <scope> [-H "Header: ${VAR}" …]`
+
+Per-target config shapes diverge:
+
+- **Claude / Copilot** share `{ command, args?, env? }` (local) /
+  `{ type, url, headers? }` (remote) under `mcpServers`.
+- **VS Code** uses root key `servers`; local servers are typed `"stdio"`.
+- **opencode** uses `type: "local"|"remote"`; local `command` is a single array
+  `[command, args…]` and the env map is named `environment`.
+- **Copilot** has no documented project-scope config file (`.github/mcp.json`
+  is not a Copilot CLI source), so the fallback is always the user-scope
+  `~/.copilot/mcp-config.json`; project scope is configured via the CLI or
+  warn-skipped.
 
 Config-write fallback is never the primary path — the same stance
 ADR-0008 took against patching `settings.json` as the primary plugin
@@ -179,17 +199,20 @@ entries silently ignore the unknown array (serde `default`).
 ### Removal and reconciliation
 
 - **`upskill remove-mcp <name>`**: a dedicated top-level subcommand (not
-  `upskill remove`). It shells out to `claude mcp remove <name> --scope
-  <scope>` (CLI-first), falling back to removing the entry from `.mcp.json`
-  when the CLI is absent. Drops the `LockedMcp` entry from the lockfile.
-- **`upskill doctor`**: checks each `claude`-client MCP entry in the
-  lockfile via `claude mcp list` (substring match on the server name). A
-  server present in the lockfile but absent from the client makes doctor
-  report `NotRegistered` and exit non-clean (exit 1). Doctor also reports
-  `CliNotFound` when the `claude` CLI is absent and `QueryFailed` when the
-  list query fails; it does **not** check `requires-env` variables.
-  Reconciliation never auto-removes entries — consistent with the project's
-  "never auto-delete" ethos.
+  `upskill remove`). For targets with a native remove verb (Claude
+  `claude mcp remove <name> --scope <scope>`, Copilot `copilot mcp remove
+  <name>`) it is CLI-first, falling back to deleting the entry from the
+  target's config file when the CLI is absent; VS Code and opencode are
+  config-file only. Drops every matching `LockedMcp` entry from the lockfile.
+- **`upskill doctor`**: reconciles each lockfile MCP entry against its
+  target. Claude is queried via `claude mcp list` (substring match); the
+  config-write targets (Copilot, VS Code, opencode) are checked against their
+  config file. A server present in the lockfile but absent from a present
+  config file (or from the Claude client) makes doctor report `NotRegistered`
+  and exit non-clean (exit 1). Claude also reports `CliNotFound` and
+  `QueryFailed`; for a config-write target whose config file is **absent** the
+  state is undetermined and the entry is skipped — no false positives. Doctor
+  does **not** check `requires-env` variables and never auto-removes entries.
 - **`upskill add` (install time)**: warns for each variable listed in
   `requires-env` that is not set in the current environment, immediately
   after configuring the server.
@@ -199,21 +222,27 @@ entries silently ignore the unknown array (serde `default`).
 - `src/model/bundle.rs` — `McpEntry { transport: McpTransport, requires_env }`;
   `McpTransport::Remote(McpRemote)` / `McpTransport::Local(McpLocal)`;
   `Bundle::validate_mcps`.
-- `src/mcp.rs` — typed CLI-shellout functions (`install_claude_local`,
-  `install_claude_remote`, `uninstall_claude`, `check_claude_installed`),
-  reusing the spawn/CLI-not-found helpers from `src/plugin.rs`. Never
-  writes to stdout/stderr.
-- `src/ancillary.rs` — `write_claude_mcp_local` / `write_claude_mcp_remote`
-  (config-write fallback into `.mcp.json`); `remove_claude_mcp` (removal
-  fallback). Merge-preserving: existing servers in `mcpServers` are not
-  clobbered.
-- `src/pipeline/install.rs` — `install_mcps_from_bundles`: iterates
-  resolved bundles, attempts CLI shellout, falls back to config-write on
-  `CliNotFound`, returns structured `McpResult` per server.
-- `src/lockfile.rs` — `LockedMcp`, `McpInstallStatus`, `upsert_mcp`,
-  `remove_mcps_by_name`.
-- `src/cli.rs` / `src/main.rs` — `Commands::RemoveMcp`; doctor
-  reconciliation loop over `mcps` lockfile entries.
+- `src/mcp.rs` — the `McpTarget` enum (`Claude`, `Copilot`, `VsCode`,
+  `OpenCode`) plus typed CLI-shellout functions per target with a CLI verb
+  (`install_claude_*`, `install_copilot_*`, `install_vscode_*`,
+  `uninstall_claude`, `uninstall_copilot`, `check_claude_installed`), reusing
+  the spawn/CLI-not-found helpers from `src/plugin.rs`. Never writes to
+  stdout/stderr.
+- `src/ancillary.rs` — config-write fallbacks per target
+  (`write_claude_mcp_*` → `.mcp.json`, `write_copilot_mcp_*` →
+  `~/.copilot/mcp-config.json`, `write_vscode_mcp_*` → `.vscode/mcp.json`,
+  `write_opencode_mcp_*` → `opencode.json`), the shared merge `upsert_mcp_server`
+  (path + root key), removers (`remove_*_mcp`), and doctor state queries
+  (`vscode_mcp_state` / `opencode_mcp_state` / `copilot_mcp_state`). All
+  merge-preserving: sibling servers and other top-level keys are never clobbered.
+- `src/pipeline/install.rs` — `install_mcps_from_bundles`: for each bundle
+  `mcps:` entry, fans out over `McpTarget::ALL`, attempts CLI shellout, falls
+  back to the target's config-write on `CliNotFound`, returns one structured
+  `McpResult` per `(name, target)`.
+- `src/lockfile.rs` — `LockedMcp`, `McpInstallStatus`, `upsert_mcp`
+  (keyed by `(name, client)`), `remove_mcps_by_name`.
+- `src/cli.rs` / `src/main.rs` — `Commands::RemoveMcp`; the `unconfigure_mcp`
+  dispatch over targets; doctor reconciliation loop over `mcps` lockfile entries.
 
 ## Consequences
 
@@ -234,19 +263,23 @@ entries silently ignore the unknown array (serde `default`).
 
 **Negative / limits.**
 
-- v1 is Claude-only. Teams using opencode or VS Code in parallel do not get
-  MCP configuration from the same bundle install — they must configure MCP
-  manually until those clients are supported.
-- Determinism loss: install outcome depends on whether `claude` is on PATH.
-  Integration tests that exercise the CLI path must shim `claude` on PATH;
-  tests that exercise config-write must clear PATH or point to an absent
-  binary.
+- A single bundle `mcps:` entry now fans out to four targets, so one server
+  yields four `LockedMcp` rows and may write up to four config files. There is
+  not yet a consumer-side switch to narrow the target set (tracked by #238); a
+  per-target consumer selection should honour the same filtering when it lands.
+- Determinism loss: install outcome depends on whether each target CLI is on
+  PATH. Integration tests that exercise a CLI path must shim it on PATH; tests
+  that exercise config-write must clear PATH or point to an absent binary.
 - The warn-skip policy can mask a real misconfiguration. Mitigated by
   `doctor`, which surfaces every `NotRegistered` server, and by `upskill add`
   which warns at install time for every unset `requires-env` variable.
-- Config-write fallback (`.mcp.json`) is a project-scope file; it does not
-  cover the global scope as cleanly as the CLI. The global config location
-  is client-version-specific and not yet handled by the fallback path.
+- Config-write fallbacks are project-scope files except Copilot, whose only
+  documented config file is the user-scope `~/.copilot/mcp-config.json`. The
+  Claude global-scope config location is client-version-specific and not yet
+  handled by the fallback path. VS Code's `code --add-mcp` writes the user
+  profile MCP store, which differs from the `.vscode/mcp.json` workspace file
+  the fallback writes — so a CLI-installed VS Code server is not removed by the
+  config-file remover.
 
 ## Alternatives considered
 
@@ -294,9 +327,10 @@ v1 config-write machinery. v2 also includes a generated skill-body preflight
 runtime under the client's permission prompts. upskill stays
 execution-free.
 
-**Non-Claude clients.** opencode, VS Code (`code --add-mcp`), and GitHub
-Copilot MCP configuration are deferred. When added, they will follow the
-same CLI-first / config-write-fallback pattern used here for Claude.
+**Non-Claude clients.** ~~Deferred.~~ **Delivered (2026-07-01, issue #237):**
+opencode, VS Code (`code --add-mcp`), and GitHub Copilot (`copilot mcp add`)
+now follow the same CLI-first / config-write-fallback pattern — see the
+amended _Per-target install contract_ above.
 
 ## Migration
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -751,14 +751,33 @@ secret values anywhere (not in config files, not in the lockfile, not in SSOT). 
 install time (e.g., during `upskill add`) when a declared variable is unset in the current
 environment, without reading its value.
 
-**Per-client install behavior (v1):** v1 targets Claude Code only. Other clients produce a
-warn-skip.
+**Per-client install behavior:** A bundle's `mcps:` entry is configured for every MCP **target** —
+Claude Code, GitHub Copilot, VS Code, and opencode — CLI-first with a config-write fallback per
+target. VS Code is an MCP target but **not** a generation client: it shares `.github/**`
+rules/skills/agents output with Copilot and forks **only** on MCP, so the MCP target set
+(`claude`, `copilot`, `vscode`, `opencode`) is modelled separately from the generation `Client`
+enum (`claude`, `copilot`, `opencode`).
 
-| Client      | Primary (CLI)                                                                         | Fallback (config-write, CLI absent)                          |
-| ----------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Claude Code | `claude mcp add <name> --scope <scope> [-e K=${V}] -- <cmd> [args]` (local)           | Write `{ "mcpServers": { "<name>": { … } } }` to `.mcp.json` |
-| Claude Code | `claude mcp add --transport <http\|sse> <name> <url> --scope <scope> [-H …]` (remote) | Same `.mcp.json` fallback                                    |
-| other       | not supported in v1 — warn-skip                                                       | —                                                            |
+| Target         | Primary (CLI)                                                                                                                                                       | Fallback config file                      | Root key     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ------------ |
+| Claude Code    | `claude mcp add <name> --scope <scope> [-e K=${V}] -- <cmd> [args]` (local) / `claude mcp add --transport <http\|sse> <name> <url> --scope <scope> [-H …]` (remote) | `.mcp.json`                               | `mcpServers` |
+| GitHub Copilot | `copilot mcp add …` (no `--scope`)                                                                                                                                  | `~/.copilot/mcp-config.json` (user scope) | `mcpServers` |
+| VS Code        | `code --add-mcp '<json>'`                                                                                                                                           | `.vscode/mcp.json`                        | `servers`    |
+| opencode       | — (no `mcp add` verb; config-only)                                                                                                                                  | `opencode.json`                           | `mcp`        |
+
+Per-target config shapes differ:
+
+- **Claude Code / GitHub Copilot** — `{ command, args?, env? }` (local) or `{ type, url, headers? }`
+  (remote).
+- **VS Code** — local servers are typed `"stdio"`; remote servers carry their `http`/`sse` value in
+  `type`, plus `url` and `headers`. The root key is **`servers`**, not `mcpServers`.
+- **opencode** — `type` is `"local"` or `"remote"`. For local servers `command` is a single **array**
+  combining the command and its args (`["npx", "-y", "my-tool-mcp"]`) and the env map is named
+  **`environment`** (not `env`). Remote servers carry `url` and `headers`.
+- **GitHub Copilot scope caveat** — Copilot has no documented project-scope MCP config file
+  (`.github/mcp.json` is not a Copilot CLI config source). The config-write fallback therefore always
+  targets the **user-scope** `~/.copilot/mcp-config.json`; project scope is configured via the
+  `copilot mcp add` CLI or warn-skipped.
 
 Claude's `--scope` derives from upskill's project/global context:
 
@@ -795,16 +814,21 @@ Lockfile MCP entry shape:
 The `mcps` array is additive. Implementations that do not support this field MUST ignore it
 (serde `default`). The lockfile `schema` field stays at `1` — no version bump.
 
-**Removal:** `upskill remove-mcp <name>` unregisters the named server from the client (via
-`claude mcp remove <name> --scope <scope>`, falling back to removing the entry from `.mcp.json`
-when the CLI is absent) and drops the `LockedMcp` entry from the lockfile.
+**Removal:** `upskill remove-mcp <name>` unregisters the named server from every target it was
+configured for and drops the matching `LockedMcp` entries from the lockfile. Targets with a native
+remove verb (Claude `claude mcp remove`, Copilot `copilot mcp remove`) are CLI-first, falling back
+to deleting the entry from the target's config file when the CLI is absent; VS Code and opencode
+are config-file only.
 
-**Reconciliation:** `upskill doctor` checks each Claude-client MCP entry in the lockfile
-against `claude mcp list`. A server present in the lockfile but absent from the client is
-reported as `NotRegistered` and causes doctor to exit non-clean (exit 1). Doctor also reports
-`CliNotFound` when the `claude` CLI is absent and `QueryFailed` when the list query fails;
-it does not check `requires-env` variables. The unset-env warning for `requires-env` variables
-is emitted by `upskill add` at install time.
+**Reconciliation:** `upskill doctor` reconciles each lockfile MCP entry against its target. Claude
+is queried via `claude mcp list`; the config-write targets (Copilot, VS Code, opencode) are checked
+against their config file. A server present in the lockfile but absent from a present config file
+(or from the Claude client) is reported as `NotRegistered` and causes doctor to exit non-clean
+(exit 1). Claude also reports `CliNotFound` when the `claude` CLI is absent and `QueryFailed` when
+the list query fails; for a config-write target whose config file is absent the state is
+undetermined and the entry is skipped rather than reported as drift (no false positives). Doctor
+does not check `requires-env` variables — the unset-env warning is emitted by `upskill add` at
+install time.
 
 Implementations:
 

--- a/src/ancillary.rs
+++ b/src/ancillary.rs
@@ -338,51 +338,215 @@ pub fn remove_opencode_plugin_uri(target: &Path, plugin_uri: &str) -> Result<()>
     Ok(())
 }
 
-/// Filename Claude Code reads for project-scoped MCP servers.
-const CLAUDE_MCP_JSON: &str = ".mcp.json";
+// ---------------------------------------------------------------------------
+// MCP config-write fallbacks (ADR-0010, issue #237)
+//
+// Each MCP target has its own config file and root key; the CLI is preferred
+// and these writers run only when the target's CLI is absent. All writes are
+// merge-preserving via `upsert_mcp_server` and never expand `${VAR}` values.
+// ---------------------------------------------------------------------------
 
-/// Write a local (stdio) MCP server into `<target>/.mcp.json` under
-/// `mcpServers.<name>`. Merge-preserving; creates the file if absent.
-/// Used as the fallback when the `claude` CLI is not on PATH.
-pub fn write_claude_mcp_local(target: &Path, name: &str, local: &McpLocal) -> PluginOutcome {
+/// Filename Claude Code reads for project-scoped MCP servers (root key
+/// `mcpServers`).
+const CLAUDE_MCP_JSON: &str = ".mcp.json";
+/// Filename VS Code reads for workspace MCP servers (root key `servers`).
+const VSCODE_MCP_JSON: &str = ".vscode/mcp.json";
+/// User-scope file the GitHub Copilot CLI reads (root key `mcpServers`).
+/// Copilot has no documented project-scope config file, so the fallback is
+/// always user-scope (issue #237 caveat).
+const COPILOT_MCP_CONFIG: &str = ".copilot/mcp-config.json";
+
+/// Resolve `~/.copilot/mcp-config.json`. `None` when neither `HOME` nor
+/// `USERPROFILE` is set.
+fn copilot_mcp_config_path() -> Option<std::path::PathBuf> {
+    crate::source::home_dir().map(|home| home.join(COPILOT_MCP_CONFIG))
+}
+
+// -- Claude / Copilot share the `{ "<root>": { "<name>": { … } } }` shape --
+
+/// `mcpServers`-style server object for a local (stdio) descriptor:
+/// `{ command, args?, env? }`.
+fn mcp_servers_local_value(local: &McpLocal) -> Value {
     let mut server = serde_json::Map::new();
     server.insert("command".into(), json!(local.command));
     if !local.args.is_empty() {
         server.insert("args".into(), json!(local.args));
     }
     if !local.env.is_empty() {
-        let env: serde_json::Map<String, Value> = local
-            .env
-            .iter()
-            .map(|(k, v)| (k.clone(), json!(v)))
-            .collect();
-        server.insert("env".into(), Value::Object(env));
+        server.insert("env".into(), json!(local.env));
     }
-    upsert_mcp_server(target, name, Value::Object(server))
+    Value::Object(server)
+}
+
+/// `mcpServers`-style server object for a remote descriptor:
+/// `{ type, url, headers? }`.
+fn mcp_servers_remote_value(remote: &McpRemote) -> Value {
+    let mut server = serde_json::Map::new();
+    server.insert("type".into(), json!(remote.transport_type));
+    server.insert("url".into(), json!(remote.url));
+    if !remote.headers.is_empty() {
+        server.insert("headers".into(), json!(remote.headers));
+    }
+    Value::Object(server)
+}
+
+/// Write a local (stdio) MCP server into `<target>/.mcp.json` under
+/// `mcpServers.<name>`. Merge-preserving; creates the file if absent.
+/// Used as the fallback when the `claude` CLI is not on PATH.
+pub fn write_claude_mcp_local(target: &Path, name: &str, local: &McpLocal) -> PluginOutcome {
+    upsert_mcp_server(
+        &target.join(CLAUDE_MCP_JSON),
+        "mcpServers",
+        name,
+        mcp_servers_local_value(local),
+    )
 }
 
 /// Write a remote MCP server into `<target>/.mcp.json` under
 /// `mcpServers.<name>`. Merge-preserving; creates the file if absent.
 pub fn write_claude_mcp_remote(target: &Path, name: &str, remote: &McpRemote) -> PluginOutcome {
+    upsert_mcp_server(
+        &target.join(CLAUDE_MCP_JSON),
+        "mcpServers",
+        name,
+        mcp_servers_remote_value(remote),
+    )
+}
+
+/// Write a local (stdio) MCP server into `~/.copilot/mcp-config.json` under
+/// `mcpServers.<name>` (Copilot's user-scope file). Fallback when the
+/// `copilot` CLI is not on PATH.
+pub fn write_copilot_mcp_local(name: &str, local: &McpLocal) -> PluginOutcome {
+    let Some(path) = copilot_mcp_config_path() else {
+        return PluginOutcome::Failed {
+            exit_code: None,
+            stderr: "could not determine HOME for ~/.copilot/mcp-config.json".into(),
+        };
+    };
+    upsert_mcp_server(&path, "mcpServers", name, mcp_servers_local_value(local))
+}
+
+/// Write a remote MCP server into `~/.copilot/mcp-config.json` under
+/// `mcpServers.<name>`.
+pub fn write_copilot_mcp_remote(name: &str, remote: &McpRemote) -> PluginOutcome {
+    let Some(path) = copilot_mcp_config_path() else {
+        return PluginOutcome::Failed {
+            exit_code: None,
+            stderr: "could not determine HOME for ~/.copilot/mcp-config.json".into(),
+        };
+    };
+    upsert_mcp_server(&path, "mcpServers", name, mcp_servers_remote_value(remote))
+}
+
+// -- VS Code: `.vscode/mcp.json`, root key `servers`, stdio typed `"stdio"` --
+
+/// VS Code server object for a local (stdio) descriptor:
+/// `{ type: "stdio", command, args?, env? }`.
+fn vscode_local_value(local: &McpLocal) -> Value {
+    let mut server = serde_json::Map::new();
+    server.insert("type".into(), json!("stdio"));
+    server.insert("command".into(), json!(local.command));
+    if !local.args.is_empty() {
+        server.insert("args".into(), json!(local.args));
+    }
+    if !local.env.is_empty() {
+        server.insert("env".into(), json!(local.env));
+    }
+    Value::Object(server)
+}
+
+/// VS Code server object for a remote descriptor: `{ type, url, headers? }`
+/// where `type` is the `http`/`sse` transport value.
+fn vscode_remote_value(remote: &McpRemote) -> Value {
     let mut server = serde_json::Map::new();
     server.insert("type".into(), json!(remote.transport_type));
     server.insert("url".into(), json!(remote.url));
     if !remote.headers.is_empty() {
-        let headers: serde_json::Map<String, Value> = remote
-            .headers
-            .iter()
-            .map(|(k, v)| (k.clone(), json!(v)))
-            .collect();
-        server.insert("headers".into(), Value::Object(headers));
+        server.insert("headers".into(), json!(remote.headers));
     }
-    upsert_mcp_server(target, name, Value::Object(server))
+    Value::Object(server)
 }
 
-/// Shared merge: insert `server` at `mcpServers.<name>` in `.mcp.json`,
-/// preserving any other top-level keys and other servers.
-fn upsert_mcp_server(target: &Path, name: &str, server: Value) -> PluginOutcome {
-    let path = target.join(CLAUDE_MCP_JSON);
-    let mut doc: Value = match std::fs::read_to_string(&path) {
+/// Write a local (stdio) MCP server into `<target>/.vscode/mcp.json` under
+/// `servers.<name>`. Merge-preserving; fallback when `code` is not on PATH.
+pub fn write_vscode_mcp_local(target: &Path, name: &str, local: &McpLocal) -> PluginOutcome {
+    upsert_mcp_server(
+        &target.join(VSCODE_MCP_JSON),
+        "servers",
+        name,
+        vscode_local_value(local),
+    )
+}
+
+/// Write a remote MCP server into `<target>/.vscode/mcp.json` under
+/// `servers.<name>`.
+pub fn write_vscode_mcp_remote(target: &Path, name: &str, remote: &McpRemote) -> PluginOutcome {
+    upsert_mcp_server(
+        &target.join(VSCODE_MCP_JSON),
+        "servers",
+        name,
+        vscode_remote_value(remote),
+    )
+}
+
+// -- opencode: `opencode.json`, root key `mcp`, distinct field shape --
+
+/// opencode server object for a local descriptor: `{ type: "local",
+/// command: [command, args…], environment? }`. opencode folds command+args
+/// into one array and names the env map `environment`.
+fn opencode_local_value(local: &McpLocal) -> Value {
+    let mut command = Vec::with_capacity(local.args.len() + 1);
+    command.push(local.command.clone());
+    command.extend(local.args.iter().cloned());
+
+    let mut server = serde_json::Map::new();
+    server.insert("type".into(), json!("local"));
+    server.insert("command".into(), json!(command));
+    if !local.env.is_empty() {
+        server.insert("environment".into(), json!(local.env));
+    }
+    Value::Object(server)
+}
+
+/// opencode server object for a remote descriptor: `{ type: "remote", url,
+/// headers? }`.
+fn opencode_remote_value(remote: &McpRemote) -> Value {
+    let mut server = serde_json::Map::new();
+    server.insert("type".into(), json!("remote"));
+    server.insert("url".into(), json!(remote.url));
+    if !remote.headers.is_empty() {
+        server.insert("headers".into(), json!(remote.headers));
+    }
+    Value::Object(server)
+}
+
+/// Write a local MCP server into `<target>/opencode.json` under `mcp.<name>`.
+/// Merge-preserving (opencode.json also holds `instructions`/`plugin`); this
+/// is opencode's only configuration path — it has no `mcp add` CLI verb.
+pub fn write_opencode_mcp_local(target: &Path, name: &str, local: &McpLocal) -> PluginOutcome {
+    upsert_mcp_server(
+        &target.join(OPENCODE_JSON),
+        "mcp",
+        name,
+        opencode_local_value(local),
+    )
+}
+
+/// Write a remote MCP server into `<target>/opencode.json` under `mcp.<name>`.
+pub fn write_opencode_mcp_remote(target: &Path, name: &str, remote: &McpRemote) -> PluginOutcome {
+    upsert_mcp_server(
+        &target.join(OPENCODE_JSON),
+        "mcp",
+        name,
+        opencode_remote_value(remote),
+    )
+}
+
+/// Shared merge: insert `server` at `<root_key>.<name>` in `path`,
+/// preserving any other top-level keys and any sibling servers. Creates the
+/// file (and parent dirs) when absent.
+fn upsert_mcp_server(path: &Path, root_key: &str, name: &str, server: Value) -> PluginOutcome {
+    let mut doc: Value = match std::fs::read_to_string(path) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => json!({}),
         Err(e) => {
             return PluginOutcome::Failed {
@@ -409,17 +573,17 @@ fn upsert_mcp_server(target: &Path, name: &str, server: Value) -> PluginOutcome 
     }
     let obj = doc.as_object_mut().expect("checked is_object");
     let servers = obj
-        .entry("mcpServers")
+        .entry(root_key)
         .or_insert_with(|| Value::Object(serde_json::Map::new()));
     let Some(servers) = servers.as_object_mut() else {
         return PluginOutcome::Failed {
             exit_code: None,
-            stderr: format!("{}: `mcpServers` must be an object", path.display()),
+            stderr: format!("{}: `{root_key}` must be an object", path.display()),
         };
     };
     servers.insert(name.to_string(), server);
 
-    if let Err(e) = write_pretty_json(&path, &doc) {
+    if let Err(e) = write_pretty_json(path, &doc) {
         return PluginOutcome::Failed {
             exit_code: None,
             stderr: e.to_string(),
@@ -430,18 +594,77 @@ fn upsert_mcp_server(target: &Path, name: &str, server: Value) -> PluginOutcome 
 
 /// Remove an MCP server from `<target>/.mcp.json`. No-op if absent.
 pub fn remove_claude_mcp(target: &Path, name: &str) -> Result<()> {
-    let path = target.join(CLAUDE_MCP_JSON);
-    let raw = match std::fs::read_to_string(&path) {
+    remove_mcp_server(&target.join(CLAUDE_MCP_JSON), "mcpServers", name)
+}
+
+/// Remove an MCP server from `<target>/.vscode/mcp.json`. No-op if absent.
+pub fn remove_vscode_mcp(target: &Path, name: &str) -> Result<()> {
+    remove_mcp_server(&target.join(VSCODE_MCP_JSON), "servers", name)
+}
+
+/// Remove an MCP server from `<target>/opencode.json` `mcp` map. No-op if
+/// absent.
+pub fn remove_opencode_mcp(target: &Path, name: &str) -> Result<()> {
+    remove_mcp_server(&target.join(OPENCODE_JSON), "mcp", name)
+}
+
+/// Remove an MCP server from `~/.copilot/mcp-config.json`. No-op if absent or
+/// if HOME is unset.
+pub fn remove_copilot_mcp(name: &str) -> Result<()> {
+    match copilot_mcp_config_path() {
+        Some(path) => remove_mcp_server(&path, "mcpServers", name),
+        None => Ok(()),
+    }
+}
+
+/// Shared removal: drop `<root_key>.<name>` from `path`. No-op if the file is
+/// absent. Preserves all other keys and servers.
+fn remove_mcp_server(path: &Path, root_key: &str, name: &str) -> Result<()> {
+    let raw = match std::fs::read_to_string(path) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
         Ok(r) => r,
     };
     let mut doc: Value =
         serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
-    if let Some(servers) = doc.get_mut("mcpServers").and_then(Value::as_object_mut) {
+    if let Some(servers) = doc.get_mut(root_key).and_then(Value::as_object_mut) {
         servers.remove(name);
     }
-    write_pretty_json(&path, &doc)
+    write_pretty_json(path, &doc)
+}
+
+// ---------------------------------------------------------------------------
+// MCP doctor reconciliation for config-write targets (issue #237)
+// ---------------------------------------------------------------------------
+
+/// Doctor query: does `<root_key>.<name>` exist in the JSON config at `path`?
+/// `None` means the file is absent or unreadable — the state is undetermined,
+/// so `doctor` must NOT treat it as drift (avoids false positives). `Some(false)`
+/// means the file exists but the server is gone (genuine drift).
+fn mcp_config_state(path: &Path, root_key: &str, name: &str) -> Option<bool> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let doc: Value = serde_json::from_str(&raw).ok()?;
+    Some(
+        doc.get(root_key)
+            .and_then(Value::as_object)
+            .is_some_and(|m| m.contains_key(name)),
+    )
+}
+
+/// Doctor state for a VS Code MCP entry (`.vscode/mcp.json` `servers.<name>`).
+pub fn vscode_mcp_state(target: &Path, name: &str) -> Option<bool> {
+    mcp_config_state(&target.join(VSCODE_MCP_JSON), "servers", name)
+}
+
+/// Doctor state for an opencode MCP entry (`opencode.json` `mcp.<name>`).
+pub fn opencode_mcp_state(target: &Path, name: &str) -> Option<bool> {
+    mcp_config_state(&target.join(OPENCODE_JSON), "mcp", name)
+}
+
+/// Doctor state for a Copilot MCP entry (`~/.copilot/mcp-config.json`
+/// `mcpServers.<name>`). `None` when HOME is unset or the file is absent.
+pub fn copilot_mcp_state(name: &str) -> Option<bool> {
+    copilot_mcp_config_path().and_then(|p| mcp_config_state(&p, "mcpServers", name))
 }
 
 fn write_pretty_json(path: &Path, value: &Value) -> Result<()> {
@@ -924,5 +1147,140 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         remove_claude_mcp(tmp.path(), "drawio").unwrap();
         assert!(!tmp.path().join(".mcp.json").exists());
+    }
+
+    #[test]
+    fn write_vscode_mcp_uses_servers_root_and_stdio_type() {
+        use crate::model::bundle::McpLocal;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = BTreeMap::new();
+        env.insert("TOK".to_string(), "${TOK}".to_string());
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec!["-y".into(), "srv".into()],
+            env,
+        };
+
+        assert!(write_vscode_mcp_local(tmp.path(), "drawio", &local).is_success());
+
+        let raw = std::fs::read_to_string(tmp.path().join(".vscode/mcp.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        // Root key MUST be `servers`, not `mcpServers` (AC for issue #237).
+        assert!(doc.get("mcpServers").is_none());
+        assert_eq!(doc["servers"]["drawio"]["type"], "stdio");
+        assert_eq!(doc["servers"]["drawio"]["command"], "npx");
+        assert_eq!(doc["servers"]["drawio"]["env"]["TOK"], "${TOK}");
+    }
+
+    #[test]
+    fn write_vscode_mcp_remote_types_by_transport() {
+        use crate::model::bundle::McpRemote;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let remote = McpRemote {
+            transport_type: "sse".into(),
+            url: "https://example.com/mcp".into(),
+            headers: BTreeMap::new(),
+        };
+        assert!(write_vscode_mcp_remote(tmp.path(), "ex", &remote).is_success());
+
+        let raw = std::fs::read_to_string(tmp.path().join(".vscode/mcp.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(doc["servers"]["ex"]["type"], "sse");
+        assert_eq!(doc["servers"]["ex"]["url"], "https://example.com/mcp");
+    }
+
+    #[test]
+    fn write_opencode_mcp_uses_array_command_and_environment() {
+        use crate::model::bundle::McpLocal;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = BTreeMap::new();
+        env.insert("TOK".to_string(), "${TOK}".to_string());
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec!["-y".into(), "srv".into()],
+            env,
+        };
+
+        assert!(write_opencode_mcp_local(tmp.path(), "drawio", &local).is_success());
+
+        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(doc["mcp"]["drawio"]["type"], "local");
+        // command is a single array combining command + args.
+        assert_eq!(
+            doc["mcp"]["drawio"]["command"],
+            serde_json::json!(["npx", "-y", "srv"])
+        );
+        // env is named `environment`; values pass through verbatim.
+        assert_eq!(doc["mcp"]["drawio"]["environment"]["TOK"], "${TOK}");
+        assert!(doc["mcp"]["drawio"].get("env").is_none());
+    }
+
+    #[test]
+    fn write_opencode_mcp_preserves_existing_keys() {
+        use crate::model::bundle::McpRemote;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        // opencode.json commonly already carries instructions / plugin keys.
+        std::fs::write(
+            tmp.path().join("opencode.json"),
+            r#"{"instructions":[".agents/rules/**/RULE.md"],"plugin":["p@git"]}"#,
+        )
+        .unwrap();
+
+        let remote = McpRemote {
+            transport_type: "http".into(),
+            url: "https://example.com/mcp".into(),
+            headers: BTreeMap::new(),
+        };
+        assert!(write_opencode_mcp_remote(tmp.path(), "ex", &remote).is_success());
+
+        let raw = std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(doc["instructions"][0], ".agents/rules/**/RULE.md");
+        assert_eq!(doc["plugin"][0], "p@git");
+        assert_eq!(doc["mcp"]["ex"]["type"], "remote");
+        assert_eq!(doc["mcp"]["ex"]["url"], "https://example.com/mcp");
+    }
+
+    #[test]
+    fn remove_vscode_and_opencode_mcp_drop_only_the_named_server() {
+        use crate::model::bundle::McpLocal;
+        use std::collections::BTreeMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec![],
+            env: BTreeMap::new(),
+        };
+        write_vscode_mcp_local(tmp.path(), "a", &local);
+        write_vscode_mcp_local(tmp.path(), "b", &local);
+        write_opencode_mcp_local(tmp.path(), "a", &local);
+        write_opencode_mcp_local(tmp.path(), "b", &local);
+
+        remove_vscode_mcp(tmp.path(), "a").unwrap();
+        remove_opencode_mcp(tmp.path(), "a").unwrap();
+
+        let vscode: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(tmp.path().join(".vscode/mcp.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(vscode["servers"]["a"].is_null());
+        assert_eq!(vscode["servers"]["b"]["command"], "npx");
+
+        let opencode: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(tmp.path().join("opencode.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(opencode["mcp"]["a"].is_null());
+        assert_eq!(opencode["mcp"]["b"]["type"], "local");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1360,6 +1360,50 @@ fn run_search(query: &str, limit: usize, registry: Option<&str>, kind: Option<&s
     EXIT_SUCCESS
 }
 
+/// Unconfigure one MCP entry from its target during `remove-mcp`. CLI-first
+/// for targets with a native remove verb (claude, copilot); falls back to
+/// deleting the entry from the target's config file when the CLI is absent.
+/// VS Code and opencode are config-only. CLI failures warn (never abort);
+/// config-file errors propagate to the caller.
+fn unconfigure_mcp(
+    client: &str,
+    name: &str,
+    scope: upskill::plugin::PluginScope,
+    target: &std::path::Path,
+) -> anyhow::Result<()> {
+    use upskill::plugin::PluginOutcome;
+
+    // CLI-first for targets with a remove verb; `None` = config-only target.
+    let cli_outcome = match client {
+        "claude" => Some(upskill::mcp::uninstall_claude(name, scope)),
+        "copilot" => Some(upskill::mcp::uninstall_copilot(name)),
+        _ => None,
+    };
+
+    match cli_outcome {
+        // CLI absent, or a config-only target → remove from the config file.
+        Some(PluginOutcome::CliNotFound) | None => match client {
+            "claude" => upskill::ancillary::remove_claude_mcp(target, name)?,
+            "copilot" => upskill::ancillary::remove_copilot_mcp(name)?,
+            "vscode" => upskill::ancillary::remove_vscode_mcp(target, name)?,
+            "opencode" => upskill::ancillary::remove_opencode_mcp(target, name)?,
+            _ => {}
+        },
+        Some(PluginOutcome::Failed { stderr, exit_code }) => {
+            eprintln!(
+                "{} failed to remove MCP '{}' from {} (exit {:?}): {}",
+                style::warn("warning:"),
+                name,
+                client,
+                exit_code,
+                stderr.trim()
+            );
+        }
+        Some(_) => {}
+    }
+    Ok(())
+}
+
 fn run_remove_mcp(name: &str, global: bool, project: bool) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
@@ -1392,26 +1436,9 @@ fn run_remove_mcp(name: &str, global: bool, project: bool) -> i32 {
     }
 
     for mcp in &matching_mcps {
-        if mcp.client == "claude" {
-            let outcome = upskill::mcp::uninstall_claude(&mcp.name, mcp_scope);
-            match outcome {
-                upskill::plugin::PluginOutcome::CliNotFound => {
-                    if let Err(err) = upskill::ancillary::remove_claude_mcp(&target, &mcp.name) {
-                        print_error_chain(&err);
-                        return EXIT_ERROR;
-                    }
-                }
-                upskill::plugin::PluginOutcome::Failed { stderr, exit_code } => {
-                    eprintln!(
-                        "{} failed to remove MCP '{}' from claude (exit {:?}): {}",
-                        style::warn("warning:"),
-                        mcp.name,
-                        exit_code,
-                        stderr.trim()
-                    );
-                }
-                _ => {}
-            }
+        if let Err(err) = unconfigure_mcp(&mcp.client, &mcp.name, mcp_scope, &target) {
+            print_error_chain(&err);
+            return EXIT_ERROR;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,6 +464,11 @@ fn print_mcp_results(report: &InstallReport) {
 
     use upskill::plugin::PluginOutcome;
 
+    // A single MCP server fans out to one result per target, so its
+    // `requires-env` warnings would otherwise repeat once per target. Warn
+    // once per (server, var) — the env var is set in the shell, not per client.
+    let mut warned_env: std::collections::HashSet<(&str, &str)> = std::collections::HashSet::new();
+
     for mr in &report.mcp_results {
         match &mr.outcome {
             PluginOutcome::Success => {
@@ -495,7 +500,7 @@ fn print_mcp_results(report: &InstallReport) {
             PluginOutcome::ManualInstructions => {}
         }
         for var in &mr.requires_env {
-            if std::env::var_os(var).is_none() {
+            if std::env::var_os(var).is_none() && warned_env.insert((&mr.name, var)) {
                 eprintln!(
                     "{} MCP '{}' needs env var '{}'; it is not set in your environment.",
                     style::warn("warning:"),
@@ -982,20 +987,20 @@ fn print_doctor_mcps(report: &DoctorReport) {
             McpDoctorStatus::Ok => {}
             McpDoctorStatus::NotRegistered => {
                 println!(
-                    "  MCP '{}' is in the lockfile but not registered in claude; re-run `upskill update`.",
-                    entry.name
+                    "  MCP '{}' is in the lockfile but not registered in {}; re-run `upskill update`.",
+                    entry.name, entry.client
                 );
             }
             McpDoctorStatus::CliNotFound => {
                 println!(
-                    "  claude CLI not found; cannot verify MCP '{}'.",
-                    entry.name
+                    "  {} CLI not found; cannot verify MCP '{}'.",
+                    entry.client, entry.name
                 );
             }
             McpDoctorStatus::QueryFailed { stderr } => {
                 println!(
-                    "  could not query claude MCP list for '{}': {}",
-                    entry.name, stderr
+                    "  could not query {} MCP list for '{}': {}",
+                    entry.client, entry.name, stderr
                 );
             }
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -8,6 +8,35 @@
 use crate::model::bundle::{McpLocal, McpRemote};
 use crate::plugin::{PluginCheckResult, PluginOutcome, PluginScope};
 
+/// A client whose MCP configuration upskill can write. Distinct from
+/// [`crate::generate::Client`]: VS Code shares `.github/**` rules/skills/agents
+/// output with Copilot and forks **only** on MCP, so it is an MCP target but
+/// not a generation `Client` (ADR-0010, issue #237).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum McpTarget {
+    Claude,
+    Copilot,
+    VsCode,
+    OpenCode,
+}
+
+impl McpTarget {
+    /// Every MCP target, in declaration order. Single source of truth for the
+    /// install fan-out and doctor reconciliation loops.
+    pub const ALL: [McpTarget; 4] = [Self::Claude, Self::Copilot, Self::VsCode, Self::OpenCode];
+
+    /// Stable identifier used in the lockfile `client` field, CLI output, and
+    /// [`McpResult`](crate::pipeline::report::McpResult)/[`LockedMcp`](crate::lockfile::LockedMcp).
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Copilot => "copilot",
+            Self::VsCode => "vscode",
+            Self::OpenCode => "opencode",
+        }
+    }
+}
+
 /// Build the argument vector for `claude mcp add` from a local (stdio)
 /// descriptor. Returned as owned strings so the caller can borrow them.
 pub fn claude_add_local_args(name: &str, local: &McpLocal, scope: PluginScope) -> Vec<String> {
@@ -76,6 +105,107 @@ pub fn check_claude_installed(name: &str) -> PluginCheckResult {
     crate::plugin::check_output_for_substring(out, name)
 }
 
+// ---------------------------------------------------------------------------
+// VS Code — `code --add-mcp '<json>'`
+// ---------------------------------------------------------------------------
+
+/// Build the single JSON argument `code --add-mcp` expects from a local
+/// (stdio) descriptor. VS Code keys the server by an inline `name` field and
+/// types stdio transports as `"stdio"`.
+pub fn vscode_add_local_json(name: &str, local: &McpLocal) -> String {
+    let mut server = serde_json::Map::new();
+    server.insert("name".into(), serde_json::json!(name));
+    server.insert("type".into(), serde_json::json!("stdio"));
+    server.insert("command".into(), serde_json::json!(local.command));
+    if !local.args.is_empty() {
+        server.insert("args".into(), serde_json::json!(local.args));
+    }
+    if !local.env.is_empty() {
+        server.insert("env".into(), serde_json::json!(local.env));
+    }
+    serde_json::Value::Object(server).to_string()
+}
+
+/// Build the single JSON argument `code --add-mcp` expects from a remote
+/// descriptor. VS Code types remote transports by their `http`/`sse` value.
+pub fn vscode_add_remote_json(name: &str, remote: &McpRemote) -> String {
+    let mut server = serde_json::Map::new();
+    server.insert("name".into(), serde_json::json!(name));
+    server.insert("type".into(), serde_json::json!(remote.transport_type));
+    server.insert("url".into(), serde_json::json!(remote.url));
+    if !remote.headers.is_empty() {
+        server.insert("headers".into(), serde_json::json!(remote.headers));
+    }
+    serde_json::Value::Object(server).to_string()
+}
+
+/// Install a local (stdio) MCP server into VS Code via `code --add-mcp`.
+pub fn install_vscode_local(name: &str, local: &McpLocal) -> PluginOutcome {
+    crate::plugin::run_command("code", &["--add-mcp", &vscode_add_local_json(name, local)])
+}
+
+/// Install a remote MCP server into VS Code via `code --add-mcp`.
+pub fn install_vscode_remote(name: &str, remote: &McpRemote) -> PluginOutcome {
+    crate::plugin::run_command(
+        "code",
+        &["--add-mcp", &vscode_add_remote_json(name, remote)],
+    )
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Copilot CLI — `copilot mcp add` / `copilot mcp remove`
+// ---------------------------------------------------------------------------
+
+/// Build the argument vector for `copilot mcp add` from a local (stdio)
+/// descriptor. Mirrors the `claude mcp add` shape; Copilot has no `--scope`.
+pub fn copilot_add_local_args(name: &str, local: &McpLocal) -> Vec<String> {
+    let mut args = vec!["mcp".to_string(), "add".to_string(), name.to_string()];
+    for (k, v) in &local.env {
+        args.push("-e".to_string());
+        args.push(format!("{k}={v}"));
+    }
+    args.push("--".to_string());
+    args.push(local.command.clone());
+    args.extend(local.args.iter().cloned());
+    args
+}
+
+/// Build the argument vector for `copilot mcp add` from a remote descriptor.
+pub fn copilot_add_remote_args(name: &str, remote: &McpRemote) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "--transport".to_string(),
+        remote.transport_type.clone(),
+        name.to_string(),
+        remote.url.clone(),
+    ];
+    for (header, value) in &remote.headers {
+        args.push("-H".to_string());
+        args.push(format!("{header}: {value}"));
+    }
+    args
+}
+
+/// Install a local (stdio) MCP server into Copilot CLI via `copilot mcp add`.
+pub fn install_copilot_local(name: &str, local: &McpLocal) -> PluginOutcome {
+    let args = copilot_add_local_args(name, local);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::plugin::run_command("copilot", &arg_refs)
+}
+
+/// Install a remote MCP server into Copilot CLI via `copilot mcp add`.
+pub fn install_copilot_remote(name: &str, remote: &McpRemote) -> PluginOutcome {
+    let args = copilot_add_remote_args(name, remote);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::plugin::run_command("copilot", &arg_refs)
+}
+
+/// Remove an MCP server from Copilot CLI via `copilot mcp remove`.
+pub fn uninstall_copilot(name: &str) -> PluginOutcome {
+    crate::plugin::run_command("copilot", &["mcp", "remove", name])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,6 +258,99 @@ mod tests {
                 "https://mcp.draw.io/mcp",
                 "--scope",
                 "user",
+            ]
+        );
+    }
+
+    #[test]
+    fn mcp_target_names_are_stable() {
+        assert_eq!(McpTarget::Claude.name(), "claude");
+        assert_eq!(McpTarget::Copilot.name(), "copilot");
+        assert_eq!(McpTarget::VsCode.name(), "vscode");
+        assert_eq!(McpTarget::OpenCode.name(), "opencode");
+        assert_eq!(McpTarget::ALL.len(), 4);
+    }
+
+    #[test]
+    fn vscode_local_json_uses_stdio_type_and_inline_name() {
+        let mut env = BTreeMap::new();
+        env.insert("DRAWIO_TOKEN".to_string(), "${DRAWIO_TOKEN}".to_string());
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec!["-y".into(), "drawio-mcp-server".into()],
+            env,
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&vscode_add_local_json("drawio", &local)).unwrap();
+        assert_eq!(json["name"], "drawio");
+        assert_eq!(json["type"], "stdio");
+        assert_eq!(json["command"], "npx");
+        assert_eq!(json["args"], serde_json::json!(["-y", "drawio-mcp-server"]));
+        // Secret passes through verbatim — never expanded.
+        assert_eq!(json["env"]["DRAWIO_TOKEN"], "${DRAWIO_TOKEN}");
+    }
+
+    #[test]
+    fn vscode_remote_json_carries_transport_type_and_url() {
+        let mut headers = BTreeMap::new();
+        headers.insert("Authorization".to_string(), "Bearer ${TOK}".to_string());
+        let remote = McpRemote {
+            transport_type: "sse".into(),
+            url: "https://mcp.draw.io/mcp".into(),
+            headers,
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&vscode_add_remote_json("drawio", &remote)).unwrap();
+        assert_eq!(json["name"], "drawio");
+        assert_eq!(json["type"], "sse");
+        assert_eq!(json["url"], "https://mcp.draw.io/mcp");
+        assert_eq!(json["headers"]["Authorization"], "Bearer ${TOK}");
+    }
+
+    #[test]
+    fn copilot_local_args_have_no_scope_flag() {
+        let mut env = BTreeMap::new();
+        env.insert("DRAWIO_TOKEN".to_string(), "${DRAWIO_TOKEN}".to_string());
+        let local = McpLocal {
+            command: "npx".into(),
+            args: vec!["-y".into(), "drawio-mcp-server".into()],
+            env,
+        };
+        let args = copilot_add_local_args("drawio", &local);
+        assert_eq!(
+            args,
+            vec![
+                "mcp",
+                "add",
+                "drawio",
+                "-e",
+                "DRAWIO_TOKEN=${DRAWIO_TOKEN}",
+                "--",
+                "npx",
+                "-y",
+                "drawio-mcp-server",
+            ]
+        );
+        assert!(!args.iter().any(|a| a == "--scope"));
+    }
+
+    #[test]
+    fn copilot_remote_args_include_transport_and_url() {
+        let remote = McpRemote {
+            transport_type: "http".into(),
+            url: "https://mcp.draw.io/mcp".into(),
+            headers: BTreeMap::new(),
+        };
+        let args = copilot_add_remote_args("drawio", &remote);
+        assert_eq!(
+            args,
+            vec![
+                "mcp",
+                "add",
+                "--transport",
+                "http",
+                "drawio",
+                "https://mcp.draw.io/mcp",
             ]
         );
     }

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -924,54 +924,114 @@ pub(super) fn install_plugins_from_bundles(
 // ---------------------------------------------------------------------------
 
 /// Iterate all resolved bundles and configure each declared MCP server for
-/// Claude Code (v1's only target client). CLI-first: `claude mcp add`; on
-/// CliNotFound, fall back to writing `.mcp.json`. Warn-skip preserved: a
-/// failure never aborts the overall install.
+/// every [`McpTarget`](crate::mcp::McpTarget): Claude, Copilot, VS Code, and
+/// opencode (ADR-0010, issue #237). Per target, CLI-first; on `CliNotFound`,
+/// fall back to the target's config-write file. Warn-skip preserved: a single
+/// target's failure or skip never aborts the overall install. One `McpResult`
+/// is recorded per `(name, target)`.
 ///
 /// Covered by the `tests/pipeline_mcp.rs` integration test, which clears
 /// PATH so the config-write fallback runs deterministically into a tempdir
-/// (an in-process unit test cannot safely force the `claude` CLI off PATH).
+/// (an in-process unit test cannot safely force the client CLIs off PATH).
 pub(super) fn install_mcps_from_bundles(
     bundles: &[crate::model::Bundle],
     scope: crate::plugin::PluginScope,
     target: &Path,
 ) -> Vec<McpResult> {
-    use crate::model::bundle::McpTransport;
-    use crate::plugin::PluginOutcome;
+    use crate::mcp::McpTarget;
 
     let mut results = Vec::new();
     for bundle in bundles {
         for (name, entry) in &bundle.mcps {
-            let cli_outcome = match &entry.transport {
-                McpTransport::Local(local) => crate::mcp::install_claude_local(name, local, scope),
-                McpTransport::Remote(remote) => {
-                    crate::mcp::install_claude_remote(name, remote, scope)
-                }
-            };
-
-            // CLI absent → config-write fallback into .mcp.json.
-            let outcome = match cli_outcome {
-                PluginOutcome::CliNotFound => match &entry.transport {
-                    McpTransport::Local(local) => {
-                        crate::ancillary::write_claude_mcp_local(target, name, local)
-                    }
-                    McpTransport::Remote(remote) => {
-                        crate::ancillary::write_claude_mcp_remote(target, name, remote)
-                    }
-                },
-                other => other,
-            };
-
-            results.push(McpResult {
-                name: name.clone(),
-                client: "claude".into(),
-                outcome,
-                bundle: bundle.name.clone(),
-                requires_env: entry.requires_env.clone(),
-            });
+            for mcp_target in McpTarget::ALL {
+                let outcome = configure_mcp_for_target(mcp_target, name, entry, scope, target);
+                results.push(McpResult {
+                    name: name.clone(),
+                    client: mcp_target.name().into(),
+                    outcome,
+                    bundle: bundle.name.clone(),
+                    requires_env: entry.requires_env.clone(),
+                });
+            }
         }
     }
     results
+}
+
+/// Configure one MCP server into one target: CLI-first, then the target's
+/// config-write fallback when the CLI is absent. opencode has no `mcp add`
+/// verb, so it goes straight to config-write.
+fn configure_mcp_for_target(
+    mcp_target: crate::mcp::McpTarget,
+    name: &str,
+    entry: &crate::model::bundle::McpEntry,
+    scope: crate::plugin::PluginScope,
+    target: &Path,
+) -> crate::plugin::PluginOutcome {
+    use crate::mcp::McpTarget;
+    use crate::model::bundle::McpTransport;
+    use crate::plugin::PluginOutcome;
+
+    // CLI-first. opencode is config-only — treat as CliNotFound so the match
+    // below routes it to config-write.
+    let cli_outcome = match (mcp_target, &entry.transport) {
+        (McpTarget::Claude, McpTransport::Local(l)) => {
+            crate::mcp::install_claude_local(name, l, scope)
+        }
+        (McpTarget::Claude, McpTransport::Remote(r)) => {
+            crate::mcp::install_claude_remote(name, r, scope)
+        }
+        (McpTarget::Copilot, McpTransport::Local(l)) => crate::mcp::install_copilot_local(name, l),
+        (McpTarget::Copilot, McpTransport::Remote(r)) => {
+            crate::mcp::install_copilot_remote(name, r)
+        }
+        (McpTarget::VsCode, McpTransport::Local(l)) => crate::mcp::install_vscode_local(name, l),
+        (McpTarget::VsCode, McpTransport::Remote(r)) => crate::mcp::install_vscode_remote(name, r),
+        (McpTarget::OpenCode, _) => PluginOutcome::CliNotFound,
+    };
+
+    match cli_outcome {
+        PluginOutcome::CliNotFound => config_write_mcp_for_target(mcp_target, name, entry, target),
+        other => other,
+    }
+}
+
+/// Config-write fallback dispatch — one writer per target/transport. Copilot
+/// writes its user-scope `~/.copilot/mcp-config.json` (no project file).
+fn config_write_mcp_for_target(
+    mcp_target: crate::mcp::McpTarget,
+    name: &str,
+    entry: &crate::model::bundle::McpEntry,
+    target: &Path,
+) -> crate::plugin::PluginOutcome {
+    use crate::ancillary;
+    use crate::mcp::McpTarget;
+    use crate::model::bundle::McpTransport;
+
+    match (mcp_target, &entry.transport) {
+        (McpTarget::Claude, McpTransport::Local(l)) => {
+            ancillary::write_claude_mcp_local(target, name, l)
+        }
+        (McpTarget::Claude, McpTransport::Remote(r)) => {
+            ancillary::write_claude_mcp_remote(target, name, r)
+        }
+        (McpTarget::Copilot, McpTransport::Local(l)) => ancillary::write_copilot_mcp_local(name, l),
+        (McpTarget::Copilot, McpTransport::Remote(r)) => {
+            ancillary::write_copilot_mcp_remote(name, r)
+        }
+        (McpTarget::VsCode, McpTransport::Local(l)) => {
+            ancillary::write_vscode_mcp_local(target, name, l)
+        }
+        (McpTarget::VsCode, McpTransport::Remote(r)) => {
+            ancillary::write_vscode_mcp_remote(target, name, r)
+        }
+        (McpTarget::OpenCode, McpTransport::Local(l)) => {
+            ancillary::write_opencode_mcp_local(target, name, l)
+        }
+        (McpTarget::OpenCode, McpTransport::Remote(r)) => {
+            ancillary::write_opencode_mcp_remote(target, name, r)
+        }
+    }
 }
 
 /// The per-kind frontmatter fields the install loop needs after parsing,

--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -303,24 +303,41 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
         }
     }
 
-    // -- MCP server reconciliation (ADR-0010) --
+    // -- MCP server reconciliation (ADR-0010, issue #237) --
     // Walk the lockfile's MCP entries and check whether each is still
-    // registered in the client. Only `claude` client is supported for
-    // query; others are skipped (no list command available).
+    // configured for its target. Claude is queried via `claude mcp list`; the
+    // config-write targets (copilot, vscode, opencode) are reconciled against
+    // their config file. When that file is absent the state is undetermined,
+    // so the entry is skipped rather than reported as drift (no false
+    // positives for targets configured out-of-band).
     for mcp in &lock.mcps {
-        if mcp.client != "claude" {
-            continue;
-        }
         use crate::pipeline::report::{McpDoctorEntry, McpDoctorStatus};
-        use crate::plugin::PluginCheckResult;
 
-        let status = match crate::mcp::check_claude_installed(&mcp.name) {
-            PluginCheckResult::Installed => McpDoctorStatus::Ok,
-            PluginCheckResult::NotInstalled => McpDoctorStatus::NotRegistered,
-            PluginCheckResult::CliNotFound => McpDoctorStatus::CliNotFound,
-            PluginCheckResult::QueryFailed { stderr, .. } => {
-                McpDoctorStatus::QueryFailed { stderr }
+        let status = match mcp.client.as_str() {
+            "claude" => {
+                use crate::plugin::PluginCheckResult;
+                match crate::mcp::check_claude_installed(&mcp.name) {
+                    PluginCheckResult::Installed => McpDoctorStatus::Ok,
+                    PluginCheckResult::NotInstalled => McpDoctorStatus::NotRegistered,
+                    PluginCheckResult::CliNotFound => McpDoctorStatus::CliNotFound,
+                    PluginCheckResult::QueryFailed { stderr, .. } => {
+                        McpDoctorStatus::QueryFailed { stderr }
+                    }
+                }
             }
+            "copilot" | "vscode" | "opencode" => {
+                let state = match mcp.client.as_str() {
+                    "copilot" => crate::ancillary::copilot_mcp_state(&mcp.name),
+                    "vscode" => crate::ancillary::vscode_mcp_state(target, &mcp.name),
+                    _ => crate::ancillary::opencode_mcp_state(target, &mcp.name),
+                };
+                match state {
+                    Some(true) => McpDoctorStatus::Ok,
+                    Some(false) => McpDoctorStatus::NotRegistered,
+                    None => continue,
+                }
+            }
+            _ => continue,
         };
         report.mcp_entries.push(McpDoctorEntry {
             name: mcp.name.clone(),

--- a/tests/cli_mcp.rs
+++ b/tests/cli_mcp.rs
@@ -163,6 +163,7 @@ fn add_bundle_with_mcp_is_deterministic_second_run() {
             .success();
     }
 
+    // Claude's `.mcp.json` holds exactly the one server (one file per target).
     let raw = fs::read_to_string(project.join(".mcp.json")).unwrap();
     let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
     let servers = doc["mcpServers"].as_object().expect("mcpServers object");
@@ -172,12 +173,15 @@ fn add_bundle_with_mcp_is_deterministic_second_run() {
         "second add must not duplicate the server entry; got {servers:?}"
     );
 
+    // The lockfile records one entry per MCP target (claude, copilot, vscode,
+    // opencode) — a single server fans out to four. The second run upserts by
+    // (name, client) and must NOT accumulate duplicates beyond those four.
     let lock_raw = fs::read_to_string(project.join(".upskill-lock.json")).unwrap();
     let lock: serde_json::Value = serde_json::from_str(&lock_raw).unwrap();
     let mcps = lock["mcps"].as_array().expect("mcps array");
     assert_eq!(
         mcps.len(),
-        1,
-        "second add must not duplicate the lockfile mcp entry; got {mcps:?}"
+        4,
+        "second add must not duplicate beyond one entry per target; got {mcps:?}"
     );
 }

--- a/tests/pipeline_mcp.rs
+++ b/tests/pipeline_mcp.rs
@@ -1,11 +1,10 @@
-//! ATDD tests for the MCP server install + remove lifecycle.
+//! ATDD tests for the MCP server install + remove lifecycle across all four
+//! MCP targets (Claude, Copilot, VS Code, opencode — ADR-0010, issue #237).
 //!
-//! Exercises `upskill add` → lockfile records MCP server, then
-//! `upskill remove-mcp <name>` → lockfile drops MCP server.
-//!
-//! `claude` is kept off PATH throughout by setting PATH to an empty
-//! directory, so the config-write fallback runs deterministically into the
-//! test's tempdir.
+//! `claude`, `copilot`, and `code` are kept off PATH throughout by setting
+//! PATH to an empty directory, so each target's config-write fallback runs
+//! deterministically into the test's tempdir (and the test HOME for Copilot's
+//! user-scope file). opencode is config-only and has no CLI step.
 
 mod common;
 
@@ -26,7 +25,7 @@ Minimal body.
 ";
 
 /// Bundle with a remote HTTP MCP server.
-const BUNDLE_YAML: &str = "\
+const BUNDLE_REMOTE_YAML: &str = "\
 schema: 1
 name: b
 description: Bundle with remote MCP
@@ -42,24 +41,49 @@ mcps:
       url: https://example.com/mcp
 ";
 
-/// Build a minimal SSOT registry with a single skill and a bundle that
-/// declares a remote MCP server.
-fn stage_remote_mcp_registry(root: &Path) {
+/// Bundle with a local (stdio) MCP server that references a secret via
+/// `${TOKEN}` indirection — upskill must write it verbatim, never expand it.
+const BUNDLE_LOCAL_YAML: &str = "\
+schema: 1
+name: b
+description: Bundle with local MCP
+
+items:
+  skills:
+    - s
+
+mcps:
+  local-srv:
+    local:
+      command: npx
+      args: [\"-y\", \"my-tool-mcp\"]
+      env:
+        TOKEN: \"${TOKEN}\"
+";
+
+/// Build a minimal SSOT registry with a single skill and a bundle whose
+/// `.bundle.yaml` contents are `bundle_yaml`.
+fn stage_registry(root: &Path, bundle_yaml: &str) {
     let skill_dir = root.join("s");
     fs::create_dir_all(&skill_dir).unwrap();
     fs::write(skill_dir.join("SKILL.md"), SKILL_MD).unwrap();
 
     let bundles_dir = root.join("bundles");
     fs::create_dir_all(&bundles_dir).unwrap();
-    fs::write(bundles_dir.join("b.bundle.yaml"), BUNDLE_YAML).unwrap();
+    fs::write(bundles_dir.join("b.bundle.yaml"), bundle_yaml).unwrap();
 }
 
-/// PATH that contains only an empty directory — `claude` absent, local-path
-/// add still works (no external binary needed for local sources).
+/// PATH that contains only an empty directory — every client CLI is absent,
+/// so config-write fallbacks run. Local-path `add` needs no external binary.
 fn empty_bin_path(tmp: &Path) -> String {
     let bin = tmp.join("empty-bin");
     fs::create_dir_all(&bin).unwrap();
     bin.to_str().unwrap().to_string()
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    let raw = fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&raw).unwrap()
 }
 
 #[test]
@@ -70,7 +94,7 @@ fn add_then_remove_mcp_updates_lockfile() {
 
     let registry = tmp.path().join("registry");
     let project = tmp.path().join("project");
-    stage_remote_mcp_registry(&registry);
+    stage_registry(&registry, BUNDLE_REMOTE_YAML);
     fs::create_dir_all(&project).unwrap();
     // Mark as a git repo so project scope is selected.
     fs::create_dir_all(project.join(".git")).unwrap();
@@ -109,4 +133,239 @@ fn add_then_remove_mcp_updates_lockfile() {
         !lock_raw_after.contains("\"remote-srv\""),
         "lockfile must NOT contain 'remote-srv' after remove-mcp: {lock_raw_after}"
     );
+}
+
+#[test]
+fn add_remote_mcp_configures_every_target_with_correct_root_key() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_registry(&registry, BUNDLE_REMOTE_YAML);
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/b.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["add", bundle_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Claude — `.mcp.json`, root key `mcpServers`.
+    let claude = read_json(&project.join(".mcp.json"));
+    assert_eq!(claude["mcpServers"]["remote-srv"]["type"], "http");
+    assert_eq!(
+        claude["mcpServers"]["remote-srv"]["url"],
+        "https://example.com/mcp"
+    );
+
+    // VS Code — `.vscode/mcp.json`, root key `servers` (NOT mcpServers).
+    let vscode = read_json(&project.join(".vscode/mcp.json"));
+    assert!(
+        vscode.get("mcpServers").is_none(),
+        "VS Code config must use `servers`, not `mcpServers`: {vscode}"
+    );
+    assert_eq!(vscode["servers"]["remote-srv"]["type"], "http");
+    assert_eq!(
+        vscode["servers"]["remote-srv"]["url"],
+        "https://example.com/mcp"
+    );
+
+    // opencode — `opencode.json`, key `mcp.<name>`, transport `remote`.
+    let opencode = read_json(&project.join("opencode.json"));
+    assert_eq!(opencode["mcp"]["remote-srv"]["type"], "remote");
+    assert_eq!(
+        opencode["mcp"]["remote-srv"]["url"],
+        "https://example.com/mcp"
+    );
+
+    // Copilot — user-scope `~/.copilot/mcp-config.json`, root key `mcpServers`.
+    let copilot = read_json(&home.join(".copilot/mcp-config.json"));
+    assert_eq!(
+        copilot["mcpServers"]["remote-srv"]["url"],
+        "https://example.com/mcp"
+    );
+}
+
+#[test]
+fn add_local_mcp_uses_per_target_shapes_and_keeps_secret_verbatim() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_registry(&registry, BUNDLE_LOCAL_YAML);
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/b.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        // Ensure TOKEN is unset so any accidental expansion would be visible.
+        .env_remove("TOKEN")
+        .args(["add", bundle_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // opencode — command folded into one array, env named `environment`.
+    let opencode = read_json(&project.join("opencode.json"));
+    assert_eq!(opencode["mcp"]["local-srv"]["type"], "local");
+    assert_eq!(
+        opencode["mcp"]["local-srv"]["command"],
+        serde_json::json!(["npx", "-y", "my-tool-mcp"])
+    );
+    assert_eq!(
+        opencode["mcp"]["local-srv"]["environment"]["TOKEN"],
+        "${TOKEN}"
+    );
+    assert!(opencode["mcp"]["local-srv"].get("env").is_none());
+
+    // VS Code — `type: stdio`, separate command + args + env.
+    let vscode = read_json(&project.join(".vscode/mcp.json"));
+    assert_eq!(vscode["servers"]["local-srv"]["type"], "stdio");
+    assert_eq!(vscode["servers"]["local-srv"]["command"], "npx");
+    assert_eq!(vscode["servers"]["local-srv"]["env"]["TOKEN"], "${TOKEN}");
+
+    // Claude / Copilot — `mcpServers` shape with `env`.
+    let claude = read_json(&project.join(".mcp.json"));
+    assert_eq!(claude["mcpServers"]["local-srv"]["command"], "npx");
+    assert_eq!(
+        claude["mcpServers"]["local-srv"]["env"]["TOKEN"],
+        "${TOKEN}"
+    );
+    let copilot = read_json(&home.join(".copilot/mcp-config.json"));
+    assert_eq!(
+        copilot["mcpServers"]["local-srv"]["env"]["TOKEN"],
+        "${TOKEN}"
+    );
+
+    // No literal secret leaks into any config file — `${TOKEN}` is verbatim.
+    for path in [
+        project.join(".mcp.json"),
+        project.join(".vscode/mcp.json"),
+        project.join("opencode.json"),
+        home.join(".copilot/mcp-config.json"),
+    ] {
+        let raw = fs::read_to_string(&path).unwrap();
+        assert!(
+            raw.contains("${TOKEN}"),
+            "{} must keep the ${{TOKEN}} reference verbatim",
+            path.display()
+        );
+    }
+}
+
+/// The `status` string `doctor --json` reports for `name` under `client`.
+fn doctor_mcp_status(report: &serde_json::Value, client: &str, name: &str) -> String {
+    report["mcp_entries"]
+        .as_array()
+        .expect("mcp_entries array")
+        .iter()
+        .find(|e| e["client"] == client && e["name"] == name)
+        .unwrap_or_else(|| panic!("no mcp_entry for {client}/{name}: {report}"))["status"]
+        .as_str()
+        .expect("status string")
+        .to_string()
+}
+
+fn run_doctor_json(home: &Path, project: &Path, path_val: &str) -> serde_json::Value {
+    let assert = common::upskill_cmd(home)
+        .current_dir(project)
+        .env("PATH", path_val)
+        .args(["doctor", "--json"])
+        .assert();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("doctor --json not JSON: {e}\n{stdout}"))
+}
+
+#[test]
+fn doctor_reconciles_config_targets_and_flags_drift_without_false_positives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_registry(&registry, BUNDLE_REMOTE_YAML);
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/b.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["add", bundle_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Right after add, every config-write target carries the server (`ok`),
+    // and claude — its CLI absent (PATH cleared) — is `cli-not-found`, NOT a
+    // false `not-registered`.
+    let report = run_doctor_json(&home, &project, &path_val);
+    assert_eq!(doctor_mcp_status(&report, "vscode", "remote-srv"), "ok");
+    assert_eq!(doctor_mcp_status(&report, "opencode", "remote-srv"), "ok");
+    assert_eq!(doctor_mcp_status(&report, "copilot", "remote-srv"), "ok");
+    assert_eq!(
+        doctor_mcp_status(&report, "claude", "remote-srv"),
+        "cli-not-found"
+    );
+
+    // Drop the server from VS Code's config only — doctor flags exactly that
+    // target as drifted, leaving the others untouched.
+    fs::write(project.join(".vscode/mcp.json"), "{\"servers\":{}}\n").unwrap();
+    let report = run_doctor_json(&home, &project, &path_val);
+    assert_eq!(
+        doctor_mcp_status(&report, "vscode", "remote-srv"),
+        "not-registered"
+    );
+    assert_eq!(doctor_mcp_status(&report, "opencode", "remote-srv"), "ok");
+}
+
+#[test]
+fn remove_mcp_clears_every_target_config_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_registry(&registry, BUNDLE_REMOTE_YAML);
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/b.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["add", bundle_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["remove-mcp", "remote-srv"])
+        .assert()
+        .success();
+
+    // Each target's config file must no longer carry the server.
+    let claude = read_json(&project.join(".mcp.json"));
+    assert!(claude["mcpServers"]["remote-srv"].is_null());
+    let vscode = read_json(&project.join(".vscode/mcp.json"));
+    assert!(vscode["servers"]["remote-srv"].is_null());
+    let opencode = read_json(&project.join("opencode.json"));
+    assert!(opencode["mcp"]["remote-srv"].is_null());
+    let copilot = read_json(&home.join(".copilot/mcp-config.json"));
+    assert!(copilot["mcpServers"]["remote-srv"].is_null());
 }

--- a/tests/pipeline_mcp.rs
+++ b/tests/pipeline_mcp.rs
@@ -329,6 +329,19 @@ fn doctor_reconciles_config_targets_and_flags_drift_without_false_positives() {
         "not-registered"
     );
     assert_eq!(doctor_mcp_status(&report, "opencode", "remote-srv"), "ok");
+
+    // The human-readable message must name the drifted target (vscode), not a
+    // hardcoded "claude".
+    let assert = common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["doctor"])
+        .assert();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("not registered in vscode"),
+        "doctor must attribute the drift to vscode, not claude: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Closes #237. Extends ADR-0010's CLI-first / config-write-fallback MCP
contract from **Claude-only** to **all four MCP targets**: Claude Code,
GitHub Copilot, VS Code, and opencode. A bundle that ships a skill plus its
MCP server is now fully installed for every non-Claude consumer.

## Design

- **`McpTarget` set, separate from `Client`.** New `McpTarget` enum
  `{claude, copilot, vscode, opencode}` in `src/mcp.rs`. The generation
  `Client` enum is **unchanged** (no `VsCode` variant) — VS Code shares
  `.github/**` rules/skills/agents output with Copilot and forks only on MCP.
- **Fan-out at install.** Each bundle `mcps:` entry is configured for every
  target, CLI-first then config-write on `CliNotFound`; one `McpResult` per
  `(name, target)`.
- **Per-target config shapes** (config-write fallbacks, shared merge keyed by
  file + root key):

  | Target | CLI-first | Config file | Root key |
  | --- | --- | --- | --- |
  | Claude | `claude mcp add …` | `.mcp.json` | `mcpServers` |
  | Copilot | `copilot mcp add …` | `~/.copilot/mcp-config.json` (user scope) | `mcpServers` |
  | VS Code | `code --add-mcp '<json>'` | `.vscode/mcp.json` | `servers` |
  | opencode | — (config-only) | `opencode.json` | `mcp` |

  VS Code stdio typed `"stdio"`; opencode local `command` is an array and env
  is `environment`.
- **`remove-mcp` parity** across targets (CLI-first for claude/copilot,
  config-file for vscode/opencode).
- **`doctor` parity** — claude via `claude mcp list`; config-write targets
  reconciled against their config file. Absent file = undetermined → skipped
  (no false positives); present-but-missing entry = drift (`NotRegistered`).

## Resolved caveat — Copilot project scope

Copilot has no documented project-scope MCP config file (`.github/mcp.json`
is not a Copilot CLI source), so the config-write fallback always targets the
**user-scope** `~/.copilot/mcp-config.json`; project scope is configured via
the `copilot mcp add` CLI. Documented in ADR-0010 / format-spec §7.

## Invariants preserved

- `${VAR}` references written verbatim; **no literal secret** ever persisted
  (covered by a test).
- Idempotent, merge-preserving writes (sibling servers and other top-level
  keys never clobbered).
- Warn-skip: a single target's failure never aborts the bundle install.

## Tests

- `tests/pipeline_mcp.rs`: remote + local bundles, PATH cleared — asserts
  every target's file and **root key** (`servers` for VS Code, `mcpServers`
  for Copilot, `mcp.<name>` for opencode), `${VAR}` verbatim, remove clears
  every file, and a doctor reconcile/drift round-trip via `doctor --json`.
- `src/mcp.rs` + `src/ancillary.rs` unit tests for the arg/JSON builders and
  config writers.
- `tests/cli_mcp.rs` idempotency updated for one lockfile entry per target.

`just verify` + `just check` (clippy `-D warnings`) green.

## Notes / follow-ups

- No consumer-side switch to narrow the target set yet — tracked by #238; a
  per-target consumer selection should honour the same filtering.
- VS Code's `code --add-mcp` writes the user-profile MCP store, which differs
  from the `.vscode/mcp.json` workspace file the fallback writes — a
  CLI-installed VS Code server is not removed by the config-file remover.
- The `copilot mcp add` / `code --add-mcp` flag forms are arg-builder-tested
  but not verified against the live CLIs in this environment; the
  config-write path is the deterministically tested contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
