### PR TITLE
feat(mcp): doctor surfaces missing/unreadable config for config-write targets (#241)

### DIFF
--- a/docs/adr/0010-mcp-config-write.md
+++ b/docs/adr/0010-mcp-config-write.md
@@ -210,8 +210,11 @@ entries silently ignore the unknown array (serde `default`).
   config file. A server present in the lockfile but absent from a present
   config file (or from the Claude client) makes doctor report `NotRegistered`
   and exit non-clean (exit 1). Claude also reports `CliNotFound` and
-  `QueryFailed`; for a config-write target whose config file is **absent** the
-  state is undetermined and the entry is skipped — no false positives. Doctor
+  `QueryFailed`; a config-write target whose config file is **absent** reports
+  `ConfigMissing` and one that is **unreadable/corrupt** reports
+  `ConfigUnreadable` (issue #241) — both are informational "cannot verify"
+  states that are surfaced but do **not** fail `is_clean` (no false-positive
+  exit 1, since the server may be configured via the client's own CLI). Doctor
   does **not** check `requires-env` variables and never auto-removes entries.
 - **`upskill add` (install time)**: warns for each variable listed in
   `requires-env` that is not set in the current environment, immediately

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -825,10 +825,11 @@ is queried via `claude mcp list`; the config-write targets (Copilot, VS Code, op
 against their config file. A server present in the lockfile but absent from a present config file
 (or from the Claude client) is reported as `NotRegistered` and causes doctor to exit non-clean
 (exit 1). Claude also reports `CliNotFound` when the `claude` CLI is absent and `QueryFailed` when
-the list query fails; for a config-write target whose config file is absent the state is
-undetermined and the entry is skipped rather than reported as drift (no false positives). Doctor
-does not check `requires-env` variables — the unset-env warning is emitted by `upskill add` at
-install time.
+the list query fails; a config-write target whose config file is absent reports `ConfigMissing`
+and one that is unreadable reports `ConfigUnreadable` — both are informational "cannot verify"
+states that are surfaced but do not fail cleanliness (no false-positive exit 1), since the server
+may be configured via the client's own CLI. Doctor does not check `requires-env` variables — the
+unset-env warning is emitted by `upskill add` at install time.
 
 Implementations:
 

--- a/src/ancillary.rs
+++ b/src/ancillary.rs
@@ -634,37 +634,67 @@ fn remove_mcp_server(path: &Path, root_key: &str, name: &str) -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// MCP doctor reconciliation for config-write targets (issue #237)
+// MCP doctor reconciliation for config-write targets (issue #237, #241)
 // ---------------------------------------------------------------------------
 
-/// Doctor query: does `<root_key>.<name>` exist in the JSON config at `path`?
-/// `None` means the file is absent or unreadable — the state is undetermined,
-/// so `doctor` must NOT treat it as drift (avoids false positives). `Some(false)`
-/// means the file exists but the server is gone (genuine drift).
-fn mcp_config_state(path: &Path, root_key: &str, name: &str) -> Option<bool> {
-    let raw = std::fs::read_to_string(path).ok()?;
-    let doc: Value = serde_json::from_str(&raw).ok()?;
-    Some(
-        doc.get(root_key)
-            .and_then(Value::as_object)
-            .is_some_and(|m| m.contains_key(name)),
-    )
+/// Result of probing a config-write target's file for a named MCP server.
+/// Lets `doctor` distinguish "configured", "drifted", "file absent", and
+/// "file unreadable" instead of collapsing the last three into a silent skip
+/// (issue #241).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpConfigState {
+    /// The server is present in the target's config file.
+    Present,
+    /// The config file exists but the server entry is gone (genuine drift).
+    Missing,
+    /// The config file does not exist — state undetermined (the server may be
+    /// configured via the client's own CLI in a store upskill cannot read).
+    FileAbsent,
+    /// The config file exists but could not be read or parsed as JSON.
+    Unreadable(String),
+}
+
+/// Doctor query: is `<root_key>.<name>` present in the JSON config at `path`?
+/// Distinguishes absent from unreadable so `doctor` can surface a broken or
+/// missing config instead of silently skipping it.
+fn mcp_config_state(path: &Path, root_key: &str, name: &str) -> McpConfigState {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return McpConfigState::FileAbsent,
+        Err(e) => return McpConfigState::Unreadable(e.to_string()),
+    };
+    let doc: Value = match serde_json::from_str(&raw) {
+        Ok(doc) => doc,
+        Err(e) => return McpConfigState::Unreadable(e.to_string()),
+    };
+    if doc
+        .get(root_key)
+        .and_then(Value::as_object)
+        .is_some_and(|m| m.contains_key(name))
+    {
+        McpConfigState::Present
+    } else {
+        McpConfigState::Missing
+    }
 }
 
 /// Doctor state for a VS Code MCP entry (`.vscode/mcp.json` `servers.<name>`).
-pub fn vscode_mcp_state(target: &Path, name: &str) -> Option<bool> {
+pub fn vscode_mcp_state(target: &Path, name: &str) -> McpConfigState {
     mcp_config_state(&target.join(VSCODE_MCP_JSON), "servers", name)
 }
 
 /// Doctor state for an opencode MCP entry (`opencode.json` `mcp.<name>`).
-pub fn opencode_mcp_state(target: &Path, name: &str) -> Option<bool> {
+pub fn opencode_mcp_state(target: &Path, name: &str) -> McpConfigState {
     mcp_config_state(&target.join(OPENCODE_JSON), "mcp", name)
 }
 
 /// Doctor state for a Copilot MCP entry (`~/.copilot/mcp-config.json`
-/// `mcpServers.<name>`). `None` when HOME is unset or the file is absent.
-pub fn copilot_mcp_state(name: &str) -> Option<bool> {
-    copilot_mcp_config_path().and_then(|p| mcp_config_state(&p, "mcpServers", name))
+/// `mcpServers.<name>`). Treated as `FileAbsent` when HOME is unset.
+pub fn copilot_mcp_state(name: &str) -> McpConfigState {
+    match copilot_mcp_config_path() {
+        Some(path) => mcp_config_state(&path, "mcpServers", name),
+        None => McpConfigState::FileAbsent,
+    }
 }
 
 fn write_pretty_json(path: &Path, value: &Value) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1003,6 +1003,18 @@ fn print_doctor_mcps(report: &DoctorReport) {
                     entry.client, entry.name, stderr
                 );
             }
+            McpDoctorStatus::ConfigMissing => {
+                println!(
+                    "  MCP '{}' for {}: config file not found; cannot verify (it may be configured via the {} CLI).",
+                    entry.name, entry.client, entry.client
+                );
+            }
+            McpDoctorStatus::ConfigUnreadable { detail } => {
+                println!(
+                    "  MCP '{}' for {}: config file could not be read ({}); fix or re-run `upskill update`.",
+                    entry.name, entry.client, detail
+                );
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -966,54 +966,73 @@ fn print_doctor_skipped_plugins(report: &DoctorReport) {
 fn print_doctor_mcps(report: &DoctorReport) {
     use upskill::pipeline::McpDoctorStatus;
 
-    let non_ok: Vec<&upskill::pipeline::McpDoctorEntry> = report
+    // Split genuine drift (fails is_clean → exit 1) from "cannot verify"
+    // states (informational; the server may be configured via the client's
+    // own CLI). Only the former is framed as "needs attention" so a normal
+    // doctor run over a CLI-installed target does not look alarming.
+    let drifted: Vec<&upskill::pipeline::McpDoctorEntry> = report
         .mcp_entries
         .iter()
-        .filter(|e| !matches!(e.status, McpDoctorStatus::Ok))
+        .filter(|e| matches!(e.status, McpDoctorStatus::NotRegistered))
+        .collect();
+    let unverifiable: Vec<&upskill::pipeline::McpDoctorEntry> = report
+        .mcp_entries
+        .iter()
+        .filter(|e| {
+            !matches!(
+                e.status,
+                McpDoctorStatus::Ok | McpDoctorStatus::NotRegistered
+            )
+        })
         .collect();
 
-    if non_ok.is_empty() {
-        return;
+    if !drifted.is_empty() {
+        println!(
+            "{} {} MCP server(s) need attention",
+            style::warn("doctor:"),
+            drifted.len()
+        );
+        for entry in &drifted {
+            println!(
+                "  MCP '{}' is in the lockfile but not registered in {}; re-run `upskill update`.",
+                entry.name, entry.client
+            );
+        }
     }
 
-    println!(
-        "{} {} MCP server(s) need attention",
-        style::warn("doctor:"),
-        non_ok.len()
-    );
-
-    for entry in &non_ok {
-        match &entry.status {
-            McpDoctorStatus::Ok => {}
-            McpDoctorStatus::NotRegistered => {
-                println!(
-                    "  MCP '{}' is in the lockfile but not registered in {}; re-run `upskill update`.",
-                    entry.name, entry.client
-                );
-            }
-            McpDoctorStatus::CliNotFound => {
-                println!(
-                    "  {} CLI not found; cannot verify MCP '{}'.",
-                    entry.client, entry.name
-                );
-            }
-            McpDoctorStatus::QueryFailed { stderr } => {
-                println!(
-                    "  could not query {} MCP list for '{}': {}",
-                    entry.client, entry.name, stderr
-                );
-            }
-            McpDoctorStatus::ConfigMissing => {
-                println!(
-                    "  MCP '{}' for {}: config file not found; cannot verify (it may be configured via the {} CLI).",
-                    entry.name, entry.client, entry.client
-                );
-            }
-            McpDoctorStatus::ConfigUnreadable { detail } => {
-                println!(
-                    "  MCP '{}' for {}: config file could not be read ({}); fix or re-run `upskill update`.",
-                    entry.name, entry.client, detail
-                );
+    if !unverifiable.is_empty() {
+        println!(
+            "{} {} MCP server(s) could not be verified",
+            style::dim("doctor:"),
+            unverifiable.len()
+        );
+        for entry in &unverifiable {
+            match &entry.status {
+                McpDoctorStatus::CliNotFound => {
+                    println!(
+                        "  {} CLI not found; cannot verify MCP '{}'.",
+                        entry.client, entry.name
+                    );
+                }
+                McpDoctorStatus::QueryFailed { stderr } => {
+                    println!(
+                        "  could not query {} MCP list for '{}': {}",
+                        entry.client, entry.name, stderr
+                    );
+                }
+                McpDoctorStatus::ConfigMissing => {
+                    println!(
+                        "  MCP '{}' for {}: config file not found; cannot verify (it may be configured via the {} CLI).",
+                        entry.name, entry.client, entry.client
+                    );
+                }
+                McpDoctorStatus::ConfigUnreadable { detail } => {
+                    println!(
+                        "  MCP '{}' for {}: config file could not be read ({}); fix or re-run `upskill update`.",
+                        entry.name, entry.client, detail
+                    );
+                }
+                McpDoctorStatus::Ok | McpDoctorStatus::NotRegistered => {}
             }
         }
     }

--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -303,14 +303,15 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
         }
     }
 
-    // -- MCP server reconciliation (ADR-0010, issue #237) --
+    // -- MCP server reconciliation (ADR-0010, issue #237, #241) --
     // Walk the lockfile's MCP entries and check whether each is still
     // configured for its target. Claude is queried via `claude mcp list`; the
     // config-write targets (copilot, vscode, opencode) are reconciled against
-    // their config file. When that file is absent the state is undetermined,
-    // so the entry is skipped rather than reported as drift (no false
-    // positives for targets configured out-of-band).
+    // their config file. A present-but-missing entry is drift; an absent or
+    // unreadable config file is surfaced as an informational "cannot verify"
+    // state rather than drift, so it never produces a false-positive exit 1.
     for mcp in &lock.mcps {
+        use crate::ancillary::McpConfigState;
         use crate::pipeline::report::{McpDoctorEntry, McpDoctorStatus};
 
         let status = match mcp.client.as_str() {
@@ -332,9 +333,12 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
                     _ => crate::ancillary::opencode_mcp_state(target, &mcp.name),
                 };
                 match state {
-                    Some(true) => McpDoctorStatus::Ok,
-                    Some(false) => McpDoctorStatus::NotRegistered,
-                    None => continue,
+                    McpConfigState::Present => McpDoctorStatus::Ok,
+                    McpConfigState::Missing => McpDoctorStatus::NotRegistered,
+                    McpConfigState::FileAbsent => McpDoctorStatus::ConfigMissing,
+                    McpConfigState::Unreadable(detail) => {
+                        McpDoctorStatus::ConfigUnreadable { detail }
+                    }
                 }
             }
             _ => continue,

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -189,6 +189,11 @@ pub struct McpDoctorEntry {
 }
 
 /// The specific condition detected during doctor MCP reconciliation.
+///
+/// Only `NotRegistered` is drift that fails [`DoctorReport::is_clean`]. The
+/// other non-`Ok` variants are informational "cannot verify" states — the
+/// server may well be configured, upskill just cannot confirm it — so they are
+/// surfaced without flipping the exit code (issue #241).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum McpDoctorStatus {
@@ -200,6 +205,12 @@ pub enum McpDoctorStatus {
     CliNotFound,
     /// CLI returned non-zero when listing MCP servers.
     QueryFailed { stderr: String },
+    /// Config-write target: the config file does not exist, so state is
+    /// undetermined (the server may be configured via the client's own CLI).
+    ConfigMissing,
+    /// Config-write target: the config file exists but could not be read or
+    /// parsed as JSON.
+    ConfigUnreadable { detail: String },
 }
 
 /// A dependency-pulled item whose every requirer is no longer installed.
@@ -412,6 +423,29 @@ mod tests {
             bundle: "my-bundle".into(),
             status: McpDoctorStatus::QueryFailed {
                 stderr: "some error".into(),
+            },
+        });
+        assert!(report.is_clean());
+    }
+
+    #[test]
+    fn doctor_report_clean_with_config_missing_or_unreadable_mcp() {
+        // Config-write targets whose config file is absent or unreadable are
+        // informational "cannot verify" states — they must NOT flip is_clean
+        // (issue #241, no false-positive exit 1).
+        let mut report = DoctorReport::default();
+        report.mcp_entries.push(McpDoctorEntry {
+            name: "my-mcp".into(),
+            client: "vscode".into(),
+            bundle: "my-bundle".into(),
+            status: McpDoctorStatus::ConfigMissing,
+        });
+        report.mcp_entries.push(McpDoctorEntry {
+            name: "my-mcp".into(),
+            client: "opencode".into(),
+            bundle: "my-bundle".into(),
+            status: McpDoctorStatus::ConfigUnreadable {
+                detail: "expected value at line 1".into(),
             },
         });
         assert!(report.is_clean());

--- a/tests/pipeline_mcp.rs
+++ b/tests/pipeline_mcp.rs
@@ -345,6 +345,107 @@ fn doctor_reconciles_config_targets_and_flags_drift_without_false_positives() {
 }
 
 #[test]
+fn doctor_surfaces_missing_config_file_without_flagging_drift() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_registry(&registry, BUNDLE_REMOTE_YAML);
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/b.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["add", bundle_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Delete VS Code's config file entirely (the server may have been
+    // configured via the `code` CLI instead) — this is *undetermined*, not
+    // drift.
+    fs::remove_file(project.join(".vscode/mcp.json")).unwrap();
+    let report = run_doctor_json(&home, &project, &path_val);
+    assert_eq!(
+        doctor_mcp_status(&report, "vscode", "remote-srv"),
+        "config-missing"
+    );
+    // Not reported as drift, so it must not be `not-registered`.
+    assert_ne!(
+        doctor_mcp_status(&report, "vscode", "remote-srv"),
+        "not-registered"
+    );
+    // The other targets are unaffected.
+    assert_eq!(doctor_mcp_status(&report, "opencode", "remote-srv"), "ok");
+
+    // Human-readable output explains the undetermined state for vscode.
+    let assert = common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["doctor"])
+        .assert();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("config file not found") && stdout.contains("vscode"),
+        "doctor must surface the missing vscode config as undetermined: {stdout}"
+    );
+}
+
+#[test]
+fn doctor_surfaces_unreadable_config_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let project = tmp.path().join("project");
+    stage_registry(&registry, BUNDLE_REMOTE_YAML);
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let bundle_path = registry.join("bundles/b.bundle.yaml");
+    let path_val = empty_bin_path(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["add", bundle_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Corrupt opencode's config file so it no longer parses as JSON.
+    fs::write(project.join("opencode.json"), "{ not valid json").unwrap();
+    let report = run_doctor_json(&home, &project, &path_val);
+    let entry = report["mcp_entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["client"] == "opencode" && e["name"] == "remote-srv")
+        .unwrap_or_else(|| panic!("no opencode entry: {report}"));
+    assert!(
+        entry["status"]
+            .get("config-unreadable")
+            .and_then(|v| v.get("detail"))
+            .is_some(),
+        "opencode entry must report config-unreadable with a detail: {entry}"
+    );
+
+    let assert = common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", &path_val)
+        .args(["doctor"])
+        .assert();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("config file could not be read") && stdout.contains("opencode"),
+        "doctor must surface the unreadable opencode config: {stdout}"
+    );
+}
+
+#[test]
 fn remove_mcp_clears_every_target_config_file() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join("home");


### PR DESCRIPTION
## What

Closes #241 (debt from the #237 review). `upskill doctor` no longer silently
skips a config-write MCP target (Copilot, VS Code, opencode) whose config file
is **absent** or **corrupt** — it surfaces both as informational "cannot verify"
states without producing a false-positive exit 1.

## Before

`ancillary::mcp_config_state` returned `Option<bool>`, collapsing three
distinct states into one silent skip:

- file present + entry there → `Some(true)` → `Ok`
- file present + entry gone → `Some(false)` → `NotRegistered` (drift)
- **file absent OR unparseable → `None` → doctor `continue`d (silent)**

So a user who deleted `.vscode/mcp.json`, or corrupted `opencode.json`, got no
signal at all.

## After

- `mcp_config_state` returns a `McpConfigState` enum: `Present` / `Missing` /
  `FileAbsent` / `Unreadable(detail)` — an absent file and a corrupt file are
  now distinct.
- `McpDoctorStatus` gains `ConfigMissing` and `ConfigUnreadable { detail }`.
  Both are **informational**: `is_clean()` still only fails on `NotRegistered`,
  so neither flips the exit code. Rationale: an absent workspace file doesn't
  mean the server is unconfigured — it may live in the client's own CLI store
  (e.g. `code --add-mcp` writes the VS Code user profile, not
  `.vscode/mcp.json`). Framing it as "cannot verify" keeps it a true statement,
  not a false positive.
- `doctor` prints an explanatory line for each new state.

## Acceptance criteria (#241)

- [x] `doctor` emits an informational line for a config-write MCP entry whose
      config file is absent (distinct from `Ok` / `NotRegistered`).
- [x] A corrupt/unparseable target config file is reported, not silently skipped.
- [x] Neither case flips `is_clean()` to non-clean (no false-positive exit 1) —
      unit test asserts this directly.
- [x] Coverage in `tests/pipeline_mcp.rs` (deleted file → `config-missing`;
      corrupt file → `config-unreadable`, via `doctor --json` + plain output).

Docs (ADR-0010, format-spec §7) updated to match.

`just check` green (clippy `-D warnings`).

## Not in scope

The lower-priority notes recorded in #241 (removal-dispatch placement in
`main.rs`, per-target dispatch/writer DRY, VS Code CLI-vs-workspace-file
removal mismatch, modeling "config-only target" explicitly) are left as future
cleanup — they match existing codebase patterns and aren't the observability
gap this issue targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
