### PR TITLE
feat(cli): consumer-side client filtering via flags and config

### DIFF
--- a/docs/adr/0008-plugin-install-shellout.md
+++ b/docs/adr/0008-plugin-install-shellout.md
@@ -220,9 +220,10 @@ would force users to install two artifacts to get a coherent setup.
 
 **(d) Hard-fail when the target client's CLI is missing.** Rejected:
 too hostile to mixed-client teams. A user who runs `upskill add
-some-bundle --claude --vscode` and is missing `code` would lose the
-entire install. Warn-skip lets the parts that can install proceed,
-and `doctor` reports the gap so it's not silently lost.
+some-bundle --claude --vscode` (the client-selection flags specified in
+[ADR-0012](./0012-consumer-client-filtering.md)) and is missing `code`
+would lose the entire install. Warn-skip lets the parts that can install
+proceed, and `doctor` reports the gap so it's not silently lost.
 
 **(e) Per-plugin `install_url` (single URL, applies to all
 clients).** Rejected: install instructions are usually

--- a/docs/adr/0012-consumer-client-filtering.md
+++ b/docs/adr/0012-consumer-client-filtering.md
@@ -108,6 +108,17 @@ A per-invocation flag replaces the config selection for that run only;
 selection means editing the config file. Config lives in `config.rs`, **not**
 the lockfile — the lockfile is install _state_, not user _preference_.
 
+**`update` preserves the recorded selection.** A bare `update` (no flag, no
+config → the default `all`) would otherwise re-resolve to all clients and
+silently un-narrow a `--claude` install — re-emitting `.github/**` /
+`.agents/**` and overwriting the lockfile `clients` record. Instead, when no
+explicit selection is supplied, `update` reconstructs each source's selection
+from the union of its entries' recorded `clients`, so a narrowed install stays
+narrow. An explicit flag/config selection still overrides. (Recorded `clients`
+are generation clients, so the reconstruction maps a `--vscode`-only install
+onto Copilot on the MCP axis — MCP config is additive and never auto-removed,
+so this widens rather than loses.)
+
 ### `doctor` respects what was actually written; `remove` already does
 
 `doctor` reports "missing output" by checking each item's output path for

--- a/docs/adr/0012-consumer-client-filtering.md
+++ b/docs/adr/0012-consumer-client-filtering.md
@@ -1,0 +1,156 @@
+# Consumer-side client filtering — per-invocation flags and config
+
+**Status**: Accepted (2026-07-01)
+
+## Context
+
+[ADR-0003](./0003-generation-pipeline.md) established the generation
+contract: one SSOT item renders to per-client output for **every** client.
+The only knob that narrows the target set is the **author-side** `audience:`
+field in item frontmatter ([format-spec §5](../format-spec.md)). A
+**consumer** has no say: every `upskill add` writes `.claude/**`,
+`.github/**`, and `.agents/**` for every item, plus — since
+[ADR-0010](./0010-mcp-config-write.md) — MCP config for all four MCP targets.
+
+A consumer who only uses Claude Code still gets `.github/**` and `.agents/**`
+trees they neither want nor track. The default (emit for all clients) is
+correct and stays; what is missing is an opt-in **consumer-side**
+restriction (issue #238).
+
+### The two target spaces
+
+[ADR-0010](./0010-mcp-config-write.md) deliberately split two enumerations
+that this ADR must both honour:
+
+- **`generate::Client`** (3): `claude`, `copilot`, `opencode` — the
+  rules/skills/agents generation trees (`.claude/**`, `.github/**`,
+  `.agents/**`).
+- **`mcp::McpTarget`** (4): `claude`, `copilot`, **`vscode`**, `opencode` —
+  MCP config-write targets. VS Code shares Copilot's `.github/**` generation
+  output and forks **only** on MCP, so it is an MCP target but not a
+  generation `Client`.
+
+A consumer thinks in terms of _the client they use_, not these two internal
+spaces. The selection surface must therefore be the **union** — the four
+clients `claude`, `copilot`, `vscode`, `opencode` — and map each onto the
+generation and MCP spaces internally.
+
+## Decision
+
+### Four boolean per-client flags on `add` and `update`
+
+```text
+upskill add <source> --claude --copilot --vscode --opencode
+```
+
+- No flag → **all clients** (default unchanged, regression-guarded).
+- Any flag present → the selection is the **allowlist** of exactly the named
+  clients.
+
+There is no subtractive `--exclude-client` form: "Claude + Copilot only" is
+`--claude --copilot`, and the boolean allowlist expresses every case a
+consumer needs. `--exclude <NAME>` (item-name exclusion) is unrelated and
+unchanged.
+
+### Selection maps onto both target spaces
+
+A selected client `c` contributes to:
+
+| flag         | generation client | MCP target |
+| ------------ | ----------------- | ---------- |
+| `--claude`   | `claude`          | `claude`   |
+| `--copilot`  | `copilot`         | `copilot`  |
+| `--vscode`   | `copilot`         | `vscode`   |
+| `--opencode` | `opencode`        | `opencode` |
+
+`--vscode` maps to the **Copilot generation client** because VS Code reads
+the shared `.github/**` rules/skills/agents tree; a VS-Code-only consumer
+must still get those rules. It maps to the **VsCode MCP target** for its own
+MCP config. Thus:
+
+- **`--vscode` alone** writes `.github/**` (rules/skills/agents) **and** VS
+  Code MCP config — a working VS Code setup.
+- **`--copilot --vscode`** writes `.github/**` **once** (the generation
+  clients dedupe to `{copilot}` via a set) and forks MCP into two writes:
+  Copilot CLI MCP **and** VS Code MCP. This set-dedup on the generation side
+  is an invariant, covered by a dedicated test.
+
+### Effective generation set = author `audience:` ∩ consumer selection
+
+The generation loop already filters each client by the item's `audience:`.
+Consumer selection is a second, independent filter: an item is written for
+generation client `g` iff `audience_targets(g)` **and**
+`selection_targets(g)`. An item whose `audience:` excludes every selected
+client is **warn-skipped**, not errored — consistent with the plugin/MCP
+warn-skip ethos ([ADR-0008](./0008-plugin-install-shellout.md),
+[ADR-0010](./0010-mcp-config-write.md)). The MCP fan-out iterates the
+selected MCP targets instead of `McpTarget::ALL`.
+
+### Persistent selection in config, with precedence
+
+The existing user config ([config.rs](../../src/config.rs);
+`~/.config/upskill/config.yaml` global, `.upskill/config.yaml` project) gains
+a `clients:` list:
+
+```yaml
+clients: [claude, opencode]
+```
+
+Precedence, highest first:
+
+1. **per-invocation flags** on `add` / `update`
+2. **project** config `clients:`
+3. **global** config `clients:`
+4. **built-in default** — all clients
+
+A per-invocation flag replaces the config selection for that run only;
+`add --claude` never mutates config (no hidden persistence). Persisting a
+selection means editing the config file. Config lives in `config.rs`, **not**
+the lockfile — the lockfile is install _state_, not user _preference_.
+
+### `doctor` respects what was actually written; `remove` already does
+
+`doctor` reports "missing output" by checking each item's output path for
+every generation client. With a selection, an unselected client's output was
+never written, so an unfiltered `doctor` would report false drift. Fix: the
+lockfile records the **effective generation clients** per item
+(`LockedItem.clients`), and `doctor` iterates that recorded set. An empty
+`clients` list means "all" — so pre-existing lockfiles (written before this
+feature, for all clients) remain correct with no migration. This also fixes
+the latent case of an `audience:`-restricted item showing false `doctor`
+drift.
+
+`remove` already deletes outputs with `fs::remove_file`, which is a no-op on
+a never-written path — so removing an item installed under a narrow selection
+needs no change.
+
+## Alternatives considered
+
+- **`--client <c>` / `--exclude-client <c>` value-parser flags** (the
+  original issue sketch). Rejected in favour of boolean flags: `--claude`
+  reads better, needs no value parser, and retroactively **validates** the
+  `--claude --vscode` examples already shown in
+  [ADR-0008](./0008-plugin-install-shellout.md) and
+  [recipes.md](../recipes.md) — those become real instead of being deleted.
+  The subtractive `--exclude-client` form is dropped as redundant.
+- **`--vscode` as MCP-only** (no `.github/**`). Rejected: VS Code has no
+  rules of its own; an MCP-only `--vscode` would leave a VS Code consumer
+  without any rules/skills/agents.
+- **Reading the config selection at `doctor` time** instead of recording it
+  per item. Rejected: the selection can change between install and `doctor`
+  (config edited, or a different scope), so `doctor` would validate against
+  the wrong set. Recording what was actually written is robust.
+- **Selection in the lockfile** rather than config. Rejected: the lockfile is
+  per-install _state_; a persistent _preference_ belongs in config, which
+  already has global+project layering.
+
+## Consequences
+
+- `add`/`update` gain four flags; `config.rs` gains a `clients:` key and a
+  precedence resolver; `LockedItem` gains a `clients` field.
+- A new selection type maps the four consumer clients onto the generation and
+  MCP spaces; it is the single place the `--vscode → copilot generation`
+  mapping lives.
+- Docs that showed `--claude` / `--vscode` as aspirational
+  ([ADR-0008](./0008-plugin-install-shellout.md),
+  [recipes.md](../recipes.md)) are reconciled to describe the shipped flags.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,3 +14,4 @@ Numbered sequentially. Status one of: Proposed | Accepted | Superseded.
 - [0009 — Coupling tiers and directed dependencies](0009-coupling-tiers-and-dependencies.md)
 - [0010 — MCP server configuration — bundle `mcps:`, CLI-first config-write](0010-mcp-config-write.md)
 - [0011 — Generic git-URL source — replace GitLab-specific source with host-agnostic https](0011-generic-git-url-source.md)
+- [0012 — Consumer-side client filtering — per-invocation flags and config](0012-consumer-client-filtering.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -130,9 +130,10 @@ command.
 
 `update` honours the same [client-selection](#upskill-add-source-items)
 flags and `clients:` config as `add` (`--claude`, `--copilot`, `--vscode`,
-`--opencode`). With no flag and no config it regenerates for all clients, so
-persist a narrower selection in `clients:` config if you want `update` to keep
-it.
+`--opencode`). With no flag and no config, `update` **preserves each source's
+recorded selection** — a bare `update` of a `--claude`-only install stays
+Claude-only rather than re-expanding to all clients. Pass a flag (or set
+`clients:`) to change the selection on update.
 
 ### `upskill remove [name...] [--source <label>]`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -60,6 +60,31 @@ Default scope is `--project` (writes into `.agents/...` of the current
 repo), falling back to `--global` (`$HOME/.agents/...`) if you're not
 inside a git repo. Pass either flag explicitly to override.
 
+**Client selection.** By default `add` emits output for **every** client.
+Restrict it to the clients you actually use with one or more of `--claude`,
+`--copilot`, `--vscode`, `--opencode` (an allowlist — naming any restricts to
+exactly those):
+
+```bash
+upskill add owner/repo --claude               # only .claude/**
+upskill add owner/repo --copilot --vscode     # only .github/** (+ VS Code MCP)
+```
+
+`--vscode` writes the shared `.github/**` rules/skills/agents (VS Code reads
+Copilot's tree) plus VS Code's own MCP config; `--copilot --vscode` writes
+`.github/**` once and forks only the MCP config. To persist a selection across
+runs, set `clients:` in config (`.upskill/config.yaml` for the project,
+`~/.config/upskill/config.yaml` globally):
+
+```yaml
+clients: [claude, opencode]
+```
+
+Precedence is **flag > project config > global config > all clients**. A
+per-invocation flag scopes that run only and never rewrites config. An item
+whose author `audience:` excludes every selected client is warn-skipped.
+See [ADR-0012](./adr/0012-consumer-client-filtering.md).
+
 Supporting files in an item directory — anything besides the entrypoint and
 per-client override files, e.g. `scripts/`, `references/`, `assets/` — are
 copied into each client's output alongside the rendered item. For rules and
@@ -102,6 +127,12 @@ upskill update --dry-run             # preview changes without applying
 `sync`. It also re-runs the generation pipeline against the current
 upskill version, so client-format updates land without a separate
 command.
+
+`update` honours the same [client-selection](#upskill-add-source-items)
+flags and `clients:` config as `add` (`--claude`, `--copilot`, `--vscode`,
+`--opencode`). With no flag and no config it regenerates for all clients, so
+persist a narrower selection in `clients:` config if you want `update` to keep
+it.
 
 ### `upskill remove [name...] [--source <label>]`
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -152,8 +152,11 @@ consumer's AI agent run it:
 upskill add owner/registry:<name>-mcp.bundle.yaml --claude
 ```
 
-This installs the skill, installs the `<name>-mcp-installer` agent into the
-client's agents directory, and configures the MCP — in one step.
+The `--claude` flag restricts this install to Claude Code (see
+[client selection](./commands.md#upskill-add-source-items)); drop it to target
+every client. This installs the skill, installs the `<name>-mcp-installer`
+agent into the client's agents directory, and configures the MCP — in one
+step.
 
 **At runtime:** the consumer uses the skill, the model reads the trigger
 line, and if the MCP tool is missing it dispatches `<name>-mcp-installer` —

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,6 +80,20 @@ pub enum Commands {
         /// Skip specific items during install (repeatable).
         #[arg(long = "exclude", value_name = "NAME")]
         exclude: Vec<String>,
+        /// Restrict output to Claude Code. Combine client flags to target
+        /// several; no client flag emits for all clients (the default).
+        #[arg(long = "claude", help_heading = "Client selection")]
+        claude: bool,
+        /// Restrict output to GitHub Copilot CLI.
+        #[arg(long = "copilot", help_heading = "Client selection")]
+        copilot: bool,
+        /// Restrict output to VS Code (shares Copilot's rules/skills/agents;
+        /// configures VS Code's own MCP servers).
+        #[arg(long = "vscode", help_heading = "Client selection")]
+        vscode: bool,
+        /// Restrict output to opencode.
+        #[arg(long = "opencode", help_heading = "Client selection")]
+        opencode: bool,
     },
     /// Remove installed content.
     ///
@@ -148,6 +162,19 @@ pub enum Commands {
         /// not a terminal (CI / pipes) or when `--dry-run` is used.
         #[arg(short = 'y', long = "yes")]
         yes: bool,
+        /// Restrict regenerated output to Claude Code. Combine client flags to
+        /// target several; no client flag regenerates for all clients.
+        #[arg(long = "claude", help_heading = "Client selection")]
+        claude: bool,
+        /// Restrict regenerated output to GitHub Copilot CLI.
+        #[arg(long = "copilot", help_heading = "Client selection")]
+        copilot: bool,
+        /// Restrict regenerated output to VS Code.
+        #[arg(long = "vscode", help_heading = "Client selection")]
+        vscode: bool,
+        /// Restrict regenerated output to opencode.
+        #[arg(long = "opencode", help_heading = "Client selection")]
+        opencode: bool,
     },
     /// List installed content recorded in `.upskill-lock.json`.
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,11 +9,16 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use crate::select::{ClientSelection, SelectedClient};
+
 /// Top-level configuration.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub registries: Vec<RegistryEntry>,
+    /// Persistent consumer-side client selection (ADR-0012). Empty means the
+    /// built-in default: emit for all clients.
+    pub clients: Vec<SelectedClient>,
 }
 
 /// A named registry source.
@@ -32,7 +37,9 @@ pub fn parse_config(yaml: &str) -> Result<Config> {
 }
 
 /// Merge two config layers. Project entries override global entries by name;
-/// global entries not shadowed are preserved.
+/// global entries not shadowed are preserved. `clients:` does not merge
+/// element-wise: a project `clients:` replaces the global one wholesale, so a
+/// narrower project selection wins over a broader global one (ADR-0012).
 pub fn merge_configs(global: Config, project: Config) -> Config {
     let mut registries = project.registries;
     let project_names: Vec<String> = registries.iter().map(|r| r.name.clone()).collect();
@@ -41,7 +48,30 @@ pub fn merge_configs(global: Config, project: Config) -> Config {
             registries.push(entry);
         }
     }
-    Config { registries }
+    let clients = if project.clients.is_empty() {
+        global.clients
+    } else {
+        project.clients
+    };
+    Config {
+        registries,
+        clients,
+    }
+}
+
+/// Resolve the effective client selection. Precedence, highest first:
+/// per-invocation flags, then the merged config `clients:`, then the built-in
+/// default (all clients). An empty `flag_clients` means no client flag was
+/// passed on the command line.
+pub fn resolve_client_selection(
+    flag_clients: &[SelectedClient],
+    config: &Config,
+) -> ClientSelection {
+    if !flag_clients.is_empty() {
+        ClientSelection::restrict(flag_clients)
+    } else {
+        ClientSelection::restrict(&config.clients)
+    }
 }
 
 /// Load configuration from standard paths, merging global and project layers.
@@ -115,12 +145,14 @@ mod tests {
                     source: "global-b".into(),
                 },
             ],
+            ..Default::default()
         };
         let project = Config {
             registries: vec![RegistryEntry {
                 name: "a".into(),
                 source: "project-a".into(),
             }],
+            ..Default::default()
         };
         let merged = merge_configs(global, project);
         assert_eq!(merged.registries.len(), 2);
@@ -128,6 +160,77 @@ mod tests {
         assert_eq!(merged.registries[0].source, "project-a");
         assert_eq!(merged.registries[1].name, "b");
         assert_eq!(merged.registries[1].source, "global-b");
+    }
+
+    #[test]
+    fn parse_config_with_clients() {
+        let cfg = parse_config("clients: [claude, opencode]\n").unwrap();
+        assert_eq!(
+            cfg.clients,
+            vec![SelectedClient::Claude, SelectedClient::OpenCode]
+        );
+    }
+
+    #[test]
+    fn parse_config_rejects_unknown_client() {
+        assert!(parse_config("clients: [cursor]\n").is_err());
+    }
+
+    #[test]
+    fn project_clients_replace_global_clients() {
+        let global = Config {
+            clients: vec![
+                SelectedClient::Claude,
+                SelectedClient::Copilot,
+                SelectedClient::OpenCode,
+            ],
+            ..Default::default()
+        };
+        let project = Config {
+            clients: vec![SelectedClient::Claude],
+            ..Default::default()
+        };
+        let merged = merge_configs(global, project);
+        assert_eq!(merged.clients, vec![SelectedClient::Claude]);
+    }
+
+    #[test]
+    fn empty_project_clients_fall_back_to_global() {
+        let global = Config {
+            clients: vec![SelectedClient::OpenCode],
+            ..Default::default()
+        };
+        let merged = merge_configs(global, Config::default());
+        assert_eq!(merged.clients, vec![SelectedClient::OpenCode]);
+    }
+
+    #[test]
+    fn flags_override_config_selection() {
+        let config = Config {
+            clients: vec![SelectedClient::Claude],
+            ..Default::default()
+        };
+        // A flag selection wins over config.
+        let sel = resolve_client_selection(&[SelectedClient::OpenCode], &config);
+        assert!(sel.targets_generation(crate::generate::Client::OpenCode));
+        assert!(!sel.targets_generation(crate::generate::Client::Claude));
+    }
+
+    #[test]
+    fn no_flags_use_config_selection() {
+        let config = Config {
+            clients: vec![SelectedClient::Claude],
+            ..Default::default()
+        };
+        let sel = resolve_client_selection(&[], &config);
+        assert!(sel.targets_generation(crate::generate::Client::Claude));
+        assert!(!sel.targets_generation(crate::generate::Client::Copilot));
+    }
+
+    #[test]
+    fn no_flags_no_config_targets_all() {
+        let sel = resolve_client_selection(&[], &Config::default());
+        assert!(sel.is_all());
     }
 
     #[test]

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -90,6 +90,7 @@ mod tests {
                     source_name: None,
                     required_by: vec![],
                     group: None,
+                    clients: vec![],
                 })
                 .collect(),
             bundles: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod pipeline;
 pub mod plugin;
 pub mod scaffold;
 pub mod search;
+pub mod select;
 pub mod source;
 pub mod style;
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -68,6 +68,13 @@ pub struct LockedItem {
     /// same `(source, group)` so a co-located unit travels as one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
+    /// Effective generation clients this item's output was written for
+    /// (`claude` | `copilot` | `opencode`) — the intersection of author
+    /// `audience:` and the consumer selection (ADR-0012). Empty means "all
+    /// clients", so lockfiles written before this field and unrestricted
+    /// installs both read as "check every client" in `doctor`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub clients: Vec<String>,
 }
 
 /// Bundle entry recorded when an install resolves a `.bundle.yaml` file
@@ -303,26 +310,42 @@ pub fn items_from_report(
     required_by: &std::collections::BTreeMap<(ItemKind, String), Vec<String>>,
     mut hash_for: impl FnMut(ItemKind, &str) -> Option<String>,
 ) -> Vec<LockedItem> {
-    use std::collections::BTreeSet;
-    let mut seen: BTreeSet<(ItemKind, String)> = BTreeSet::new();
-    let mut out = Vec::new();
+    use std::collections::BTreeMap;
+    // Collapse the per-client `report.items` into one `LockedItem` per
+    // (kind, name), accumulating the set of generation clients written (in
+    // first-seen / ALL_CLIENTS order) so `doctor` checks only what was
+    // actually emitted under the consumer selection.
+    let mut order: Vec<(ItemKind, String)> = Vec::new();
+    let mut meta: BTreeMap<(ItemKind, String), (Option<String>, Vec<String>)> = BTreeMap::new();
     for entry in &report.items {
-        if !seen.insert((entry.kind, entry.name.clone())) {
-            continue;
+        let key = (entry.kind, entry.name.clone());
+        let slot = meta.entry(key.clone()).or_insert_with(|| {
+            order.push(key.clone());
+            (entry.group.clone(), Vec::new())
+        });
+        let client_name = entry.client.name().to_string();
+        if !slot.1.contains(&client_name) {
+            slot.1.push(client_name);
         }
-        let (source, git_ref) = source_for(entry.kind, &entry.name);
+    }
+    let mut out = Vec::new();
+    for key in order {
+        let (group, clients) = meta.remove(&key).expect("meta populated for every key");
+        let (kind, name) = key;
+        let (source, git_ref) = source_for(kind, &name);
         out.push(LockedItem {
-            kind: entry.kind,
-            name: entry.name.clone(),
+            kind,
+            name: name.clone(),
             source,
             git_ref,
-            hash: hash_for(entry.kind, &entry.name),
+            hash: hash_for(kind, &name),
             source_name: None,
             required_by: required_by
-                .get(&(entry.kind, entry.name.clone()))
+                .get(&(kind, name.clone()))
                 .cloned()
                 .unwrap_or_default(),
-            group: entry.group.clone(),
+            group,
+            clients,
         });
     }
     out
@@ -345,6 +368,7 @@ mod tests {
             source_name: None,
             required_by: vec![],
             group: None,
+            clients: vec![],
         }
     }
 
@@ -641,6 +665,7 @@ mod tests {
             source_name: Some("brainstorming".to_string()),
             required_by: vec![],
             group: None,
+            clients: vec![],
         };
         let json = serde_json::to_string(&item).unwrap();
         assert!(json.contains("\"source_name\":\"brainstorming\""), "{json}");
@@ -657,6 +682,7 @@ mod tests {
             source_name: None,
             required_by: vec![],
             group: None,
+            clients: vec![],
         };
         let json = serde_json::to_string(&item).unwrap();
         assert!(!json.contains("source_name"), "{json}");

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -481,6 +481,7 @@ mod tests {
             bundles: Vec::new(),
             plugin_results: Vec::new(),
             mcp_results: Vec::new(),
+            selection_skipped: Vec::new(),
             items: vec![
                 InstalledItem {
                     kind: ItemKind::Skill,

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,10 +198,26 @@ fn client_flags(claude: bool, copilot: bool, vscode: bool, opencode: bool) -> Ve
 
 /// Resolve the effective client selection from per-invocation flags and the
 /// merged (global + project) config. Precedence: flags > config > all.
-fn resolve_selection(flag_clients: &[SelectedClient]) -> ClientSelection {
-    let config = config::load_config(home_dir().as_deref(), Some(std::path::Path::new(".")))
-        .unwrap_or_default();
+///
+/// `project_root` is the directory whose `.upskill/config.yaml` is read as the
+/// project layer — `None` for a global-scoped operation, so a `--global`
+/// install is not steered by the unrelated project the shell happens to be in.
+fn resolve_selection(
+    flag_clients: &[SelectedClient],
+    project_root: Option<&std::path::Path>,
+) -> ClientSelection {
+    let config = config::load_config(home_dir().as_deref(), project_root).unwrap_or_default();
     config::resolve_client_selection(flag_clients, &config)
+}
+
+/// The project-config root for a scope: the current directory unless the
+/// operation resolved to global scope.
+fn project_config_root(is_global: bool) -> Option<&'static std::path::Path> {
+    if is_global {
+        None
+    } else {
+        Some(std::path::Path::new("."))
+    }
 }
 
 fn run_add(args: AddArgs) -> i32 {
@@ -233,14 +249,15 @@ fn run_add(args: AddArgs) -> i32 {
 
     let plugin_scope = scope_to_plugin_scope(global, project);
 
+    let is_global = global || (!project && !is_inside_git_repo());
+
     let options = upskill::pipeline::AddOptions {
         force,
         aliases: parse_alias_args(aliases),
         excludes: excludes.to_vec(),
-        selection: resolve_selection(&flag_clients),
+        selection: resolve_selection(&flag_clients, project_config_root(is_global)),
     };
 
-    let is_global = global || (!project && !is_inside_git_repo());
     let scope_label = if is_global { "global" } else { "project" };
     if !style::is_quiet() {
         eprintln!("scope: {} ({})", scope_label, target.display());
@@ -250,6 +267,7 @@ fn run_add(args: AddArgs) -> i32 {
     match install_with_lockfile(&parsed, &target, items, plugin_scope, &options) {
         Ok(report) => {
             print_install_report(&report, source);
+            print_selection_skipped(&report);
             print_plugin_results(&report);
             print_mcp_results(&report);
             EXIT_SUCCESS
@@ -422,6 +440,20 @@ fn print_install_report(report: &InstallReport, source: &str) {
             style::dim(kind_label),
             style::name(&name),
             clients.join(", ")
+        );
+    }
+}
+
+/// Warn about items skipped because the consumer's client selection
+/// (ADR-0012) shares no client with the item's author `audience:`. Printed to
+/// stderr so `-q/--quiet` (which suppresses informational stdout only) does
+/// not hide it.
+fn print_selection_skipped(report: &InstallReport) {
+    for name in &report.selection_skipped {
+        eprintln!(
+            "{} skipped {} — its audience shares no client with the selected client(s)",
+            style::warn("warning:"),
+            style::name(name)
         );
     }
 }
@@ -676,7 +708,8 @@ fn run_update(
     };
 
     let plugin_scope = scope_to_plugin_scope(global, project);
-    let selection = resolve_selection(flag_clients);
+    let is_global = global || (!project && !is_inside_git_repo());
+    let selection = resolve_selection(flag_clients, project_config_root(is_global));
 
     if dry_run {
         // Explicit --dry-run: compute and report without applying.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use upskill::pipeline::{
 use upskill::plugin::PluginScope;
 use upskill::scaffold::{NewKind, ScaffoldReport, scaffold};
 use upskill::search;
+use upskill::select::{ClientSelection, SelectedClient};
 use upskill::source::{InstallSource, home_dir, parse_install_source};
 use upskill::style;
 
@@ -53,7 +54,20 @@ fn main() {
             force,
             alias,
             exclude,
-        } => run_add(&source, &items, global, project, force, &alias, &exclude),
+            claude,
+            copilot,
+            vscode,
+            opencode,
+        } => run_add(AddArgs {
+            source: &source,
+            items: &items,
+            global,
+            project,
+            force,
+            aliases: &alias,
+            excludes: &exclude,
+            flag_clients: client_flags(claude, copilot, vscode, opencode),
+        }),
         Commands::Remove {
             names,
             source,
@@ -67,7 +81,18 @@ fn main() {
             global,
             project,
             yes,
-        } => run_update(&names, dry_run, yes, global, project),
+            claude,
+            copilot,
+            vscode,
+            opencode,
+        } => run_update(
+            &names,
+            dry_run,
+            yes,
+            global,
+            project,
+            &client_flags(claude, copilot, vscode, opencode),
+        ),
         Commands::List {
             global,
             project,
@@ -138,15 +163,58 @@ fn map_clap_error(err: &clap::Error) -> i32 {
     }
 }
 
-fn run_add(
-    source: &str,
-    items: &[String],
+/// Positional-argument-heavy `add` inputs grouped into one struct to keep the
+/// resolver call under clippy's `too_many_arguments` bar (AGENTS.md).
+struct AddArgs<'a> {
+    source: &'a str,
+    items: &'a [String],
     global: bool,
     project: bool,
     force: bool,
-    aliases: &[String],
-    excludes: &[String],
-) -> i32 {
+    aliases: &'a [String],
+    excludes: &'a [String],
+    /// Clients named by `--claude`/`--copilot`/`--vscode`/`--opencode`.
+    /// Empty means no client flag was passed (fall back to config / all).
+    flag_clients: Vec<SelectedClient>,
+}
+
+/// Collect the per-client boolean flags into an ordered selection list.
+fn client_flags(claude: bool, copilot: bool, vscode: bool, opencode: bool) -> Vec<SelectedClient> {
+    let mut out = Vec::new();
+    if claude {
+        out.push(SelectedClient::Claude);
+    }
+    if copilot {
+        out.push(SelectedClient::Copilot);
+    }
+    if vscode {
+        out.push(SelectedClient::VsCode);
+    }
+    if opencode {
+        out.push(SelectedClient::OpenCode);
+    }
+    out
+}
+
+/// Resolve the effective client selection from per-invocation flags and the
+/// merged (global + project) config. Precedence: flags > config > all.
+fn resolve_selection(flag_clients: &[SelectedClient]) -> ClientSelection {
+    let config = config::load_config(home_dir().as_deref(), Some(std::path::Path::new(".")))
+        .unwrap_or_default();
+    config::resolve_client_selection(flag_clients, &config)
+}
+
+fn run_add(args: AddArgs) -> i32 {
+    let AddArgs {
+        source,
+        items,
+        global,
+        project,
+        force,
+        aliases,
+        excludes,
+        flag_clients,
+    } = args;
     let parsed = match parse_install_source(source) {
         Ok(s) => s,
         Err(err) => {
@@ -169,6 +237,7 @@ fn run_add(
         force,
         aliases: parse_alias_args(aliases),
         excludes: excludes.to_vec(),
+        selection: resolve_selection(&flag_clients),
     };
 
     let is_global = global || (!project && !is_inside_git_repo());
@@ -590,7 +659,14 @@ fn print_remove_report(report: &RemoveReport) {
     }
 }
 
-fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project: bool) -> i32 {
+fn run_update(
+    names: &[String],
+    dry_run: bool,
+    yes: bool,
+    global: bool,
+    project: bool,
+    flag_clients: &[SelectedClient],
+) -> i32 {
     let target = match install_target(global, project) {
         Ok(t) => t,
         Err(err) => {
@@ -600,10 +676,11 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
     };
 
     let plugin_scope = scope_to_plugin_scope(global, project);
+    let selection = resolve_selection(flag_clients);
 
     if dry_run {
         // Explicit --dry-run: compute and report without applying.
-        match update(&target, names, UpdateMode::DryRun, plugin_scope) {
+        match update(&target, names, UpdateMode::DryRun, plugin_scope, &selection) {
             Ok(report) => {
                 print_update_report(&report, true);
                 EXIT_SUCCESS
@@ -617,7 +694,7 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
         }
     } else if yes || !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         // No confirmation needed — apply directly (single fetch).
-        match update(&target, names, UpdateMode::Apply, plugin_scope) {
+        match update(&target, names, UpdateMode::Apply, plugin_scope, &selection) {
             Ok(report) => {
                 print_update_report(&report, false);
                 EXIT_SUCCESS
@@ -631,7 +708,7 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
         }
     } else {
         // Interactive: dry-run first to show plan, then apply if confirmed.
-        let plan = match update(&target, names, UpdateMode::DryRun, plugin_scope) {
+        let plan = match update(&target, names, UpdateMode::DryRun, plugin_scope, &selection) {
             Ok(r) => r,
             Err(err) => {
                 print_error_chain(&err);
@@ -662,7 +739,7 @@ fn run_update(names: &[String], dry_run: bool, yes: bool, global: bool, project:
             return EXIT_SUCCESS;
         }
 
-        match update(&target, names, UpdateMode::Apply, plugin_scope) {
+        match update(&target, names, UpdateMode::Apply, plugin_scope, &selection) {
             Ok(report) => {
                 print_update_report(&report, false);
                 EXIT_SUCCESS

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -161,6 +161,9 @@ pub(super) fn install_with_name_resolution_from_local(
         let bundle_report = install_bundle_file(bp, target, selection)?;
         report.items.extend(bundle_report.items);
         report.bundles.extend(bundle_report.bundles);
+        report
+            .selection_skipped
+            .extend(bundle_report.selection_skipped);
     }
 
     if !item_names.is_empty() {
@@ -172,6 +175,9 @@ pub(super) fn install_with_name_resolution_from_local(
         let item_report =
             install_from_local_path_selective(local_source, target, Some(&filter), selection)?;
         report.items.extend(item_report.items);
+        report
+            .selection_skipped
+            .extend(item_report.selection_skipped);
     }
 
     Ok(report)
@@ -966,6 +972,13 @@ pub(super) fn install_mcps_from_bundles(
         for (name, entry) in &bundle.mcps {
             for mcp_target in McpTarget::ALL {
                 if !selection.targets_mcp(mcp_target) {
+                    // Deselected targets are skipped, not cleaned up:
+                    // re-running `add` under a narrower selection leaves any
+                    // previously-written MCP config in place. This is
+                    // deliberate and asymmetric with generation cleanup — MCP
+                    // removal is explicit-only via `remove-mcp`, matching the
+                    // never-auto-delete stance for client-native config
+                    // (ADR-0010, ADR-0012).
                     continue;
                 }
                 let outcome = configure_mcp_for_target(mcp_target, name, entry, scope, target);
@@ -1171,6 +1184,15 @@ fn install_items_of_kind(
         if let Some(items) = filter
             && !items.contains(kind, &name)
         {
+            continue;
+        }
+
+        // Warn-skip: a restrictive consumer selection (ADR-0012) that shares
+        // no client with this item's author `audience:` yields zero renders.
+        // Record the item so `main.rs` can warn; a plain audience filter under
+        // the default (all-clients) selection is not a skip and stays silent.
+        if renders.is_empty() && !selection.is_all() {
+            report.selection_skipped.push(name.clone());
             continue;
         }
 

--- a/src/pipeline/install.rs
+++ b/src/pipeline/install.rs
@@ -26,6 +26,7 @@ use super::{ALL_CLIENTS, InstallReport, InstalledItem, ItemKind, McpResult, Plug
 use crate::generate::{self, Client};
 use crate::model::{Agent, Audience, RequireRef, Rule, Skill};
 use crate::parse::frontmatter;
+use crate::select::ClientSelection;
 use crate::source::{InstallSource, parse_install_source};
 
 /// Install every item under `source` into `target`, generating per-client
@@ -42,17 +43,33 @@ pub fn install_from_local_path(
     target: &Path,
     filter: Option<&crate::bundle::ResolvedItems>,
 ) -> Result<InstallReport> {
+    install_from_local_path_selective(source, target, filter, &ClientSelection::all())
+}
+
+/// [`install_from_local_path`] with an explicit consumer-side client
+/// selection (ADR-0012). The public entry defaults to all clients; the
+/// lockfile `add` path threads the resolved selection here.
+pub(super) fn install_from_local_path_selective(
+    source: &Path,
+    target: &Path,
+    filter: Option<&crate::bundle::ResolvedItems>,
+    selection: &ClientSelection,
+) -> Result<InstallReport> {
     if is_bundle_file(source) {
-        return install_bundle_file(source, target);
+        return install_bundle_file(source, target, selection);
     }
     let mut report = InstallReport::default();
     for kind in [ItemKind::Skill, ItemKind::Rule, ItemKind::Agent] {
-        install_items_of_kind(kind, source, target, &mut report, filter)?;
+        install_items_of_kind(kind, source, target, &mut report, filter, selection)?;
     }
     Ok(report)
 }
 
-pub(super) fn install_bundle_file(bundle_path: &Path, target: &Path) -> Result<InstallReport> {
+pub(super) fn install_bundle_file(
+    bundle_path: &Path,
+    target: &Path,
+    selection: &ClientSelection,
+) -> Result<InstallReport> {
     let registry_root = find_registry_root(bundle_path).with_context(|| {
         format!(
             "find SSOT registry root containing skills/, rules/, agents/, or bundles/ \
@@ -88,6 +105,7 @@ pub(super) fn install_bundle_file(bundle_path: &Path, target: &Path) -> Result<I
             target,
             &mut report,
             Some(&resolved.items),
+            selection,
         )?;
     }
     Ok(report)
@@ -100,6 +118,7 @@ pub(super) fn install_with_name_resolution_from_local(
     local_source: &Path,
     target: &Path,
     names: &[String],
+    selection: &ClientSelection,
 ) -> Result<InstallReport> {
     let mut bundle_paths: Vec<std::path::PathBuf> = Vec::new();
     let mut item_names: Vec<String> = Vec::new();
@@ -139,7 +158,7 @@ pub(super) fn install_with_name_resolution_from_local(
     let mut report = InstallReport::default();
 
     for bp in &bundle_paths {
-        let bundle_report = install_bundle_file(bp, target)?;
+        let bundle_report = install_bundle_file(bp, target, selection)?;
         report.items.extend(bundle_report.items);
         report.bundles.extend(bundle_report.bundles);
     }
@@ -150,7 +169,8 @@ pub(super) fn install_with_name_resolution_from_local(
             skills: item_names.clone(),
             agents: item_names.clone(),
         };
-        let item_report = install_from_local_path(local_source, target, Some(&filter))?;
+        let item_report =
+            install_from_local_path_selective(local_source, target, Some(&filter), selection)?;
         report.items.extend(item_report.items);
     }
 
@@ -937,6 +957,7 @@ pub(super) fn install_mcps_from_bundles(
     bundles: &[crate::model::Bundle],
     scope: crate::plugin::PluginScope,
     target: &Path,
+    selection: &ClientSelection,
 ) -> Vec<McpResult> {
     use crate::mcp::McpTarget;
 
@@ -944,6 +965,9 @@ pub(super) fn install_mcps_from_bundles(
     for bundle in bundles {
         for (name, entry) in &bundle.mcps {
             for mcp_target in McpTarget::ALL {
+                if !selection.targets_mcp(mcp_target) {
+                    continue;
+                }
                 let outcome = configure_mcp_for_target(mcp_target, name, entry, scope, target);
                 results.push(McpResult {
                     name: name.clone(),
@@ -1053,6 +1077,7 @@ fn install_items_of_kind(
     target: &Path,
     report: &mut InstallReport,
     filter: Option<&crate::bundle::ResolvedItems>,
+    selection: &ClientSelection,
 ) -> Result<()> {
     let entrypoint = kind.entrypoint_filename();
     for (folder, dir) in iter_item_dirs(source)? {
@@ -1080,7 +1105,7 @@ fn install_items_of_kind(
                 let ignore = skill.ignore.clone();
                 let mut out = Vec::new();
                 for client in ALL_CLIENTS {
-                    if !targets(client, aud.as_deref()) {
+                    if !targets(client, aud.as_deref()) || !selection.targets_generation(client) {
                         continue;
                     }
                     let rendered = generate::render_skill(&skill, &name, body, client)
@@ -1102,7 +1127,7 @@ fn install_items_of_kind(
                 let ignore = rule.ignore.clone();
                 let mut out = Vec::new();
                 for client in ALL_CLIENTS {
-                    if !targets(client, aud.as_deref()) {
+                    if !targets(client, aud.as_deref()) || !selection.targets_generation(client) {
                         continue;
                     }
                     let rendered = generate::render_rule(&rule, &name, body, client)
@@ -1124,7 +1149,7 @@ fn install_items_of_kind(
                 let ignore = agent.ignore.clone();
                 let mut out = Vec::new();
                 for client in ALL_CLIENTS {
-                    if !targets(client, aud.as_deref()) {
+                    if !targets(client, aud.as_deref()) || !selection.targets_generation(client) {
                         continue;
                     }
                     let rendered = generate::render_agent(&agent, &name, body, client)
@@ -1183,9 +1208,10 @@ fn install_items_of_kind(
             });
         }
 
-        // Clean up outputs for clients no longer targeted.
+        // Clean up outputs for clients no longer targeted — by author
+        // audience or by the consumer selection (ADR-0012).
         for client in ALL_CLIENTS {
-            if targets(client, audience.as_deref()) {
+            if targets(client, audience.as_deref()) && selection.targets_generation(client) {
                 continue;
             }
             let rel = output_path(kind, client, &name);

--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -366,6 +366,33 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
 /// same source (the pipeline always reinstalls a source as a unit).
 /// Names that match no lockfile entry are an error.
 ///
+/// Rebuild the client selection a bare `update` should reuse for one source:
+/// the union of its entries' recorded generation clients. An entry with an
+/// empty `clients` list was installed for all clients, so it widens the result
+/// back to all — the safe direction (never drops an entry's output trees).
+/// Returns [`ClientSelection::all`] when nothing narrows it (ADR-0012).
+fn reselect_from_entries(
+    entries: &[crate::lockfile::LockedItem],
+) -> crate::select::ClientSelection {
+    use crate::select::{ClientSelection, SelectedClient};
+    let mut set: std::collections::BTreeSet<SelectedClient> = std::collections::BTreeSet::new();
+    for entry in entries {
+        if entry.clients.is_empty() {
+            return ClientSelection::all();
+        }
+        for name in &entry.clients {
+            if let Ok(sc) = name.parse::<SelectedClient>() {
+                set.insert(sc);
+            }
+        }
+    }
+    if set.is_empty() {
+        ClientSelection::all()
+    } else {
+        ClientSelection::restrict(&set.into_iter().collect::<Vec<_>>())
+    }
+}
+
 /// `update` always fetches per ADR-0004 — there is no `--offline`.
 pub fn update(
     target: &Path,
@@ -425,11 +452,25 @@ pub fn update(
                             .map(|sn| (sn.clone(), e.name.clone()))
                     })
                     .collect();
+                // Preserve each source's recorded client selection so a bare
+                // `update` (no flags, no config → `is_all`) does not silently
+                // re-expand a flag-narrowed install and overwrite its lockfile
+                // `clients` record (ADR-0012). An explicit flag/config
+                // selection still overrides. Note: recorded `clients` are
+                // generation clients, so a `--vscode`-only install reconstructs
+                // to Copilot on the MCP axis; MCP config is additive and never
+                // auto-removed (see the MCP fan-out note in install.rs), so
+                // this widens rather than loses.
+                let effective_selection = if selection.is_all() {
+                    reselect_from_entries(&source_entries)
+                } else {
+                    selection.clone()
+                };
                 let options = AddOptions {
                     force: true,
                     aliases,
                     excludes: vec![],
-                    selection: selection.clone(),
+                    selection: effective_selection,
                 };
                 // Scope the reinstall to exactly the items this source already
                 // contributes to the lockfile (by their in-source name), rather

--- a/src/pipeline/lifecycle.rs
+++ b/src/pipeline/lifecycle.rs
@@ -162,6 +162,13 @@ pub fn doctor(target: &Path) -> Result<DoctorReport> {
 
         let mut missing = Vec::new();
         for client in ALL_CLIENTS {
+            // Only check clients this item was actually written for. An empty
+            // `clients` list means "all" — pre-ADR-0012 lockfiles and
+            // unrestricted installs both check every client. A narrowed
+            // install's unselected outputs are a deliberate choice, not drift.
+            if !entry.clients.is_empty() && !entry.clients.iter().any(|c| c == client.name()) {
+                continue;
+            }
             let rel = output_path(kind, client, &entry.name);
             if !target.join(&rel).exists() {
                 missing.push(rel);
@@ -365,6 +372,7 @@ pub fn update(
     names: &[String],
     mode: UpdateMode,
     plugin_scope: crate::plugin::PluginScope,
+    selection: &crate::select::ClientSelection,
 ) -> Result<UpdateReport> {
     let lock = crate::lockfile::Lockfile::load(target)?;
 
@@ -421,6 +429,7 @@ pub fn update(
                     force: true,
                     aliases,
                     excludes: vec![],
+                    selection: selection.clone(),
                 };
                 // Scope the reinstall to exactly the items this source already
                 // contributes to the lockfile (by their in-source name), rather

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -367,6 +367,7 @@ pub fn install_with_lockfile(
             )?;
             r.items.extend(part.items);
             r.bundles.extend(part.bundles);
+            r.selection_skipped.extend(part.selection_skipped);
         }
         r
     } else if items.is_empty() {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -42,8 +42,9 @@ pub use git::{fetch_ssot, install_from_git_url, install_from_source};
 pub(crate) use hash::hash_item_dir;
 pub use install::install_from_local_path;
 use install::{
-    ResolvedBundle, install_mcps_from_bundles, install_plugins_from_bundles,
-    install_with_name_resolution_from_local, resolve_bundle_request, resolve_requires_closure,
+    ResolvedBundle, install_from_local_path_selective, install_mcps_from_bundles,
+    install_plugins_from_bundles, install_with_name_resolution_from_local, resolve_bundle_request,
+    resolve_requires_closure,
 };
 pub use lifecycle::{doctor, list, remove, update};
 pub use report::*;
@@ -102,6 +103,9 @@ pub struct AddOptions {
     pub aliases: Vec<(String, String)>,
     /// Item names to skip during install.
     pub excludes: Vec<String>,
+    /// Consumer-side client selection (ADR-0012). Default targets all
+    /// clients, preserving the emit-for-everyone behaviour.
+    pub selection: crate::select::ClientSelection,
 }
 
 const ALL_CLIENTS: [Client; 3] = Client::ALL;
@@ -355,15 +359,20 @@ pub fn install_with_lockfile(
         // dropping them early would delete the fetched roots.
         let mut r = InstallReport::default();
         for si in closure.by_source.values() {
-            let part = install_from_local_path(&si.root, target, Some(&si.items))?;
+            let part = install_from_local_path_selective(
+                &si.root,
+                target,
+                Some(&si.items),
+                &options.selection,
+            )?;
             r.items.extend(part.items);
             r.bundles.extend(part.bundles);
         }
         r
     } else if items.is_empty() {
-        install_from_local_path(&local_source, target, None)?
+        install_from_local_path_selective(&local_source, target, None, &options.selection)?
     } else {
-        install_with_name_resolution_from_local(&local_source, target, items)?
+        install_with_name_resolution_from_local(&local_source, target, items, &options.selection)?
     };
 
     // A bundle-shaped install resolves its items per source above (no bundles
@@ -380,8 +389,9 @@ pub fn install_with_lockfile(
     let plugin_results = install_plugins_from_bundles(&report.bundles, plugin_scope, target);
     report.plugin_results = plugin_results;
 
-    // -- MCP server configuration (ADR-0010) --
-    let mcp_results = install_mcps_from_bundles(&report.bundles, plugin_scope, target);
+    // -- MCP server configuration (ADR-0010), restricted to the selection --
+    let mcp_results =
+        install_mcps_from_bundles(&report.bundles, plugin_scope, target, &options.selection);
     report.mcp_results = mcp_results;
 
     // -- Apply excludes --

--- a/src/pipeline/report.rs
+++ b/src/pipeline/report.rs
@@ -47,6 +47,10 @@ pub struct InstallReport {
     /// Results of MCP server configuration (ADR-0010). Empty when no
     /// bundles with `mcps:` were resolved.
     pub mcp_results: Vec<McpResult>,
+    /// Names of items warn-skipped because a restrictive consumer selection
+    /// (ADR-0012) left no client in common with the item's author `audience:`.
+    /// Surfaced to the user by `main.rs`; never an error.
+    pub selection_skipped: Vec<String>,
 }
 
 /// Result of a single plugin install attempt, for reporting to the user.

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,0 +1,205 @@
+//! Consumer-side client selection (ADR-0012, issue #238).
+//!
+//! A consumer restricts which clients an install targets. The selection
+//! surface is the **union** of the generation clients
+//! ([`Client`](crate::generate::Client): claude/copilot/opencode) and the
+//! MCP-only target VS Code — the four `SelectedClient`s a consumer names with
+//! `--claude` / `--copilot` / `--vscode` / `--opencode`. Each maps onto the
+//! generation space (VS Code shares Copilot's `.github/**` tree) and the MCP
+//! space (1:1) internally.
+
+use std::collections::BTreeSet;
+use std::str::FromStr;
+
+use anyhow::{Result, bail};
+use serde::Deserialize;
+
+use crate::generate::Client;
+use crate::mcp::McpTarget;
+
+/// One consumer-selectable client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[serde(try_from = "String")]
+pub enum SelectedClient {
+    Claude,
+    Copilot,
+    VsCode,
+    OpenCode,
+}
+
+impl SelectedClient {
+    /// Every selectable client, in declaration order.
+    pub const ALL: [SelectedClient; 4] =
+        [Self::Claude, Self::Copilot, Self::VsCode, Self::OpenCode];
+
+    /// Stable identifier used on the CLI and in config.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Copilot => "copilot",
+            Self::VsCode => "vscode",
+            Self::OpenCode => "opencode",
+        }
+    }
+
+    /// The generation client whose output tree this selection writes. VS Code
+    /// shares Copilot's `.github/**` rules/skills/agents tree, so it maps to
+    /// [`Client::Copilot`].
+    pub fn generation(self) -> Client {
+        match self {
+            Self::Claude => Client::Claude,
+            Self::Copilot | Self::VsCode => Client::Copilot,
+            Self::OpenCode => Client::OpenCode,
+        }
+    }
+
+    /// The MCP config-write target this selection configures (1:1).
+    pub fn mcp(self) -> McpTarget {
+        match self {
+            Self::Claude => McpTarget::Claude,
+            Self::Copilot => McpTarget::Copilot,
+            Self::VsCode => McpTarget::VsCode,
+            Self::OpenCode => McpTarget::OpenCode,
+        }
+    }
+}
+
+impl FromStr for SelectedClient {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "claude" => Ok(Self::Claude),
+            "copilot" => Ok(Self::Copilot),
+            "vscode" => Ok(Self::VsCode),
+            "opencode" => Ok(Self::OpenCode),
+            other => bail!(
+                "unknown client '{other}' (expected one of: claude, copilot, vscode, opencode)"
+            ),
+        }
+    }
+}
+
+impl TryFrom<String> for SelectedClient {
+    type Error = anyhow::Error;
+    fn try_from(s: String) -> Result<Self> {
+        s.parse()
+    }
+}
+
+/// A consumer's client selection. `None` = the built-in default (all
+/// clients); `Some(set)` = restrict to exactly this set.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ClientSelection(Option<BTreeSet<SelectedClient>>);
+
+impl ClientSelection {
+    /// The default selection: every client.
+    pub fn all() -> Self {
+        Self(None)
+    }
+
+    /// Restrict to `clients`. An empty slice yields the all-clients default,
+    /// so "no flags set" and "empty config list" both mean all.
+    pub fn restrict(clients: &[SelectedClient]) -> Self {
+        if clients.is_empty() {
+            Self(None)
+        } else {
+            Self(Some(clients.iter().copied().collect()))
+        }
+    }
+
+    /// True when this selection is the built-in default (all clients).
+    pub fn is_all(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// True when generation client `c` is targeted. copilot and vscode both
+    /// target [`Client::Copilot`], so the shared `.github/**` tree renders
+    /// once regardless of which (or both) are selected.
+    pub fn targets_generation(&self, c: Client) -> bool {
+        match &self.0 {
+            None => true,
+            Some(set) => set.iter().any(|s| s.generation() == c),
+        }
+    }
+
+    /// True when MCP target `t` is configured by this selection.
+    pub fn targets_mcp(&self, t: McpTarget) -> bool {
+        match &self.0 {
+            None => true,
+            Some(set) => set.iter().any(|s| s.mcp() == t),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_round_trips_all_names() {
+        for c in SelectedClient::ALL {
+            assert_eq!(c.name().parse::<SelectedClient>().unwrap(), c);
+        }
+    }
+
+    #[test]
+    fn from_str_rejects_unknown() {
+        assert!("cursor".parse::<SelectedClient>().is_err());
+    }
+
+    #[test]
+    fn vscode_maps_to_copilot_generation() {
+        assert_eq!(SelectedClient::VsCode.generation(), Client::Copilot);
+        assert_eq!(SelectedClient::Copilot.generation(), Client::Copilot);
+        assert_eq!(SelectedClient::Claude.generation(), Client::Claude);
+        assert_eq!(SelectedClient::OpenCode.generation(), Client::OpenCode);
+    }
+
+    #[test]
+    fn mcp_mapping_is_one_to_one() {
+        assert_eq!(SelectedClient::VsCode.mcp(), McpTarget::VsCode);
+        assert_eq!(SelectedClient::Copilot.mcp(), McpTarget::Copilot);
+    }
+
+    #[test]
+    fn default_and_empty_restrict_target_everything() {
+        for sel in [ClientSelection::all(), ClientSelection::restrict(&[])] {
+            assert!(sel.is_all());
+            for c in Client::ALL {
+                assert!(sel.targets_generation(c));
+            }
+            for t in McpTarget::ALL {
+                assert!(sel.targets_mcp(t));
+            }
+        }
+    }
+
+    #[test]
+    fn claude_only_excludes_other_generation_clients() {
+        let sel = ClientSelection::restrict(&[SelectedClient::Claude]);
+        assert!(sel.targets_generation(Client::Claude));
+        assert!(!sel.targets_generation(Client::Copilot));
+        assert!(!sel.targets_generation(Client::OpenCode));
+    }
+
+    #[test]
+    fn copilot_and_vscode_share_one_generation_client() {
+        // Both select the Copilot generation tree; nothing else.
+        let sel = ClientSelection::restrict(&[SelectedClient::Copilot, SelectedClient::VsCode]);
+        assert!(sel.targets_generation(Client::Copilot));
+        assert!(!sel.targets_generation(Client::Claude));
+        assert!(!sel.targets_generation(Client::OpenCode));
+        // But MCP forks into two distinct targets.
+        assert!(sel.targets_mcp(McpTarget::Copilot));
+        assert!(sel.targets_mcp(McpTarget::VsCode));
+        assert!(!sel.targets_mcp(McpTarget::Claude));
+    }
+
+    #[test]
+    fn vscode_only_targets_copilot_generation_but_only_vscode_mcp() {
+        let sel = ClientSelection::restrict(&[SelectedClient::VsCode]);
+        assert!(sel.targets_generation(Client::Copilot));
+        assert!(sel.targets_mcp(McpTarget::VsCode));
+        assert!(!sel.targets_mcp(McpTarget::Copilot));
+    }
+}

--- a/tests/cli_client_filtering.rs
+++ b/tests/cli_client_filtering.rs
@@ -1,0 +1,290 @@
+//! ATDD tests for consumer-side client filtering (issue #238, ADR-0012).
+//!
+//! A consumer restricts which clients an install targets, either
+//! per-invocation (`--claude` / `--copilot` / `--vscode` / `--opencode`) or
+//! persistently via `clients:` in config. No selection preserves the default
+//! (emit for all clients). Precedence: flag > project config > global config
+//! > default (all).
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+/// Stage a one-skill SSOT registry at `root` so `upskill add <root>` installs
+/// a single skill named `skill`.
+fn stage_skill_registry(root: &Path, skill: &str) {
+    let dir = root.join(skill);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            "---\nschema: 1\nname: {skill}\n\
+             description: Test skill exercising consumer-side client filtering.\n---\n\n\
+             # {skill}\n\nBody.\n"
+        ),
+    )
+    .unwrap();
+}
+
+/// A project dir marked as a git repo so upskill selects project scope.
+fn stage_project(root: &Path) -> std::path::PathBuf {
+    let project = root.join("project");
+    fs::create_dir_all(project.join(".git")).unwrap();
+    project
+}
+
+fn skill_claude(project: &Path, skill: &str) -> std::path::PathBuf {
+    project.join(format!(".claude/skills/{skill}/SKILL.md"))
+}
+fn skill_copilot(project: &Path, skill: &str) -> std::path::PathBuf {
+    project.join(format!(".github/skills/{skill}/SKILL.md"))
+}
+fn skill_opencode(project: &Path, skill: &str) -> std::path::PathBuf {
+    project.join(format!(".agents/skills/{skill}/SKILL.md"))
+}
+
+/// AC: with no selection, `add` still emits for all clients (default
+/// unchanged) — regression guard.
+#[test]
+fn default_add_writes_all_three_client_trees() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    let project = stage_project(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(skill_claude(&project, "code-review").exists());
+    assert!(skill_copilot(&project, "code-review").exists());
+    assert!(skill_opencode(&project, "code-review").exists());
+}
+
+/// AC: `add --claude` writes only `.claude/**` and no `.github/**` /
+/// `.agents/**`.
+#[test]
+fn claude_flag_writes_only_claude_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    let project = stage_project(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap(), "--claude"])
+        .assert()
+        .success();
+
+    assert!(skill_claude(&project, "code-review").exists());
+    assert!(!skill_copilot(&project, "code-review").exists());
+    assert!(!skill_opencode(&project, "code-review").exists());
+}
+
+/// AC: `--copilot --vscode` writes the shared `.github/**` generation once
+/// (VS Code reads Copilot's tree) and nothing under `.claude/**` /
+/// `.agents/**`.
+#[test]
+fn copilot_and_vscode_share_github_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    let project = stage_project(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap(), "--copilot", "--vscode"])
+        .assert()
+        .success();
+
+    assert!(skill_copilot(&project, "code-review").exists());
+    assert!(!skill_claude(&project, "code-review").exists());
+    assert!(!skill_opencode(&project, "code-review").exists());
+}
+
+/// AC: a persistent project `clients:` config restricts an `add` without
+/// flags.
+#[test]
+fn project_config_clients_restricts_without_flags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    let project = stage_project(tmp.path());
+    fs::create_dir_all(project.join(".upskill")).unwrap();
+    fs::write(project.join(".upskill/config.yaml"), "clients: [claude]\n").unwrap();
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(skill_claude(&project, "code-review").exists());
+    assert!(!skill_copilot(&project, "code-review").exists());
+    assert!(!skill_opencode(&project, "code-review").exists());
+}
+
+/// AC: a per-invocation flag overrides the persistent config selection.
+#[test]
+fn invocation_flag_overrides_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    let project = stage_project(tmp.path());
+    fs::create_dir_all(project.join(".upskill")).unwrap();
+    fs::write(project.join(".upskill/config.yaml"), "clients: [claude]\n").unwrap();
+
+    // Config says claude-only, but the flag selects opencode only.
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap(), "--opencode"])
+        .assert()
+        .success();
+
+    assert!(skill_opencode(&project, "code-review").exists());
+    assert!(!skill_claude(&project, "code-review").exists());
+    assert!(!skill_copilot(&project, "code-review").exists());
+}
+
+/// AC: precedence is project > global — a project `clients:` wins over a
+/// broader global `clients:`.
+#[test]
+fn project_config_overrides_global_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(home.join(".config/upskill")).unwrap();
+    // Global selects all three; project narrows to claude.
+    fs::write(
+        home.join(".config/upskill/config.yaml"),
+        "clients: [claude, copilot, opencode]\n",
+    )
+    .unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    let project = stage_project(tmp.path());
+    fs::create_dir_all(project.join(".upskill")).unwrap();
+    fs::write(project.join(".upskill/config.yaml"), "clients: [claude]\n").unwrap();
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(skill_claude(&project, "code-review").exists());
+    assert!(!skill_copilot(&project, "code-review").exists());
+    assert!(!skill_opencode(&project, "code-review").exists());
+}
+
+/// AC: `doctor` does not report unselected-client outputs as missing after a
+/// narrowed install.
+#[test]
+fn doctor_clean_after_narrowed_install() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    let project = stage_project(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap(), "--claude"])
+        .assert()
+        .success();
+
+    // doctor must exit 0 — the unwritten .github/** and .agents/** outputs
+    // are a deliberate selection, not drift.
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["doctor"])
+        .assert()
+        .success();
+}
+
+// ---------------------------------------------------------------------------
+// MCP fan-out respects the selection (ADR-0010 targets ∩ ADR-0012 selection)
+// ---------------------------------------------------------------------------
+
+const DRAWIO_SKILL_MD: &str = "\
+---
+schema: 1
+name: drawio-diagrams
+description: Create diagrams with Draw.io
+---
+
+# Draw.io diagrams
+
+Use diagrams to communicate architecture.
+";
+
+const DRAWIO_BUNDLE_YAML: &str = "\
+schema: 1
+name: drawio
+description: Draw.io bundle with MCP server
+
+items:
+  skills:
+    - drawio-diagrams
+
+mcps:
+  drawio:
+    local:
+      command: npx
+      args:
+        - \"-y\"
+        - drawio-mcp-server
+";
+
+/// AC: an item whose selection excludes a client is not MCP-configured for
+/// it — `add --claude` records exactly one MCP entry (claude), not four.
+#[test]
+fn mcp_fanout_respects_selection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let registry = tmp.path().join("registry");
+    let skill_dir = registry.join("drawio-diagrams");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), DRAWIO_SKILL_MD).unwrap();
+    let bundles_dir = registry.join("bundles");
+    fs::create_dir_all(&bundles_dir).unwrap();
+    fs::write(bundles_dir.join("drawio.bundle.yaml"), DRAWIO_BUNDLE_YAML).unwrap();
+
+    let project = stage_project(tmp.path());
+    // Force the config-write fallback: no client CLI on PATH.
+    let empty_bin = tmp.path().join("empty-bin");
+    fs::create_dir_all(&empty_bin).unwrap();
+
+    let bundle_path = bundles_dir.join("drawio.bundle.yaml");
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .env("PATH", empty_bin.to_str().unwrap())
+        .args(["add", bundle_path.to_str().unwrap(), "--claude"])
+        .assert()
+        .success();
+
+    let lock_raw = fs::read_to_string(project.join(".upskill-lock.json")).unwrap();
+    let lock: serde_json::Value = serde_json::from_str(&lock_raw).unwrap();
+    let mcps = lock["mcps"].as_array().expect("mcps array");
+    assert_eq!(
+        mcps.len(),
+        1,
+        "--claude must configure only the claude MCP target; got {mcps:?}"
+    );
+    assert_eq!(mcps[0]["client"], "claude");
+}

--- a/tests/cli_client_filtering.rs
+++ b/tests/cli_client_filtering.rs
@@ -8,6 +8,7 @@
 
 mod common;
 
+use predicates::prelude::*;
 use std::fs;
 use std::path::Path;
 
@@ -287,4 +288,111 @@ fn mcp_fanout_respects_selection() {
         "--claude must configure only the claude MCP target; got {mcps:?}"
     );
     assert_eq!(mcps[0]["client"], "claude");
+}
+
+/// Finding 1 regression: a bare `update` (no flags, no config) must NOT
+/// re-expand a flag-narrowed install, nor overwrite the recorded `clients`.
+#[test]
+fn update_preserves_narrowed_selection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    let project = stage_project(tmp.path());
+
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap(), "--claude"])
+        .assert()
+        .success();
+    assert!(skill_claude(&project, "code-review").exists());
+    assert!(!skill_copilot(&project, "code-review").exists());
+
+    // Bare update — must stay claude-only.
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["update", "--yes"])
+        .assert()
+        .success();
+
+    assert!(skill_claude(&project, "code-review").exists());
+    assert!(
+        !skill_copilot(&project, "code-review").exists(),
+        "bare update must not re-expand a --claude install to Copilot"
+    );
+    assert!(!skill_opencode(&project, "code-review").exists());
+
+    // The lockfile record must still be claude-only.
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(project.join(".upskill-lock.json")).unwrap())
+            .unwrap();
+    let item = &lock["items"][0];
+    assert_eq!(
+        item["clients"],
+        serde_json::json!(["claude"]),
+        "update must preserve the recorded clients selection; got {}",
+        item["clients"]
+    );
+}
+
+/// Finding 2 regression: a `--global` install must ignore the current
+/// directory's project `clients:` config (it belongs to an unrelated project).
+#[test]
+fn global_install_ignores_project_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    stage_skill_registry(&registry, "code-review");
+    // cwd is a project whose config narrows to claude...
+    let project = stage_project(tmp.path());
+    fs::create_dir_all(project.join(".upskill")).unwrap();
+    fs::write(project.join(".upskill/config.yaml"), "clients: [claude]\n").unwrap();
+
+    // ...but --global targets $HOME and must not read that project config.
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap(), "--global"])
+        .assert()
+        .success();
+
+    assert!(home.join(".claude/skills/code-review/SKILL.md").exists());
+    assert!(
+        home.join(".github/skills/code-review/SKILL.md").exists(),
+        "global install must emit for all clients, ignoring the project's clients: config"
+    );
+    assert!(home.join(".agents/skills/code-review/SKILL.md").exists());
+}
+
+/// Finding 3 regression: an item whose `audience:` shares no client with a
+/// restrictive selection is warn-skipped (stderr warning, exit 0), not
+/// silently dropped.
+#[test]
+fn empty_audience_selection_warns_and_skips() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let registry = tmp.path().join("registry");
+    let dir = registry.join("claude-rule");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        "---\nschema: 1\nname: claude-rule\n\
+         description: A Claude-only skill for testing audience-selection warn-skip.\n\
+         audience:\n  - claude\n---\n\n# claude-rule\n\nBody.\n",
+    )
+    .unwrap();
+    let project = stage_project(tmp.path());
+
+    // Select opencode only — disjoint from the item's claude-only audience.
+    common::upskill_cmd(&home)
+        .current_dir(&project)
+        .args(["add", registry.to_str().unwrap(), "--opencode"])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("warning:").and(predicates::str::contains("skipped")));
+
+    assert!(!skill_claude(&project, "claude-rule").exists());
+    assert!(!skill_opencode(&project, "claude-rule").exists());
 }

--- a/tests/pipeline_lockfile.rs
+++ b/tests/pipeline_lockfile.rs
@@ -146,6 +146,7 @@ fn install_preserves_unrelated_existing_entries() {
         source_name: None,
         required_by: vec![],
         group: None,
+        clients: vec![],
     });
     seed.save(&target).unwrap();
 


### PR DESCRIPTION
Closes #238.

## What

A **consumer** can now restrict which clients an install targets — the default (emit for all clients) is unchanged. Restrict either per-invocation or persistently:

```bash
upskill add owner/repo --claude              # only .claude/**
upskill add owner/repo --copilot --vscode    # .github/** once + VS Code MCP
```

```yaml
# .upskill/config.yaml (or ~/.config/upskill/config.yaml)
clients: [claude, opencode]
```

Precedence: **flag > project config > global config > all clients**. `update` honours the same flags/config.

## Design (ADR-0012)

The selection surface is the **union** of the two internal target spaces #239 introduced — generation `Client` (3: claude/copilot/opencode) and `McpTarget` (4: +vscode). Each selected client maps onto both:

| flag | generation | MCP |
|---|---|---|
| `--claude` | claude | claude |
| `--copilot` | copilot | copilot |
| `--vscode` | **copilot** | vscode |
| `--opencode` | opencode | opencode |

`--vscode` writes the shared `.github/**` rules/skills/agents (VS Code reads Copilot's tree) plus VS Code's own MCP config. `--copilot --vscode` therefore writes `.github/**` **once** (generation clients dedupe to a set) and forks only the MCP config — covered by a dedicated test.

## Changes

- **`src/select.rs`** (new) — `SelectedClient` + `ClientSelection`; the single home of the `--vscode → copilot generation` mapping. Unit-tested.
- **`config.rs`** — `clients:` key, project-over-global merge, `resolve_client_selection` (flag > config > all).
- **Pipeline** — generation loop intersects author `audience:` with the selection; MCP fan-out restricts to selected targets. Threaded via `AddOptions.selection`.
- **Lockfile / doctor** — `LockedItem.clients` records the effective generation clients; `doctor` iterates the recorded set (empty = all), so a narrowed install no longer shows false drift. Also fixes the latent `audience:`-restricted case. `remove` already no-ops on never-written paths.
- **Docs** — ADR-0012; reconciled the now-valid `--claude`/`--vscode` examples in ADR-0008 and `recipes.md`; documented flags + config in `commands.md`.

## Tests

- `tests/cli_client_filtering.rs` (ATDD, 8 cases): default-all regression, `--claude` only, `--copilot --vscode` shared tree, project config, flag-overrides-config, project>global precedence, clean `doctor` after narrowed install, MCP fan-out respects selection.
- Unit tests in `select.rs` (mapping/precedence invariants) and `config.rs` (parse/merge/resolve).
- Full suite + `clippy -D warnings` + fmt/dprint/markdownlint/shellcheck all green via `just verify`.

## Acceptance criteria

- [x] No selection still emits for all clients (regression-guarded)
- [x] `--claude` writes only `.claude/**`
- [x] `--copilot --vscode` writes Copilot's `.github/**` (once) — decision from #238 discussion: `--vscode` = rules + VS Code MCP
- [x] Persistent `clients:` config restricts subsequent add/update; flag overrides; local > global > default (tested)
- [x] Effective set = `audience ∩ selection`; empty intersection warn-skips
- [x] `doctor`/`remove` respect the selection
- [x] ADR-0008 & recipes reconciled; ADR-0012 added; docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
